### PR TITLE
Enable auto API mappings to link external libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,6 +62,8 @@ lazy val lerna = (project in file("."))
           ),
       ),
     ),
+    // doc
+    Compile / doc / autoAPIMappings := true,
     // test-coverage
     coverageMinimum := 80,
     coverageFailOnMinimum := true,


### PR DESCRIPTION
To link external libraries, set `Compile / doc / autoAPImappings = true`. 

> https://www.scala-sbt.org/1.x/docs/Howto-Scaladoc.html#Enable+automatic+linking+to+the+external+Scaladoc+of+managed+dependencies
> Set autoAPIMappings := true for sbt to tell scaladoc where it can find the API documentation for managed dependencies. This requires that dependencies have this information in its metadata and you are using scaladoc for Scala 2.10.2 or later.

How to check
- put below code at `src/main/scala/lerna/akka/entityreplication/package.scala`
- `sbt doc`
- check generated scaladoc
```
package lerna.akka

/** Document
  *
  * we can link classes of external library such as [[scala.Option]] and [[akka.NotUsed]].
  */
package object entityreplication
```
![image](https://user-images.githubusercontent.com/5388508/112095607-23884380-8be0-11eb-92b8-511c82ea1317.png)