### PR TITLE
👷chore: Add junit-report action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,11 @@ jobs:
       run: sbt scalafmtCheckAll
 
     - name: Run tests
+      continue-on-error: true # results are reported by action-junit-report
       run: sbt clean coverage test
 
     - name: Run integration tests
+      continue-on-error: true # results are reported by action-junit-report
       run: sh ./scripts/run-multijvm-test.sh 5
 
     - name: Publish test report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,13 @@ jobs:
     - name: Run integration tests
       run: sh ./scripts/run-multijvm-test.sh 5
 
+    - name: Publish test report
+      uses: mikepenz/action-junit-report@v2
+      with:
+        check_name: ScalaTest Report
+        report_paths: 'target/**test-reports/TEST-*.xml'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Check the test coverage is above the minimum criteria
       run: sbt coverageAggregate
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
## Overview

[mikepenz/action-junit-report] publishes test results to GitHub PR from JUnit XML report which is provided by ScalaTest.

It allows us to show quickly which test failed.
ex) https://github.com/lerna-stack/akka-entity-replication/pull/30/checks?check_run_id=2118790370

## Not to do in this PR

- put `multi-jvm:test` failure reports on a source code like:

    > RaftActorFollowerSpec.Follower should 一度目の RequestVote には Accept する
    >
    > **[Test: action junit report by negokaz · Pull Request #30 · lerna-stack/akka-entity-replication](https://github.com/lerna-stack/akka-entity-replication/pull/30/files#:~:text=RaftActorFollowerSpec.Follower,%E3%81%AF%20Accept%20%E3%81%99%E3%82%8B)**

    [mikepenz/action-junit-report] finds a source code from the class name in JUnit XML report but class names in `multi-jvm` don't match scala files.

## References

- [ステータスによるステップの制御 - GitHub Actions | nju33](https://nju33.com/notes/github-actions/articles/%E3%82%B9%E3%83%86%E3%83%BC%E3%82%BF%E3%82%B9%E3%81%AB%E3%82%88%E3%82%8B%E3%82%B9%E3%83%86%E3%83%83%E3%83%97%E3%81%AE%E5%88%B6%E5%BE%A1)

## ToDo after this PR closed

- close https://github.com/lerna-stack/akka-entity-replication/pull/30 (for workflow validation)

[mikepenz/action-junit-report]: https://github.com/mikepenz/action-junit-report