### PR TITLE
👷chore: Split compile job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,13 @@ jobs:
     - name: Check code format
       run: sbt scalafmtCheckAll
 
+    # Detect compilation errors early
+    - name: Compile
+      run: sbt clean compile test:compile multi-jvm:compile
+
     - name: Run tests
       continue-on-error: true # results are reported by action-junit-report
-      run: sbt clean coverage test
+      run: sbt coverage test
 
     - name: Run integration tests
       continue-on-error: true # results are reported by action-junit-report


### PR DESCRIPTION
## What does this PR fix

Compile errors cannot be detected because `continue-on-error: true` is set in the test execution job.