### PR TITLE
Fix serialization

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -78,6 +78,8 @@ lerna.akka.entityreplication {
       query.plugin = ""
     }
   }
+
+  kryo-serialization = ${akka-kryo-serialization}
 }
 
 # Serializer settings for akka-entity-replication messages

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -83,7 +83,7 @@ lerna.akka.entityreplication {
 # Serializer settings for akka-entity-replication messages
 akka.actor {
   serializers {
-    akka-entity-replication = "io.altoo.akka.serialization.kryo.KryoSerializer"
+    akka-entity-replication = "lerna.akka.entityreplication.serialization.ClusterReplicationSerializer"
   }
   serialization-bindings {
     "lerna.akka.entityreplication.ClusterReplicationSerializable" = akka-entity-replication

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -79,3 +79,13 @@ lerna.akka.entityreplication {
     }
   }
 }
+
+# Serializer settings for akka-entity-replication messages
+akka.actor {
+  serializers {
+    akka-entity-replication = "io.altoo.akka.serialization.kryo.KryoSerializer"
+  }
+  serialization-bindings {
+    "lerna.akka.entityreplication.ClusterReplicationSerializable" = akka-entity-replication
+  }
+}

--- a/src/main/scala/lerna/akka/entityreplication/ClusterReplicationSerializable.scala
+++ b/src/main/scala/lerna/akka/entityreplication/ClusterReplicationSerializable.scala
@@ -1,0 +1,2 @@
+package lerna.akka.entityreplication
+trait ClusterReplicationSerializable extends Serializable

--- a/src/main/scala/lerna/akka/entityreplication/ReplicationRegion.scala
+++ b/src/main/scala/lerna/akka/entityreplication/ReplicationRegion.scala
@@ -148,7 +148,7 @@ class ReplicationRegion(
     */
   private[this] var stickyRoutingRouter: Router = {
     val hashMapping: ConsistentHashingRouter.ConsistentHashMapping = {
-      case message => extractNormalizedShardIdInternal(message)
+      case message => extractNormalizedShardIdInternal(message).underlying
     }
     Router(
       ConsistentHashingRoutingLogic(context.system, virtualNodesFactor = 256, hashMapping),

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
@@ -58,6 +58,7 @@ object RaftActor {
   final case class DetectedNewTerm(term: Term)               extends PersistEvent
   final case class AppendedEntries(term: Term, logEntries: Seq[LogEntry], prevLogIndex: LogEntryIndex)
       extends PersistEvent
+      with ClusterReplicationSerializable
   final case class AppendedEvent(event: EntityEvent) extends PersistEvent with ClusterReplicationSerializable
 
   sealed trait NonPersistEvent                                                                  extends DomainEvent

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
@@ -55,7 +55,7 @@ object RaftActor {
   sealed trait PersistEvent                                  extends DomainEvent
   final case class BegunNewTerm(term: Term)                  extends PersistEvent with ClusterReplicationSerializable
   final case class Voted(term: Term, candidate: MemberIndex) extends PersistEvent with ClusterReplicationSerializable
-  final case class DetectedNewTerm(term: Term)               extends PersistEvent
+  final case class DetectedNewTerm(term: Term)               extends PersistEvent with ClusterReplicationSerializable
   final case class AppendedEntries(term: Term, logEntries: Seq[LogEntry], prevLogIndex: LogEntryIndex)
       extends PersistEvent
       with ClusterReplicationSerializable

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
@@ -58,7 +58,7 @@ object RaftActor {
   final case class DetectedNewTerm(term: Term)               extends PersistEvent
   final case class AppendedEntries(term: Term, logEntries: Seq[LogEntry], prevLogIndex: LogEntryIndex)
       extends PersistEvent
-  final case class AppendedEvent(event: EntityEvent) extends PersistEvent
+  final case class AppendedEvent(event: EntityEvent) extends PersistEvent with ClusterReplicationSerializable
 
   sealed trait NonPersistEvent                                                                  extends DomainEvent
   final case class BecameFollower()                                                             extends NonPersistEvent

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
@@ -10,7 +10,7 @@ import lerna.akka.entityreplication.raft.model._
 import lerna.akka.entityreplication.raft.routing.MemberIndex
 import lerna.akka.entityreplication.raft.snapshot.SnapshotProtocol
 import lerna.akka.entityreplication.raft.snapshot.SnapshotProtocol.EntitySnapshotMetadata
-import lerna.akka.entityreplication.{ ReplicationActor, ReplicationRegion }
+import lerna.akka.entityreplication.{ ClusterReplicationSerializable, ReplicationActor, ReplicationRegion }
 
 object RaftActor {
 
@@ -53,8 +53,8 @@ object RaftActor {
   sealed trait DomainEvent
 
   sealed trait PersistEvent                                  extends DomainEvent
-  final case class BegunNewTerm(term: Term)                  extends PersistEvent
-  final case class Voted(term: Term, candidate: MemberIndex) extends PersistEvent
+  final case class BegunNewTerm(term: Term)                  extends PersistEvent with ClusterReplicationSerializable
+  final case class Voted(term: Term, candidate: MemberIndex) extends PersistEvent with ClusterReplicationSerializable
   final case class DetectedNewTerm(term: Term)               extends PersistEvent
   final case class AppendedEntries(term: Term, logEntries: Seq[LogEntry], prevLogIndex: LogEntryIndex)
       extends PersistEvent

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftMemberData.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftMemberData.scala
@@ -1,5 +1,6 @@
 package lerna.akka.entityreplication.raft
 
+import lerna.akka.entityreplication.ClusterReplicationSerializable
 import lerna.akka.entityreplication.model.NormalizedEntityId
 import lerna.akka.entityreplication.raft.model._
 import lerna.akka.entityreplication.raft.routing.MemberIndex
@@ -8,6 +9,7 @@ import lerna.akka.entityreplication.raft.snapshot.SnapshotProtocol.EntitySnapsho
 object PersistentStateData {
 
   final case class PersistentState(currentTerm: Term, votedFor: Option[MemberIndex], replicatedLog: ReplicatedLog)
+      extends ClusterReplicationSerializable
 }
 
 trait PersistentStateData[T <: PersistentStateData[T]] {

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftProtocol.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftProtocol.scala
@@ -1,6 +1,7 @@
 package lerna.akka.entityreplication.raft
 
 import akka.actor.ActorRef
+import lerna.akka.entityreplication.ClusterReplicationSerializable
 import lerna.akka.entityreplication.model.{ EntityInstanceId, NormalizedEntityId }
 import lerna.akka.entityreplication.raft.model.{ LogEntry, LogEntryIndex }
 import lerna.akka.entityreplication.raft.snapshot.SnapshotProtocol.EntitySnapshot
@@ -10,8 +11,8 @@ object RaftProtocol {
   final case class RequestRecovery(entityId: NormalizedEntityId)
   final case class RecoveryState(events: Seq[LogEntry], snapshot: Option[EntitySnapshot])
 
-  case class Command(command: Any)
-  case class ForwardedCommand(command: Command)
+  case class Command(command: Any)              extends ClusterReplicationSerializable
+  case class ForwardedCommand(command: Command) extends ClusterReplicationSerializable
   case class Replica(logEntry: LogEntry)
 
   object Replicate {

--- a/src/main/scala/lerna/akka/entityreplication/raft/eventhandler/CommitLogStoreActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/eventhandler/CommitLogStoreActor.scala
@@ -5,13 +5,14 @@ import akka.actor.{ ActorRef, ActorSystem, Props }
 import akka.cluster.sharding.ShardRegion.HashCodeMessageExtractor
 import akka.cluster.sharding.{ ClusterSharding, ClusterShardingSettings }
 import akka.persistence.{ PersistentActor, RecoveryCompleted }
+import lerna.akka.entityreplication.ClusterReplicationSerializable
 import lerna.akka.entityreplication.raft.model.{ LogEntryIndex, NoOp }
 
 private[eventhandler] final case class Save(
     replicationId: CommitLogStore.ReplicationId,
     index: LogEntryIndex,
     committedEvent: Any,
-) extends Serializable
+) extends ClusterReplicationSerializable
 
 object CommitLogStoreActor {
 

--- a/src/main/scala/lerna/akka/entityreplication/raft/eventhandler/InternalEvent.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/eventhandler/InternalEvent.scala
@@ -1,6 +1,8 @@
 package lerna.akka.entityreplication.raft.eventhandler
 
+import lerna.akka.entityreplication.ClusterReplicationSerializable
+
 /**
   * index を揃えるために InternalEvent も永続化必要
   */
-case object InternalEvent
+case object InternalEvent extends ClusterReplicationSerializable

--- a/src/main/scala/lerna/akka/entityreplication/raft/protocol/RaftCommands.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/protocol/RaftCommands.scala
@@ -45,6 +45,7 @@ object RaftCommands {
 
   case class AppendEntriesSucceeded(term: Term, lastLogIndex: LogEntryIndex, sender: MemberIndex)
       extends AppendEntriesResponse
+      with ClusterReplicationSerializable
 
   case class AppendEntriesFailed(term: Term, sender: MemberIndex) extends AppendEntriesResponse
 }

--- a/src/main/scala/lerna/akka/entityreplication/raft/protocol/RaftCommands.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/protocol/RaftCommands.scala
@@ -47,5 +47,7 @@ object RaftCommands {
       extends AppendEntriesResponse
       with ClusterReplicationSerializable
 
-  case class AppendEntriesFailed(term: Term, sender: MemberIndex) extends AppendEntriesResponse
+  case class AppendEntriesFailed(term: Term, sender: MemberIndex)
+      extends AppendEntriesResponse
+      with ClusterReplicationSerializable
 }

--- a/src/main/scala/lerna/akka/entityreplication/raft/protocol/RaftCommands.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/protocol/RaftCommands.scala
@@ -1,5 +1,6 @@
 package lerna.akka.entityreplication.raft.protocol
 
+import lerna.akka.entityreplication.ClusterReplicationSerializable
 import lerna.akka.entityreplication.model.NormalizedShardId
 import lerna.akka.entityreplication.raft.model._
 import lerna.akka.entityreplication.raft.routing.MemberIndex
@@ -24,9 +25,11 @@ object RaftCommands {
 
   sealed trait RequestVoteResponse extends RaftResponse
 
-  case class RequestVoteAccepted(term: Term, sender: MemberIndex) extends RequestVoteResponse
+  case class RequestVoteAccepted(term: Term, sender: MemberIndex)
+      extends RequestVoteResponse
+      with ClusterReplicationSerializable
 
-  case class RequestVoteDenied(term: Term) extends RequestVoteResponse
+  case class RequestVoteDenied(term: Term) extends RequestVoteResponse with ClusterReplicationSerializable
 
   case class AppendEntries(
       shardId: NormalizedShardId,

--- a/src/main/scala/lerna/akka/entityreplication/raft/protocol/RaftCommands.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/protocol/RaftCommands.scala
@@ -22,6 +22,7 @@ object RaftCommands {
       lastLogIndex: LogEntryIndex,
       lastLogTerm: Term,
   ) extends RaftRequest
+      with ClusterReplicationSerializable
 
   sealed trait RequestVoteResponse extends RaftResponse
 
@@ -40,6 +41,7 @@ object RaftCommands {
       entries: Seq[LogEntry],
       leaderCommit: LogEntryIndex,
   ) extends RaftRequest
+      with ClusterReplicationSerializable
 
   sealed trait AppendEntriesResponse extends RaftResponse
 

--- a/src/main/scala/lerna/akka/entityreplication/raft/protocol/SuspendEntity.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/protocol/SuspendEntity.scala
@@ -1,6 +1,8 @@
 package lerna.akka.entityreplication.raft.protocol
 
+import lerna.akka.entityreplication.ClusterReplicationSerializable
 import lerna.akka.entityreplication.model.{ NormalizedEntityId, NormalizedShardId }
 
 final case class SuspendEntity(shardId: NormalizedShardId, entityId: NormalizedEntityId, stopMessage: Any)
     extends ShardRequest
+    with ClusterReplicationSerializable

--- a/src/main/scala/lerna/akka/entityreplication/raft/protocol/TryCreateEntity.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/protocol/TryCreateEntity.scala
@@ -1,5 +1,8 @@
 package lerna.akka.entityreplication.raft.protocol
 
+import lerna.akka.entityreplication.ClusterReplicationSerializable
 import lerna.akka.entityreplication.model.{ NormalizedEntityId, NormalizedShardId }
 
-final case class TryCreateEntity(shardId: NormalizedShardId, entityId: NormalizedEntityId) extends ShardRequest
+final case class TryCreateEntity(shardId: NormalizedShardId, entityId: NormalizedEntityId)
+    extends ShardRequest
+    with ClusterReplicationSerializable

--- a/src/main/scala/lerna/akka/entityreplication/raft/snapshot/SnapshotProtocol.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/snapshot/SnapshotProtocol.scala
@@ -1,6 +1,7 @@
 package lerna.akka.entityreplication.raft.snapshot
 
 import akka.actor.ActorRef
+import lerna.akka.entityreplication.ClusterReplicationSerializable
 import lerna.akka.entityreplication.model.NormalizedEntityId
 import lerna.akka.entityreplication.raft.model.LogEntryIndex
 
@@ -36,5 +37,5 @@ object SnapshotProtocol {
   final case class EntitySnapshot(
       metadata: EntitySnapshotMetadata,
       state: EntityState,
-  )
+  ) extends ClusterReplicationSerializable
 }

--- a/src/main/scala/lerna/akka/entityreplication/serialization/ClusterReplicationSerializer.scala
+++ b/src/main/scala/lerna/akka/entityreplication/serialization/ClusterReplicationSerializer.scala
@@ -10,4 +10,6 @@ class ClusterReplicationSerializer(system: ExtendedActorSystem)
   // Serializer identifier [123454323] of [lerna.akka.entityreplication.serialization.ClusterReplicationSerializer] is not unique.
   // It is also used by [io.altoo.akka.serialization.kryo.KryoSerializer]
   override def identifier: Int = 1602579212
+
+  override def configKey: String = "lerna.akka.entityreplication.kryo-serialization"
 }

--- a/src/main/scala/lerna/akka/entityreplication/serialization/ClusterReplicationSerializer.scala
+++ b/src/main/scala/lerna/akka/entityreplication/serialization/ClusterReplicationSerializer.scala
@@ -1,0 +1,13 @@
+package lerna.akka.entityreplication.serialization
+
+import akka.actor.ExtendedActorSystem
+
+class ClusterReplicationSerializer(system: ExtendedActorSystem)
+    extends io.altoo.akka.serialization.kryo.KryoSerializer(system) {
+  // To avoid an exception bellow. 1602579212 is an magic number which was created from timestamp.
+  // -----------------------------------------------------------------------------------------------------------------------------
+  // java.lang.IllegalArgumentException:
+  // Serializer identifier [123454323] of [lerna.akka.entityreplication.serialization.ClusterReplicationSerializer] is not unique.
+  // It is also used by [io.altoo.akka.serialization.kryo.KryoSerializer]
+  override def identifier: Int = 1602579212
+}

--- a/src/multi-jvm/resources/multi-jvm-testing.conf
+++ b/src/multi-jvm/resources/multi-jvm-testing.conf
@@ -17,6 +17,7 @@ akka.actor {
   }
   serialization-bindings {
     "lerna.akka.entityreplication.STMultiNodeSerializable" = kryo
+    "akka.persistence.Protocol$Message" = kryo  // used by AkkaPersistenceProxy
   }
 }
 

--- a/src/multi-jvm/resources/multi-jvm-testing.conf
+++ b/src/multi-jvm/resources/multi-jvm-testing.conf
@@ -12,6 +12,12 @@ akka {
 }
 akka.actor {
   allow-java-serialization = off
+  serializers {
+    kryo = "io.altoo.akka.serialization.kryo.KryoSerializer"
+  }
+  serialization-bindings {
+    "lerna.akka.entityreplication.STMultiNodeSerializable" = kryo
+  }
 }
 
 lerna.akka.entityreplication.raft.election-timeout = 1000 ms

--- a/src/multi-jvm/resources/multi-jvm-testing.conf
+++ b/src/multi-jvm/resources/multi-jvm-testing.conf
@@ -11,9 +11,7 @@ akka {
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
 }
 akka.actor {
-  # Akka 2.6.x から デフォルトが off になったため
-  # TODO Java Serialization を使わないように変更したほうがよい
-  allow-java-serialization = on
+  allow-java-serialization = off
 }
 
 lerna.akka.entityreplication.raft.election-timeout = 1000 ms

--- a/src/multi-jvm/scala/lerna/akka/entityreplication/ConsistencyTestBase.scala
+++ b/src/multi-jvm/scala/lerna/akka/entityreplication/ConsistencyTestBase.scala
@@ -44,12 +44,12 @@ object ConsistencyTestBase {
 
   object ConsistencyTestReplicationActor {
 
-    trait Command {
+    trait Command extends STMultiNodeSerializable {
       def id: String
       def requestId: String
     }
-    trait Event
-    trait Response {
+    trait Event extends STMultiNodeSerializable
+    trait Response extends STMultiNodeSerializable {
       def requestId: String
     }
 

--- a/src/multi-jvm/scala/lerna/akka/entityreplication/ReplicationActorSpec.scala
+++ b/src/multi-jvm/scala/lerna/akka/entityreplication/ReplicationActorSpec.scala
@@ -107,14 +107,14 @@ object ReplicationActorSpec {
 
   object LockReplicationActor {
 
-    sealed trait Command {
+    sealed trait Command extends STMultiNodeSerializable {
       def id: String
     }
     case class Lock(id: String)   extends Command
     case class UnLock(id: String) extends Command
 
-    case class GetStatus(id: String) extends Command
-    case class Status(id: String, locking: Boolean)
+    case class GetStatus(id: String)                extends Command
+    case class Status(id: String, locking: Boolean) extends STMultiNodeSerializable
 
     val extractEntityId: ReplicationRegion.ExtractEntityId = {
       case c: Command => ((c.id, c))

--- a/src/multi-jvm/scala/lerna/akka/entityreplication/ReplicationActorSpec.scala
+++ b/src/multi-jvm/scala/lerna/akka/entityreplication/ReplicationActorSpec.scala
@@ -56,12 +56,12 @@ object ReplicationActorSpec {
 
   object PingPongReplicationActor {
 
-    sealed trait Command {
+    sealed trait Command extends STMultiNodeSerializable {
       def id: String
     }
-    case class Ping(id: String) extends Command
-    case class Pong(id: String, count: Int)
-    case class Break(id: String) extends Command
+    case class Ping(id: String)             extends Command
+    case class Pong(id: String, count: Int) extends STMultiNodeSerializable
+    case class Break(id: String)            extends Command
 
     val extractEntityId: ReplicationRegion.ExtractEntityId = {
       case c: Command => (c.id, c)
@@ -164,7 +164,7 @@ object ReplicationActorSpec {
 
   object EphemeralReplicationActor {
 
-    sealed trait Command {
+    sealed trait Command extends STMultiNodeSerializable {
       def id: String
     }
 
@@ -173,7 +173,7 @@ object ReplicationActorSpec {
     case class IncrementCount(id: String) extends Command
     case class GetState(id: String)       extends Command
 
-    case class State(count: Int)
+    case class State(count: Int) extends STMultiNodeSerializable
 
     val extractEntityId: ReplicationRegion.ExtractEntityId = {
       case c: Command => (c.id, c)

--- a/src/multi-jvm/scala/lerna/akka/entityreplication/ReplicationRegionSpec.scala
+++ b/src/multi-jvm/scala/lerna/akka/entityreplication/ReplicationRegionSpec.scala
@@ -17,6 +17,7 @@ import scala.concurrent.duration._
 object ReplicationRegionSpec {
 
   case class ReceivedMessages(messages: Seq[CheckRouting], node: RoleName, memberIndex: MemberIndex)
+      extends STMultiNodeSerializable
 
   object DummyReplicationActor {
 

--- a/src/multi-jvm/scala/lerna/akka/entityreplication/ReplicationRegionSpec.scala
+++ b/src/multi-jvm/scala/lerna/akka/entityreplication/ReplicationRegionSpec.scala
@@ -22,7 +22,7 @@ object ReplicationRegionSpec {
 
     def props(probe: TestProbe) = Props(new DummyReplicationActor(probe))
 
-    sealed trait Command {
+    sealed trait Command extends STMultiNodeSerializable {
       def id: String
     }
 
@@ -31,7 +31,7 @@ object ReplicationRegionSpec {
 
     case class GetStatus(id: String)                        extends Command
     case class GetStatusWithEnsuringConsistency(id: String) extends Command
-    case class Status(count: Int)
+    case class Status(count: Int)                           extends STMultiNodeSerializable
 
     val extractEntityId: ReplicationRegion.ExtractEntityId = {
       case c: Command => (c.id, c)

--- a/src/multi-jvm/scala/lerna/akka/entityreplication/STMultiNodeSerializable.scala
+++ b/src/multi-jvm/scala/lerna/akka/entityreplication/STMultiNodeSerializable.scala
@@ -1,0 +1,3 @@
+package lerna.akka.entityreplication
+
+trait STMultiNodeSerializable extends Serializable

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -9,6 +9,10 @@ akka {
   }
 }
 
+akka.actor {
+  allow-java-serialization = off
+}
+
 lerna.akka.entityreplication.raft {
   persistence {
     journal.plugin = "inmemory-journal"


### PR DESCRIPTION
- Use kryo-serializer temporarily
- Serializer will be changed to ProtocolBuffers in a future release
- `ClusterReplicationSerializable`  should be only mixed-in to `final case class`
  - We can estimate how many `.proto` files required by counting ClusterReplicationSerializable mix-ins.

## Messages should be serializable

- [x] ~~Outgoing message attempted to use Java Serialization even though `akka.actor.allow-java-serialization = off` was set! Message type was: [class lerna.akka.entityreplication.model.NormalizedShardId]~~
- [x] Outgoing message attempted to use Java Serialization even though `akka.actor.allow-java-serialization = off` was set! Message type was: [class lerna.akka.entityreplication.raft.RaftActor$BegunNewTerm]
- [x] Outgoing message attempted to use Java Serialization even though `akka.actor.allow-java-serialization = off` was set! Message type was: [class lerna.akka.entityreplication.raft.RaftActor$Voted]
- [x] ~~Outgoing message attempted to use Java Serialization even though `akka.actor.allow-java-serialization = off` was set! Message type was: [class lerna.akka.entityreplication.ReplicationRegion$Routed]~~
- [x] Outgoing message attempted to use Java Serialization even though `akka.actor.allow-java-serialization = off` was set! Message type was: [class lerna.akka.entityreplication.raft.protocol.RaftCommands$RequestVoteAccepted]
- [x] Outgoing message attempted to use Java Serialization even though `akka.actor.allow-java-serialization = off` was set! Message type was: [class lerna.akka.entityreplication.raft.protocol.RaftCommands$RequestVoteDenied]
- [x] Outgoing message attempted to use Java Serialization even though `akka.actor.allow-java-serialization = off` was set! Message type was: [class lerna.akka.entityreplication.raft.RaftActor$AppendedEvent]
- [x] Outgoing message attempted to use Java Serialization even though `akka.actor.allow-java-serialization = off` was set! Message type was: [class lerna.akka.entityreplication.ReplicationActorSpec$LockReplicationActor$Status]
- [x] Outgoing message attempted to use Java Serialization even though `akka.actor.allow-java-serialization = off` was set! Message type was: [class lerna.akka.entityreplication.raft.RaftActor$AppendedEntries]
- [x] Outgoing message attempted to use Java Serialization even though `akka.actor.allow-java-serialization = off` was set! Message type was: [class lerna.akka.entityreplication.raft.protocol.RaftCommands$AppendEntriesSucceeded]
- [x] Outgoing message attempted to use Java Serialization even though `akka.actor.allow-java-serialization = off` was set! Message type was: [class lerna.akka.entityreplication.ConsistencyTestBase$ConsistencyTestReplicationActor$Complete]
- [x] Outgoing message attempted to use Java Serialization even though `akka.actor.allow-java-serialization = off` was set! Message type was: [class lerna.akka.entityreplication.ConsistencyTestBase$ConsistencyTestReplicationActor$Status]
- [x] Outgoing message attempted to use Java Serialization even though `akka.actor.allow-java-serialization = off` was set! Message type was: [class lerna.akka.entityreplication.raft.eventhandler.InternalEvent$]
- [x] Outgoing message attempted to use Java Serialization even though `akka.actor.allow-java-serialization = off` was set! Message type was: [class lerna.akka.entityreplication.raft.eventhandler.Save]
- [x] Outgoing message attempted to use Java Serialization even though `akka.actor.allow-java-serialization = off` was set! Message type was: [class lerna.akka.entityreplication.raft.protocol.RaftCommands$AppendEntriesFailed]
- [x] Outgoing message attempted to use Java Serialization even though `akka.actor.allow-java-serialization = off` was set! Message type was: [class lerna.akka.entityreplication.raft.snapshot.SnapshotProtocol$EntitySnapshot]
- [x] Outgoing message attempted to use Java Serialization even though `akka.actor.allow-java-serialization = off` was set! Message type was: [class lerna.akka.entityreplication.ReplicationActorSpec$EphemeralReplicationActor$State]
- [x] Outgoing message attempted to use Java Serialization even though `akka.actor.allow-java-serialization = off` was set! Message type was: [class lerna.akka.entityreplication.ReplicationActorSpec$PingPongReplicationActor$Pong]
- [x] Outgoing message attempted to use Java Serialization even though `akka.actor.allow-java-serialization = off` was set! Message type was: [class lerna.akka.entityreplication.ReplicationRegionSpec$DummyReplicationActor$Status]
- [x] Outgoing message attempted to use Java Serialization even though `akka.actor.allow-java-serialization = off` was set! Message type was: [class lerna.akka.entityreplication.raft.PersistentStateData$PersistentState]
- [x] Outgoing message attempted to use Java Serialization even though `akka.actor.allow-java-serialization = off` was set! Message type was: [class lerna.akka.entityreplication.raft.RaftActor$DetectedNewTerm]
- [x] Outgoing message attempted to use Java Serialization even though `akka.actor.allow-java-serialization = off` was set! Message type was: [class lerna.akka.entityreplication.ReplicationRegionSpec$ReceivedMessages]
- [x] Outgoing message attempted to use Java Serialization even though `akka.actor.allow-java-serialization = off` was set! Message type was: [class akka.persistence.SnapshotProtocol$LoadSnapshot]
- [x] Outgoing message attempted to use Java Serialization even though `akka.actor.allow-java-serialization = off` was set! Message type was: [class lerna.akka.entityreplication.raft.protocol.RaftCommands$RequestVote]
- [x] Outgoing message attempted to use Java Serialization even though `akka.actor.allow-java-serialization = off` was set! Message type was: [class lerna.akka.entityreplication.raft.RaftProtocol$Command]
- [x] Outgoing message attempted to use Java Serialization even though `akka.actor.allow-java-serialization = off` was set! Message type was: [class lerna.akka.entityreplication.raft.protocol.RaftCommands$AppendEntries]
- [x] Outgoing message attempted to use Java Serialization even though `akka.actor.allow-java-serialization = off` was set! Message type was: [class lerna.akka.entityreplication.raft.protocol.TryCreateEntity]
- [x] Outgoing message attempted to use Java Serialization even though `akka.actor.allow-java-serialization = off` was set! Message type was: [class lerna.akka.entityreplication.raft.RaftProtocol$ForwardedCommand]
- [x] Outgoing message attempted to use Java Serialization even though `akka.actor.allow-java-serialization = off` was set! Message type was: [class lerna.akka.entityreplication.raft.protocol.SuspendEntity]