### PR TITLE
🔨refactor: Remove ActorLogging from ReplicationActor

### DIFF
--- a/src/main/scala/lerna/akka/entityreplication/ReplicationActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/ReplicationActor.scala
@@ -2,7 +2,8 @@ package lerna.akka.entityreplication
 
 import java.util.concurrent.atomic.AtomicInteger
 
-import akka.actor.{ Actor, ActorLogging, ActorPath, ActorRef, Cancellable, Stash }
+import akka.actor.{ Actor, ActorPath, ActorRef, Cancellable, Stash }
+import akka.event.Logging
 import lerna.akka.entityreplication.model.{ EntityInstanceId, NormalizedEntityId }
 import lerna.akka.entityreplication.raft.RaftProtocol._
 import lerna.akka.entityreplication.raft.model.{ LogEntryIndex, NoOp }
@@ -23,7 +24,7 @@ object ReplicationActor {
   final case class EntityRecoveryTimeoutException(entityPath: ActorPath) extends RuntimeException
 }
 
-trait ReplicationActor[StateData] extends Actor with ActorLogging with Stash with akka.lerna.StashFactory {
+trait ReplicationActor[StateData] extends Actor with Stash with akka.lerna.StashFactory {
   import ReplicationActor._
   import context.dispatcher
 
@@ -32,6 +33,8 @@ trait ReplicationActor[StateData] extends Actor with ActorLogging with Stash wit
   private val instanceId = ReplicationActor.generateInstanceId()
 
   private[this] val settings = ClusterReplicationSettings(context.system)
+
+  private[this] val log = Logging(context.system, this)
 
   override def receive: Receive = receiveCommand
 

--- a/src/multi-jvm/scala/lerna/akka/entityreplication/ReplicationRegionSpec.scala
+++ b/src/multi-jvm/scala/lerna/akka/entityreplication/ReplicationRegionSpec.scala
@@ -1,8 +1,7 @@
 package lerna.akka.entityreplication
 
 import java.util.concurrent.atomic.AtomicInteger
-
-import akka.actor.{ Actor, ActorRef, ActorSelection, Props, RootActorPath, Terminated }
+import akka.actor.{ Actor, ActorRef, ActorSelection, DiagnosticActorLogging, Props, RootActorPath, Terminated }
 import akka.remote.testconductor.RoleName
 import akka.remote.testkit.{ MultiNodeConfig, MultiNodeSpec }
 import akka.testkit.TestProbe
@@ -43,7 +42,7 @@ object ReplicationRegionSpec {
     }
   }
 
-  class DummyReplicationActor(probe: TestProbe) extends ReplicationActor[Int] {
+  class DummyReplicationActor(probe: TestProbe) extends DiagnosticActorLogging with ReplicationActor[Int] {
 
     import DummyReplicationActor._
 


### PR DESCRIPTION
It allows `ReplicationActor` to mixin `ActorLogging`.