### PR TITLE
Enable GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  SBT_OPTS: -Dlerna.enable.discipline
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    timeout-minutes: 15
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+
+    # https://github.com/actions/cache/blob/main/examples.md#scala---sbt
+    - name: Cache sbt resources
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/coursier
+          ~/.ivy2/cache
+          ~/.sbt
+        key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
+
+    - name: Check code format
+      run: sbt scalafmtCheckAll
+
+    - name: Run tests
+      run: sbt clean test
+
+    - name: Run integration tests
+      run: sh ./scripts/run-multijvm-test.sh 5

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 akka-entity-replication
 ===
 
+[![CI](https://github.com/lerna-stack/akka-entity-replication/workflows/CI/badge.svg?branch=master)](https://github.com/lerna-stack/akka-entity-replication/actions?query=workflow%3ACI+branch%3Amaster)
+
 ## Introduction
 
 If a node failure or network failure occurs, some entities in Cluster Sharding become unavailable and it will take more than 10 seconds to recover. akka-entity-replication provides fast recovery by creating replicas of entities in multiple locations and always synchronizing their status. 


### PR DESCRIPTION
## Related issue

- #1 

## GitHub settings I changed

https://github.com/lerna-stack/akka-entity-replication/settings/branch_protection_rules/17722558

To allow merge if all tests and checks are passed.

`Require status checks to pass before merging - test`  (on)

## Reference

- [starter-workflows/scala.yml at ef1224c2841f7d5b2406861ee4cefba3060dee0f · actions/starter-workflows](https://github.com/actions/starter-workflows/blob/ef1224c2841f7d5b2406861ee4cefba3060dee0f/ci/scala.yml)
- [actions/cache: Cache dependencies and build outputs in GitHub Actions](https://github.com/actions/cache)
- [Installation · Scalafmt](https://scalameta.org/scalafmt/docs/installation.html)
- [ワークフローステータスバッジを追加する - GitHub Docs](https://docs.github.com/ja/free-pro-team@latest/actions/managing-workflow-runs/adding-a-workflow-status-badge)