### PR TITLE
Use Long in LogEntryIndex instead of Int

### DIFF
--- a/docs/implementation_guide.md
+++ b/docs/implementation_guide.md
@@ -181,8 +181,15 @@ lerna.akka.entityreplication {
           // Time interval to check the size of the log and check if a snapshotting is needed to be taken
           log-size-check-interval = 10s
 
-          // Threshold for saving snapshots and compaction of the log
-          log-size-threshold = 10000
+          // Threshold for saving snapshots and compaction of the log.
+          // If this value is too large, your application will use a lot of memory and you may get an OutOfMemoryError.
+          // If this value is too small, it compaction may occur frequently and overload the application and the data store.
+          log-size-threshold = 50000
+
+          // Preserving log entries from log reduction to avoid log replication failure.
+          // If more number of logs than this value cannot be synchronized, the raft member will be unavailable.
+          // It is recommended to set this value even less than log-size-threshold. Otherwise compaction will be run at every log-size-check-interval.
+          preserve-log-size = 10000
 
           // Time to keep a cache of snapshots in memory
           snapshot-cache-time-to-live = 10s

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -26,12 +26,14 @@ lerna.akka.entityreplication {
       // Time interval to check the size of the log and check if a snapshotting is needed to be taken
       log-size-check-interval = 10s
 
-      // Threshold for saving snapshots and compaction of the log
+      // Threshold for saving snapshots and compaction of the log.
+      // If this value is too large, your application will use a lot of memory and you may get an OutOfMemoryError.
+      // If this value is too small, it compaction may occur frequently and overload the application and the data store.
       log-size-threshold = 50000
 
       // Preserving log entries from log reduction to avoid log replication failure.
       // If more number of logs than this value cannot be synchronized, the raft member will be unavailable.
-      // This size is usually less than log-size-threshold
+      // It is recommended to set this value even less than log-size-threshold. Otherwise compaction will be run at every log-size-check-interval.
       preserve-log-size = 10000
 
       // Time to keep a cache of snapshots in memory

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
@@ -211,7 +211,7 @@ class RaftActor(
         currentData.recordSavedSnapshot(metadata, settings.compactionPreserveLogSize)(onComplete = () => {
           // 失敗する可能性があることに注意
           saveSnapshot(currentData.persistentState)
-          log.info("[{}] compaction completed (logEntryIndex: {})", currentState, metadata.logEntryIndex.underlying)
+          log.info("[{}] compaction completed (logEntryIndex: {})", currentState, metadata.logEntryIndex)
         })
       // TODO: Remove when test code is modified
       case _: NonPersistEventLike =>
@@ -330,7 +330,7 @@ class RaftActor(
         log.info(
           "[{}] compaction started (logEntryIndex: {}, number of entities: {})",
           currentState,
-          logEntryIndex.underlying,
+          logEntryIndex,
           entityIds.size,
         )
         requestTakeSnapshots(logEntryIndex, entityIds)

--- a/src/main/scala/lerna/akka/entityreplication/raft/model/LogEntry.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/model/LogEntry.scala
@@ -7,7 +7,7 @@ object LogEntry {
 }
 
 class LogEntry(val index: LogEntryIndex, val event: EntityEvent, val term: Term) extends Serializable {
-  require(index.underlying >= 1)
+  require(index > LogEntryIndex.initial())
 
   def canEqual(other: Any): Boolean = other.isInstanceOf[LogEntry]
 

--- a/src/main/scala/lerna/akka/entityreplication/raft/model/LogEntryIndex.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/model/LogEntryIndex.scala
@@ -2,7 +2,7 @@ package lerna.akka.entityreplication.raft.model
 
 object LogEntryIndex {
 
-  def initial() = LogEntryIndex(0)
+  def initial(): LogEntryIndex = LogEntryIndex(0)
 
   def min(a: LogEntryIndex, b: LogEntryIndex): LogEntryIndex = {
     if (a <= b) a else b

--- a/src/main/scala/lerna/akka/entityreplication/raft/model/LogEntryIndex.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/model/LogEntryIndex.scala
@@ -1,5 +1,7 @@
 package lerna.akka.entityreplication.raft.model
 
+import lerna.akka.entityreplication.raft.model.exception.SeqIndexOutOfBoundsException
+
 object LogEntryIndex {
 
   def initial(): LogEntryIndex = LogEntryIndex(0)
@@ -26,6 +28,11 @@ case class LogEntryIndex(private[model] val underlying: Long) extends Ordered[Lo
   override def toString: String = underlying.toString
 
   def toSeqIndex(offset: LogEntryIndex): Int = {
-    (underlying - offset.underlying - 1).toInt
+    val maybeSeqIndex = underlying - offset.underlying - 1
+    if (maybeSeqIndex > Int.MaxValue) {
+      throw SeqIndexOutOfBoundsException(this, offset)
+    } else {
+      maybeSeqIndex.toInt
+    }
   }
 }

--- a/src/main/scala/lerna/akka/entityreplication/raft/model/LogEntryIndex.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/model/LogEntryIndex.scala
@@ -9,7 +9,7 @@ object LogEntryIndex {
   }
 }
 
-case class LogEntryIndex(underlying: Long) extends Ordered[LogEntryIndex] {
+case class LogEntryIndex(private[model] val underlying: Long) extends Ordered[LogEntryIndex] {
   require(underlying >= 0)
 
   def next(): LogEntryIndex = copy(underlying + 1)
@@ -22,4 +22,10 @@ case class LogEntryIndex(underlying: Long) extends Ordered[LogEntryIndex] {
 
   override def compare(that: LogEntryIndex): Int =
     underlying.compareTo(that.underlying)
+
+  override def toString: String = underlying.toString
+
+  def toSeqIndex(offset: LogEntryIndex): Int = {
+    (underlying - offset.underlying - 1).toInt
+  }
 }

--- a/src/main/scala/lerna/akka/entityreplication/raft/model/LogEntryIndex.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/model/LogEntryIndex.scala
@@ -9,7 +9,7 @@ object LogEntryIndex {
   }
 }
 
-case class LogEntryIndex(underlying: Int) extends Ordered[LogEntryIndex] {
+case class LogEntryIndex(underlying: Long) extends Ordered[LogEntryIndex] {
   require(underlying >= 0)
 
   def next(): LogEntryIndex = copy(underlying + 1)

--- a/src/main/scala/lerna/akka/entityreplication/raft/model/ReplicatedLog.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/model/ReplicatedLog.scala
@@ -67,6 +67,6 @@ case class ReplicatedLog private[model] (entries: Seq[LogEntry]) {
 
   private[this] def toSeqIndex(index: LogEntryIndex): Int = {
     val ancestorLastIndex = headIndexOption.map(_.prev()).getOrElse(LogEntryIndex.initial())
-    index.underlying - ancestorLastIndex.underlying - 1
+    index.toSeqIndex(offset = ancestorLastIndex)
   }
 }

--- a/src/main/scala/lerna/akka/entityreplication/raft/model/exception/SeqIndexOutOfBoundsException.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/model/exception/SeqIndexOutOfBoundsException.scala
@@ -1,0 +1,6 @@
+package lerna.akka.entityreplication.raft.model.exception
+
+import lerna.akka.entityreplication.raft.model.LogEntryIndex
+
+final case class SeqIndexOutOfBoundsException(self: LogEntryIndex, offset: LogEntryIndex)
+    extends RuntimeException(s"The Seq index of $self from $offset is out of bounds")

--- a/src/test/scala/lerna/akka/entityreplication/raft/model/LogEntryIndexSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/model/LogEntryIndexSpec.scala
@@ -1,0 +1,29 @@
+package lerna.akka.entityreplication.raft.model
+
+import lerna.akka.entityreplication.raft.model.exception.SeqIndexOutOfBoundsException
+import org.scalatest.{ Matchers, WordSpec }
+
+class LogEntryIndexSpec extends WordSpec with Matchers {
+
+  "LogEntryIndex" should {
+
+    "compute an index of Seq from self and offset" in {
+      val index  = LogEntryIndex(Int.MaxValue.toLong + 2)
+      val offset = LogEntryIndex(1)
+
+      index.toSeqIndex(offset) should be(Int.MaxValue)
+    }
+
+    "throw an exception if the index of Seq is out of bounds" in {
+      val index  = LogEntryIndex(Int.MaxValue.toLong + 2)
+      val offset = LogEntryIndex(0)
+
+      val caught = intercept[SeqIndexOutOfBoundsException] {
+        index.toSeqIndex(offset)
+      }
+
+      caught.self should be(index)
+      caught.offset should be(offset)
+    }
+  }
+}


### PR DESCRIPTION
`Int` of `LogEntryIndex` overflows with running for a long time.

For example:

- 100 TPS/Shard
- 10 events/transaction
- Int.Max: 2147483647

The `Int` of `LogEntryIndex` overflows after 0.7 years.

[`2147483647/(10*100*60*60*24*365) ≒ 0.7`](https://www.google.com/search?q=2147483647%2F%2810*100*60*60*24*365%29)

## If it uses `Long`

- 10,000,000 TPS/Shard
- 10 events/transaction
- Long.Max: 9223372036854775807

The `Long` of `LogEntryIndex` overflows after 292.5 years.

[`9223372036854775807/(10*10000000*60*60*24*365 ≒ 292.5`](https://www.google.com/search?q=9223372036854775807%2F%28100*10000000*60*60*24*365)

