### PR TITLE
Configure publishing a Scaladoc to GitHub Pages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,3 +43,18 @@ sbt doc
 ```
 
 A Scaladoc is generated in the directory `target/scala-2.13/api`.
+
+## Publish GitHub Pages
+
+We publish a Scaladoc to GitHub Pages using `sbt-site` and `sbt-ghpages`.
+
+To preview generated web pages, run the below command.
+```shell
+sbt previewSite
+```
+
+To publish the pages, run the below command.  
+You should have proper permission to publish.
+```shell
+sbt ghpagesPushSite
+```

--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,7 @@ lazy val lerna = (project in file("."))
   .enablePlugins(
     MultiJvmPlugin,
     SiteScaladocPlugin,
+    GhpagesPlugin,
   )
   .configs(MultiJvm)
   .settings(
@@ -67,6 +68,7 @@ lazy val lerna = (project in file("."))
     ),
     // doc
     Compile / doc / autoAPIMappings := true,
+    git.remoteRepo := "git@github.com:lerna-stack/akka-entity-replication.git",
     // test-coverage
     coverageMinimum := 80,
     coverageFailOnMinimum := true,

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,10 @@ lazy val akkaVersion           = "2.6.12"
 lazy val akkaProjectionVersion = "1.0.0"
 
 lazy val lerna = (project in file("."))
-  .enablePlugins(MultiJvmPlugin)
+  .enablePlugins(
+    MultiJvmPlugin,
+    SiteScaladocPlugin,
+  )
   .configs(MultiJvm)
   .settings(
     inThisBuild(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,3 +9,5 @@ addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.25")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.1")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.3")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,3 +7,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-multi-jvm" % "0.4.0")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.25")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.1")

--- a/src/site/index.html
+++ b/src/site/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Project Documentation</title>
+    <script language="JavaScript">
+        <!--
+        function doRedirect()
+        {
+            window.location.replace("latest/api");
+        }
+
+        doRedirect();
+        //-->
+    </script>
+</head>
+<body>
+<a href="latest/api">Go to the project documentation
+</a>
+</body>
+</html>


### PR DESCRIPTION
## Goals

Be able to publish a Scaladoc to GitHub Pages.

## Changes
- Add `sbt-site`
  To generate project websites.
  [sbt site](https://github.com/sbt/sbt-site)
- Add `sbt-ghpages`
  To publish the websites to GitHub Pages
  [sbt-ghpages](https://github.com/sbt/sbt-ghpages)
- Add some sbt configuration to publish
- Add "Publish GitHub Pages" section to CONTRIBUTING

## Generated Websites

We can see a generated websites at https://lerna-stack.github.io/akka-entity-replication/.

## How to publish
We have to run the below command, manually 😢 .

```shell
sbt ghpagesPushSite
```

This PR could not achieve automation, but it would be better to automate it in the future.