### PR TITLE
Enable JUnit XML Reporter in MultiJVM

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,14 +51,17 @@ lazy val lerna = (project in file("."))
         // TODO 2.6.x 系に対応できる方法に変更する。
         "com.github.dnvriend" %% "akka-persistence-inmemory" % "2.5.15.2" % Test,
       ),
-    // multi-jvm ディレクトリをフォーマットするために必要
     inConfig(MultiJvm)(
-      scalafmtConfigSettings ++ scalafixConfigSettings(MultiJvm),
-    ),
-    scalatestOptions in MultiJvm ++= Seq(
-        "-u",
-        "target/multi-jvm-test-reports",
+      // multi-jvm ディレクトリをフォーマットするために必要
+      scalafmtConfigSettings
+      ++ scalafixConfigSettings(MultiJvm)
+      ++ Seq(
+        scalatestOptions ++= Seq(
+            "-u",
+            "target/multi-jvm-test-reports",
+          ),
       ),
+    ),
     // test-coverage
     coverageMinimum := 80,
     coverageFailOnMinimum := true,

--- a/build.sbt
+++ b/build.sbt
@@ -55,6 +55,10 @@ lazy val lerna = (project in file("."))
     inConfig(MultiJvm)(
       scalafmtConfigSettings ++ scalafixConfigSettings(MultiJvm),
     ),
+    scalatestOptions in MultiJvm ++= Seq(
+        "-u",
+        "target/multi-jvm-test-reports",
+      ),
     // test-coverage
     coverageMinimum := 80,
     coverageFailOnMinimum := true,


### PR DESCRIPTION
## Purpose

Make it easier to show failed test cases in `multi-jvm`.

## Changes I made

Add a `-u target/multi-jvm-test-reports` option to run MultiJvm.

`sbt-multi-jvm` plugin runs specs with ScalaTest.
ScalaTest can generate JUnit XML reports by specifying the `-u` option.

> -u  \<directory name\>	select the JUnit XML reporter, specifying the output directory
>
> [ScalaTest](https://www.scalatest.org/user_guide/using_the_runner#:~:text=%2du,output%20directory)

A `scalatestOptions in MultiJvm` setting injects ScalaTest arguments.

```
    scalatestOptions := defaultScalatestOptions,
```
[sbt-multi-jvm/SbtMultiJvm.scala at v0.4.0 · sbt/sbt-multi-jvm](https://github.com/sbt/sbt-multi-jvm/blob/v0.4.0/src/main/scala/com/typesafe/sbt/SbtMultiJvm.scala#L104)

## Generated report files

```
❯ ls -1 target/multi-jvm-test-reports/
TEST-lerna.akka.entityreplication.ConsistencyTestNormalMultiJvmNode1.xml
TEST-lerna.akka.entityreplication.ConsistencyTestNormalMultiJvmNode2.xml
TEST-lerna.akka.entityreplication.ConsistencyTestNormalMultiJvmNode3.xml
TEST-lerna.akka.entityreplication.ConsistencyTestNormalMultiJvmNode4.xml
TEST-lerna.akka.entityreplication.ConsistencyTestNormalMultiJvmNode5.xml
TEST-lerna.akka.entityreplication.raft.RaftActorSpecMultiJvmController.xml
TEST-lerna.akka.entityreplication.raft.RaftActorSpecMultiJvmNode1.xml
TEST-lerna.akka.entityreplication.raft.RaftActorSpecMultiJvmNode2.xml
TEST-lerna.akka.entityreplication.raft.RaftActorSpecMultiJvmNode3.xml
TEST-lerna.akka.entityreplication.ReplicationActorSpecMultiJvmNode1.xml
TEST-lerna.akka.entityreplication.ReplicationActorSpecMultiJvmNode2.xml
TEST-lerna.akka.entityreplication.ReplicationActorSpecMultiJvmNode3.xml
TEST-lerna.akka.entityreplication.ReplicationRegionSpecMultiJvmController.xml
TEST-lerna.akka.entityreplication.ReplicationRegionSpecMultiJvmNode1.xml
TEST-lerna.akka.entityreplication.ReplicationRegionSpecMultiJvmNode2.xml
TEST-lerna.akka.entityreplication.ReplicationRegionSpecMultiJvmNode3.xml
TEST-lerna.akka.entityreplication.ReplicationRegionSpecMultiJvmNode4.xml
TEST-lerna.akka.entityreplication.ReplicationRegionSpecMultiJvmNode5.xml
TEST-lerna.akka.entityreplication.ReplicationRegionSpecMultiJvmNode6.xml
TEST-lerna.akka.entityreplication.ReplicationRegionSpecMultiJvmNode7.xml
TEST-lerna.akka.entityreplication.SampleSpecMultiJvmNode1.xml
TEST-lerna.akka.entityreplication.SampleSpecMultiJvmNode2.xml
```

## How to show reports

`xunit-viewer` can generate a (human-readable) HTML file to show JUnit XML reports.

> Takes all your XUnit and JUnit XML files and makes them readable
>
> [xunit-viewer - npm](https://www.npmjs.com/package/xunit-viewer)

![image](https://user-images.githubusercontent.com/1239141/111101895-3078b780-858e-11eb-8773-d329a788838b.png)
