### PR TITLE
Improve persistent data compatibility

### DIFF
--- a/src/main/protobuf/cluster_replication.proto
+++ b/src/main/protobuf/cluster_replication.proto
@@ -72,13 +72,9 @@ message CommitLogStoreInternalEvent {
 }
 
 message CommitLogStoreSave {
-  required ReplicationId replication_id = 1;
+  required NormalizedShardId shard_id = 1;
   required LogEntryIndex index = 2;
   required Payload committed_event = 3;
-}
-
-message ReplicationId {
-  required string underlying = 1;
 }
 
 // ===

--- a/src/main/scala/lerna/akka/entityreplication/ClusterReplication.scala
+++ b/src/main/scala/lerna/akka/entityreplication/ClusterReplication.scala
@@ -1,6 +1,7 @@
 package lerna.akka.entityreplication
 
 import akka.actor.{ ActorRef, ActorSystem, Props }
+import lerna.akka.entityreplication.model.TypeName
 import lerna.akka.entityreplication.raft.eventsourced.{ CommitLogStore, ShardedCommitLogStore }
 
 object ClusterReplication {
@@ -21,11 +22,13 @@ class ClusterReplication(system: ActorSystem) {
       extractEntityId: ReplicationRegion.ExtractEntityId,
       extractShardId: ReplicationRegion.ExtractShardId,
   ): ActorRef = {
+    val _typeName = TypeName.from(typeName)
+
     val maybeCommitLogStore: Option[CommitLogStore] = {
       // TODO: RMUの有効無効をconfigから指定
       val enabled = true // FIXME: settings から取得する (typeName ごとに切り替えられる必要あり)
       // TODO: テストのために差し替え出来るようにする
-      Option.when(enabled)(new ShardedCommitLogStore(typeName, system))
+      Option.when(enabled)(new ShardedCommitLogStore(_typeName, system))
     }
 
     system.actorOf(

--- a/src/main/scala/lerna/akka/entityreplication/protobuf/ClusterReplicationSerializer.scala
+++ b/src/main/scala/lerna/akka/entityreplication/protobuf/ClusterReplicationSerializer.scala
@@ -387,7 +387,7 @@ private[entityreplication] final class ClusterReplicationSerializer(val system: 
   private def commitLogStoreSaveToBinary(message: raft.eventsourced.Save): Array[Byte] = {
     msg.CommitLogStoreSave
       .of(
-        replicationId = replicationIdToProto(message.replicationId),
+        shardId = normalizedShardIdToProto(message.shardId),
         index = logEntryIndexToProto(message.index),
         committedEvent = payloadToProto(message.committedEvent),
       ).toByteArray
@@ -396,20 +396,10 @@ private[entityreplication] final class ClusterReplicationSerializer(val system: 
   private def commitLogStoreSaveFromBinary(bytes: Array[Byte]): raft.eventsourced.Save = {
     val proto = msg.CommitLogStoreSave.parseFrom(bytes)
     raft.eventsourced.Save(
-      replicationId = replicationIdFromProto(proto.replicationId),
+      shardId = normalizedShardIdFromProto(proto.shardId),
       index = logEntryIndexFromProto(proto.index),
       committedEvent = payloadFromProto(proto.committedEvent),
     )
-  }
-
-  private def replicationIdToProto(message: raft.eventsourced.CommitLogStore.ReplicationId): msg.ReplicationId = {
-    // Use a consistent style for the future even if the ReplicationId is not a value class
-    msg.ReplicationId.of(message)
-  }
-
-  private def replicationIdFromProto(proto: msg.ReplicationId): raft.eventsourced.CommitLogStore.ReplicationId = {
-    // Use a consistent style for the future even if the ReplicationId is not a value class
-    proto.underlying
   }
 
   // ===

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
@@ -159,7 +159,8 @@ class RaftActor(
     }
   }
 
-  override val persistenceId: String = s"raft-${typeName.underlying}-${shardId.underlying}-${selfMemberIndex.role}"
+  override val persistenceId: String =
+    ActorIds.persistenceId("raft", typeName.underlying, shardId.underlying, selfMemberIndex.role)
 
   override def journalPluginId: String = settings.journalPluginId
 
@@ -169,7 +170,7 @@ class RaftActor(
 
   override def snapshotPluginConfig: Config = ConfigFactory.empty()
 
-  private[this] def replicationId = s"${typeName.underlying}-${shardId.underlying}"
+  private[this] def replicationId = shardId.underlying
 
   val numberOfMembers: Int = settings.replicationFactor
 

--- a/src/main/scala/lerna/akka/entityreplication/raft/eventsourced/CommitLogStore.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/eventsourced/CommitLogStore.scala
@@ -1,14 +1,11 @@
 package lerna.akka.entityreplication.raft.eventsourced
 
+import lerna.akka.entityreplication.model.NormalizedShardId
 import lerna.akka.entityreplication.raft.model.LogEntryIndex
-
-object CommitLogStore {
-  type ReplicationId = String
-}
 
 trait CommitLogStore {
   private[raft] def save(
-      replicationId: CommitLogStore.ReplicationId,
+      shardId: NormalizedShardId,
       index: LogEntryIndex,
       committedEvent: Any,
   ): Unit

--- a/src/main/scala/lerna/akka/entityreplication/raft/eventsourced/ShardedCommitLogStore.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/eventsourced/ShardedCommitLogStore.scala
@@ -3,13 +3,14 @@ package lerna.akka.entityreplication.raft.eventsourced
 import akka.actor.{ ActorSystem, Scheduler }
 import akka.pattern.ask
 import akka.util.Timeout
+import lerna.akka.entityreplication.model.TypeName
 import lerna.akka.entityreplication.raft.eventsourced.CommitLogStore.ReplicationId
 import lerna.akka.entityreplication.raft.model.LogEntryIndex
 
 import scala.jdk.DurationConverters._
 import scala.concurrent.duration.FiniteDuration
 
-class ShardedCommitLogStore(typeName: String, system: ActorSystem) extends CommitLogStore {
+class ShardedCommitLogStore(typeName: TypeName, system: ActorSystem) extends CommitLogStore {
   import system.dispatcher
   private implicit val scheduler: Scheduler = system.scheduler
 

--- a/src/main/scala/lerna/akka/entityreplication/raft/eventsourced/ShardedCommitLogStore.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/eventsourced/ShardedCommitLogStore.scala
@@ -3,8 +3,7 @@ package lerna.akka.entityreplication.raft.eventsourced
 import akka.actor.{ ActorSystem, Scheduler }
 import akka.pattern.ask
 import akka.util.Timeout
-import lerna.akka.entityreplication.model.TypeName
-import lerna.akka.entityreplication.raft.eventsourced.CommitLogStore.ReplicationId
+import lerna.akka.entityreplication.model.{ NormalizedShardId, TypeName }
 import lerna.akka.entityreplication.raft.model.LogEntryIndex
 
 import scala.jdk.DurationConverters._
@@ -23,12 +22,12 @@ class ShardedCommitLogStore(typeName: TypeName, system: ActorSystem) extends Com
   private val shardRegion = CommitLogStoreActor.startClusterSharding(typeName, system)
 
   override private[raft] def save(
-      replicationId: ReplicationId,
+      shardId: NormalizedShardId,
       index: LogEntryIndex,
       committedEvent: Any,
   ): Unit = {
     akka.pattern.retry(
-      () => shardRegion ? Save(replicationId, index, committedEvent),
+      () => shardRegion ? Save(shardId, index, committedEvent),
       attempts = retryAttempts,
       delay = retryDelay,
     )

--- a/src/multi-jvm/scala/lerna/akka/entityreplication/ReplicationActorMultiNodeSpec.scala
+++ b/src/multi-jvm/scala/lerna/akka/entityreplication/ReplicationActorMultiNodeSpec.scala
@@ -259,7 +259,7 @@ class ReplicationActorMultiNodeSpec extends MultiNodeSpec(ReplicationActorSpecCo
         }
       }
 
-      val entityId = createSeqReplicationId()
+      val entityId = createSeqEntityId()
 
       runOn(node1) {
         clusterReplication ! Ping(entityId)
@@ -288,7 +288,7 @@ class ReplicationActorMultiNodeSpec extends MultiNodeSpec(ReplicationActorSpecCo
         }
       }
 
-      val entityId = createSeqReplicationId()
+      val entityId = createSeqEntityId()
 
       runOn(node1) {
         clusterReplication ! Ping(entityId)
@@ -322,7 +322,7 @@ class ReplicationActorMultiNodeSpec extends MultiNodeSpec(ReplicationActorSpecCo
         }
       }
 
-      val entityId = createSeqReplicationId()
+      val entityId = createSeqEntityId()
 
       runOn(node1) {
         // 初期状態はロックされていない
@@ -345,7 +345,7 @@ class ReplicationActorMultiNodeSpec extends MultiNodeSpec(ReplicationActorSpecCo
       var clusterReplication: ActorRef = null
       var raftMember: ActorRef         = null
 
-      val entityId = createSeqReplicationId()
+      val entityId = createSeqEntityId()
 
       runOn(node1, node2, node3) {
         clusterReplication = planAutoKill {
@@ -399,7 +399,7 @@ class ReplicationActorMultiNodeSpec extends MultiNodeSpec(ReplicationActorSpecCo
       }
     }
 
-    val entityId = createSeqReplicationId()
+    val entityId = createSeqEntityId()
 
     runOn(node1) {
       // 初期値は 0
@@ -440,7 +440,7 @@ class ReplicationActorMultiNodeSpec extends MultiNodeSpec(ReplicationActorSpecCo
     }
   }
 
-  private[this] val idGenerator                      = new AtomicInteger(0)
-  private[this] def createSeqReplicationId(): String = s"replication-${idGenerator.incrementAndGet()}"
+  private[this] val idGenerator                 = new AtomicInteger(0)
+  private[this] def createSeqEntityId(): String = s"replication-${idGenerator.incrementAndGet()}"
 
 }

--- a/src/multi-jvm/scala/lerna/akka/entityreplication/ReplicationRegionSpec.scala
+++ b/src/multi-jvm/scala/lerna/akka/entityreplication/ReplicationRegionSpec.scala
@@ -243,7 +243,7 @@ class ReplicationRegionSpec extends MultiNodeSpec(ReplicationRegionSpecConfig) w
     "子の Entity にコマンドを転送する" in {
       val typeName = createSeqTypeName()
 
-      val entityId = createSeqReplicationId()
+      val entityId = createSeqEntityId()
       runOn(node1, node2, node3) {
         clusterReplication = createReplication(typeName)
       }
@@ -259,7 +259,7 @@ class ReplicationRegionSpec extends MultiNodeSpec(ReplicationRegionSpecConfig) w
 
     "各 ReplicationActor の状態が同期する" in {
       val typeName = createSeqTypeName()
-      val entityId = createSeqReplicationId()
+      val entityId = createSeqEntityId()
       runOn(node1, node2, node3) {
         clusterReplication = createReplication(typeName)
       }
@@ -288,7 +288,7 @@ class ReplicationRegionSpec extends MultiNodeSpec(ReplicationRegionSpecConfig) w
 
     "一度 Region を停止しても各 ReplicationActor の状態が復元する" in {
       val typeName = createSeqTypeName()
-      val entityId = createSeqReplicationId()
+      val entityId = createSeqEntityId()
       runOn(node1, node2, node3) {
         clusterReplication = createReplication(typeName)
       }
@@ -340,7 +340,7 @@ class ReplicationRegionSpec extends MultiNodeSpec(ReplicationRegionSpecConfig) w
         }
         enterBarrier("ReplicationRegion created")
 
-        val entityId = createSeqReplicationId()
+        val entityId = createSeqEntityId()
 
         val message = Command(CheckRouting(entityId))
 
@@ -365,7 +365,7 @@ class ReplicationRegionSpec extends MultiNodeSpec(ReplicationRegionSpecConfig) w
         }
         enterBarrier("ReplicationRegion created")
 
-        val entityId = createSeqReplicationId()
+        val entityId = createSeqEntityId()
 
         val message = Command(CheckRouting(entityId))
 
@@ -393,7 +393,7 @@ class ReplicationRegionSpec extends MultiNodeSpec(ReplicationRegionSpecConfig) w
         }
         enterBarrier("ReplicationRegion created")
 
-        val entityId = createSeqReplicationId()
+        val entityId = createSeqEntityId()
 
         val message = Command(CheckRouting(entityId))
 
@@ -415,7 +415,7 @@ class ReplicationRegionSpec extends MultiNodeSpec(ReplicationRegionSpecConfig) w
 
       "いずれかの MemberIndex に配信される" in {
         val typeName = createSeqTypeName()
-        val entityId = createSeqReplicationId()
+        val entityId = createSeqEntityId()
 
         val message = CheckRouting(entityId)
 
@@ -451,7 +451,7 @@ class ReplicationRegionSpec extends MultiNodeSpec(ReplicationRegionSpecConfig) w
       "ShardId が同じ場合は、ある role の同じノードに転送される" in {
         val typeName = createSeqTypeName()
         // entityId が同じなら ShardId も同じになる
-        val entityId = createSeqReplicationId()
+        val entityId = createSeqEntityId()
 
         val message = CheckRouting(entityId)
 
@@ -485,7 +485,7 @@ class ReplicationRegionSpec extends MultiNodeSpec(ReplicationRegionSpecConfig) w
       "Adding a node has no effect on routing except for the MemberIndex with more nodes" in {
         val typeName = createSeqTypeName()
         // entityId が同じなら ShardId も同じになる
-        val entityId = createSeqReplicationId()
+        val entityId = createSeqEntityId()
 
         val message = CheckRouting(entityId)
 
@@ -540,8 +540,8 @@ class ReplicationRegionSpec extends MultiNodeSpec(ReplicationRegionSpecConfig) w
     }
   }
 
-  private[this] val idGenerator                      = new AtomicInteger(0)
-  private[this] def createSeqReplicationId(): String = s"replication-${idGenerator.incrementAndGet()}"
-  private[this] def createSeqTypeName(): String      = s"typeName-${idGenerator.incrementAndGet()}"
+  private[this] val idGenerator                 = new AtomicInteger(0)
+  private[this] def createSeqEntityId(): String = s"replication-${idGenerator.incrementAndGet()}"
+  private[this] def createSeqTypeName(): String = s"typeName-${idGenerator.incrementAndGet()}"
 
 }

--- a/src/test/scala/lerna/akka/entityreplication/protobuf/ClusterReplicationSerializerSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/protobuf/ClusterReplicationSerializerSpec.scala
@@ -135,7 +135,7 @@ final class ClusterReplicationSerializerSpec
     checkSerialization(InternalEvent)
     checkSerialization(
       Save(
-        "rep&id172",
+        NormalizedShardId("shard:need?url&encode"),
         LogEntryIndex(75185),
         MyEvent(908125, "save?my-event!"),
       ),

--- a/src/test/scala/lerna/akka/entityreplication/protobuf/ClusterReplicationSerializerSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/protobuf/ClusterReplicationSerializerSpec.scala
@@ -135,7 +135,7 @@ final class ClusterReplicationSerializerSpec
     checkSerialization(InternalEvent)
     checkSerialization(
       Save(
-        NormalizedShardId("shard:need?url&encode"),
+        NormalizedShardId.from("shard:need?url&encode"),
         LogEntryIndex(75185),
         MyEvent(908125, "save?my-event!"),
       ),


### PR DESCRIPTION
- Use `ActorIds.persistenceId` for all persistenceIds:
    - IDs that are simply joined with `-` can conflict with other ids
- Do not use `replicationId` for `persistenceId` of  `CommitLogStore`:
    - Changing the `replicationId` breaks data compatibility
    - Use `NormalizedShardId` instead of `replicationId`

