### PR TITLE
Make internal API private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+[Unreleased]: https://github.com/lerna-stack/akka-entity-replication/compare/.v1.0.0...master
+
+### Removed
+
+- Made internal APIs private
+  
+  ⚠️ If you are only using the APIs using in the implementation guide, this change does not affect your application. 
+  Otherwise, some APIs may be unavailable.
+  Please see the following PR to check APIs that will no longer be available.
+
+  https://github.com/lerna-stack/akka-entity-replication/pull/47
+
+## [v1.0.0] - 2021-03-29
+[v1.0.0]: https://github.com/lerna-stack/akka-entity-replication/compare/v0.1.1...v1.0.0
+
+- GA release 🚀
+
+## [v0.1.0] - 2021-01-12
+[v0.1.0]: https://github.com/lerna-stack/akka-entity-replication/tree/v0.1.1
+
+- Initial release (under development)

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ You can see a sample application using this extension in the following project.
 
 [lerna-stack/akka-entity-replication-sample](https://github.com/lerna-stack/akka-entity-replication-sample)
 
+## Changelog
+
+You can see all the notable changes in [CHANGELOG](CHANGELOG.md).
+
 ## License
 
 akka-entity-replication is released under the terms of the [Apache License Version 2.0](./LICENSE).

--- a/src/main/scala/lerna/akka/entityreplication/ClusterReplication.scala
+++ b/src/main/scala/lerna/akka/entityreplication/ClusterReplication.scala
@@ -8,7 +8,7 @@ object ClusterReplication {
 
   def apply(system: ActorSystem): ClusterReplication = new ClusterReplication(system)
 
-  val actorNamePrefix: String = "replicationRegion"
+  private val actorNamePrefix: String = "replicationRegion"
 }
 
 class ClusterReplication private (system: ActorSystem) {

--- a/src/main/scala/lerna/akka/entityreplication/ClusterReplication.scala
+++ b/src/main/scala/lerna/akka/entityreplication/ClusterReplication.scala
@@ -11,7 +11,7 @@ object ClusterReplication {
   val actorNamePrefix: String = "replicationRegion"
 }
 
-class ClusterReplication(system: ActorSystem) {
+class ClusterReplication private (system: ActorSystem) {
 
   import ClusterReplication._
 

--- a/src/main/scala/lerna/akka/entityreplication/ClusterReplicationSerializable.scala
+++ b/src/main/scala/lerna/akka/entityreplication/ClusterReplicationSerializable.scala
@@ -1,2 +1,2 @@
 package lerna.akka.entityreplication
-trait ClusterReplicationSerializable extends Serializable
+private[entityreplication] trait ClusterReplicationSerializable extends Serializable

--- a/src/main/scala/lerna/akka/entityreplication/ReplicationActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/ReplicationActor.scala
@@ -10,18 +10,19 @@ import lerna.akka.entityreplication.raft.model.{ LogEntryIndex, NoOp }
 import lerna.akka.entityreplication.raft.protocol.SnapshotOffer
 import lerna.akka.entityreplication.raft.snapshot.SnapshotProtocol._
 
-object ReplicationActor {
+private[entityreplication] object ReplicationActor {
 
-  private val instanceIdCounter = new AtomicInteger(1)
+  private[this] val instanceIdCounter = new AtomicInteger(1)
 
   private def generateInstanceId(): EntityInstanceId = EntityInstanceId(instanceIdCounter.getAndIncrement())
 
-  final case class TakeSnapshot(metadata: EntitySnapshotMetadata, replyTo: ActorRef)
-  final case class Snapshot(metadata: EntitySnapshotMetadata, state: EntityState)
+  private[entityreplication] final case class TakeSnapshot(metadata: EntitySnapshotMetadata, replyTo: ActorRef)
+  private[entityreplication] final case class Snapshot(metadata: EntitySnapshotMetadata, state: EntityState)
 
   private final case object RecoveryTimeout
 
-  final case class EntityRecoveryTimeoutException(entityPath: ActorPath) extends RuntimeException
+  private[entityreplication] final case class EntityRecoveryTimeoutException(entityPath: ActorPath)
+      extends RuntimeException
 }
 
 trait ReplicationActor[StateData] extends Actor with Stash with akka.lerna.StashFactory {

--- a/src/main/scala/lerna/akka/entityreplication/ReplicationRegion.scala
+++ b/src/main/scala/lerna/akka/entityreplication/ReplicationRegion.scala
@@ -51,7 +51,7 @@ object ReplicationRegion {
 
   private[entityreplication] type ExtractNormalizedShardId = PartialFunction[Msg, NormalizedShardId]
 
-  def props(
+  private[entityreplication] def props(
       typeName: String,
       entityProps: Props,
       settings: ClusterReplicationSettings,
@@ -61,24 +61,24 @@ object ReplicationRegion {
   ) =
     Props(new ReplicationRegion(typeName, entityProps, settings, extractEntityId, extractShardId, maybeCommitLogStore))
 
-  case class CreateShard(shardId: NormalizedShardId) extends ShardRequest
+  private[entityreplication] case class CreateShard(shardId: NormalizedShardId) extends ShardRequest
 
   final case class Passivate(entityPath: ActorPath, stopMessage: Any)
 
-  sealed trait RoutingCommand
-  final case class Broadcast(message: Any)                     extends RoutingCommand
-  final case class BroadcastWithoutSelf(message: Any)          extends RoutingCommand
-  final case class DeliverTo(index: MemberIndex, message: Any) extends RoutingCommand
-  final case class DeliverSomewhere(message: Any)              extends RoutingCommand
+  private[entityreplication] sealed trait RoutingCommand
+  private[entityreplication] final case class Broadcast(message: Any)                     extends RoutingCommand
+  private[entityreplication] final case class BroadcastWithoutSelf(message: Any)          extends RoutingCommand
+  private[entityreplication] final case class DeliverTo(index: MemberIndex, message: Any) extends RoutingCommand
+  private[entityreplication] final case class DeliverSomewhere(message: Any)              extends RoutingCommand
 
   /**
     * [[ReplicationRegion]] 同士の通信で利用。適切なノードにメッセージがルーティング済みであることを表す
     * @param message
     */
-  final case class Routed(message: Any)
+  private[entityreplication] final case class Routed(message: Any)
 }
 
-class ReplicationRegion(
+private[entityreplication] class ReplicationRegion(
     typeName: String,
     entityProps: Props,
     settings: ClusterReplicationSettings,

--- a/src/main/scala/lerna/akka/entityreplication/model/EntityInstanceId.scala
+++ b/src/main/scala/lerna/akka/entityreplication/model/EntityInstanceId.scala
@@ -1,3 +1,3 @@
 package lerna.akka.entityreplication.model
 
-final case class EntityInstanceId(underlying: Int) extends AnyVal
+private[entityreplication] final case class EntityInstanceId(underlying: Int) extends AnyVal

--- a/src/main/scala/lerna/akka/entityreplication/model/NormalizedEntityId.scala
+++ b/src/main/scala/lerna/akka/entityreplication/model/NormalizedEntityId.scala
@@ -5,7 +5,7 @@ import lerna.akka.entityreplication.ReplicationRegion.EntityId
 
 import java.net.URLEncoder
 
-object NormalizedEntityId {
+private[entityreplication] object NormalizedEntityId {
   def from(entityId: EntityId): NormalizedEntityId = new NormalizedEntityId(URLEncoder.encode(entityId, "utf-8"))
 
   def of(entityPath: ActorPath): NormalizedEntityId = new NormalizedEntityId(entityPath.name)
@@ -14,4 +14,4 @@ object NormalizedEntityId {
     new NormalizedEntityId(encodedEntityId)
 }
 
-final case class NormalizedEntityId private (underlying: String) extends AnyVal
+private[entityreplication] final case class NormalizedEntityId private (underlying: String) extends AnyVal

--- a/src/main/scala/lerna/akka/entityreplication/model/NormalizedShardId.scala
+++ b/src/main/scala/lerna/akka/entityreplication/model/NormalizedShardId.scala
@@ -4,7 +4,7 @@ import java.net.{ URLDecoder, URLEncoder }
 
 import akka.actor.ActorPath
 
-object NormalizedShardId {
+private[entityreplication] object NormalizedShardId {
   def from(shardId: String): NormalizedShardId = new NormalizedShardId(URLEncoder.encode(shardId, "utf-8"))
 
   private[entityreplication] def from(path: ActorPath) = new NormalizedShardId(path.name)
@@ -13,6 +13,6 @@ object NormalizedShardId {
     new NormalizedShardId(encodedShardId)
 }
 
-final case class NormalizedShardId private (underlying: String) extends AnyVal {
+private[entityreplication] final case class NormalizedShardId private (underlying: String) extends AnyVal {
   def raw: String = URLDecoder.decode(underlying, "utf-8")
 }

--- a/src/main/scala/lerna/akka/entityreplication/model/TypeName.scala
+++ b/src/main/scala/lerna/akka/entityreplication/model/TypeName.scala
@@ -2,10 +2,10 @@ package lerna.akka.entityreplication.model
 
 import java.net.URLEncoder
 
-object TypeName {
+private[entityreplication] object TypeName {
   def from(typeName: String): TypeName = new TypeName(URLEncoder.encode(typeName, "utf-8"))
 }
 
-final class TypeName private (val underlying: String) extends AnyVal {
+private[entityreplication] final class TypeName private (val underlying: String) extends AnyVal {
   override def toString: String = underlying
 }

--- a/src/main/scala/lerna/akka/entityreplication/raft/Candidate.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/Candidate.scala
@@ -7,7 +7,7 @@ import lerna.akka.entityreplication.raft.protocol.{ SuspendEntity, TryCreateEnti
 import lerna.akka.entityreplication.raft.snapshot.SnapshotProtocol
 import lerna.akka.entityreplication.raft.snapshot.sync.SnapshotSyncManager
 
-trait Candidate { this: RaftActor =>
+private[raft] trait Candidate { this: RaftActor =>
   import RaftActor._
 
   def candidateBehavior: Receive = {

--- a/src/main/scala/lerna/akka/entityreplication/raft/Follower.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/Follower.scala
@@ -7,7 +7,7 @@ import lerna.akka.entityreplication.raft.snapshot.SnapshotProtocol
 import lerna.akka.entityreplication.raft.snapshot.sync.SnapshotSyncManager
 import lerna.akka.entityreplication.{ ReplicationActor, ReplicationRegion }
 
-trait Follower { this: RaftActor =>
+private[raft] trait Follower { this: RaftActor =>
   import RaftActor._
 
   def followerBehavior: Receive = {

--- a/src/main/scala/lerna/akka/entityreplication/raft/Leader.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/Leader.scala
@@ -10,7 +10,7 @@ import lerna.akka.entityreplication.raft.snapshot.SnapshotProtocol
 import lerna.akka.entityreplication.raft.snapshot.sync.SnapshotSyncManager
 import lerna.akka.entityreplication.{ ReplicationActor, ReplicationRegion }
 
-trait Leader { this: RaftActor =>
+private[raft] trait Leader { this: RaftActor =>
   import RaftActor._
 
   def leaderBehavior: Receive = {

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
@@ -17,7 +17,7 @@ import lerna.akka.entityreplication.raft.snapshot.sync.SnapshotSyncManager
 import lerna.akka.entityreplication.util.ActorIds
 import lerna.akka.entityreplication.{ ClusterReplicationSerializable, ReplicationActor, ReplicationRegion }
 
-object RaftActor {
+private[entityreplication] object RaftActor {
 
   def props(
       typeName: TypeName,
@@ -95,7 +95,7 @@ object RaftActor {
   trait NonPersistEventLike extends NonPersistEvent // テスト用
 }
 
-class RaftActor(
+private[raft] class RaftActor(
     typeName: TypeName,
     val extractEntityId: PartialFunction[Msg, (NormalizedEntityId, Msg)],
     replicationActorProps: Props,

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftActorBase.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftActorBase.scala
@@ -5,14 +5,14 @@ import akka.persistence.{ PersistentActor, RecoveryCompleted, SnapshotOffer }
 import lerna.akka.entityreplication.raft.PersistentStateData.PersistentState
 import lerna.akka.entityreplication.raft.RaftActor._
 
-object RaftActorBase {
+private[raft] object RaftActorBase {
 
   object `->` {
     def unapply(in: (State, State)) = Some(in)
   }
 }
 
-trait RaftActorBase extends PersistentActor with ActorLogging {
+private[raft] trait RaftActorBase extends PersistentActor with ActorLogging {
 
   type TransitionHandler = PartialFunction[(State, State), Unit]
 

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftMemberData.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftMemberData.scala
@@ -6,7 +6,7 @@ import lerna.akka.entityreplication.raft.model._
 import lerna.akka.entityreplication.raft.routing.MemberIndex
 import lerna.akka.entityreplication.raft.snapshot.SnapshotProtocol.EntitySnapshotMetadata
 
-object PersistentStateData {
+private[entityreplication] object PersistentStateData {
 
   final case class PersistentState(
       currentTerm: Term,
@@ -16,7 +16,7 @@ object PersistentStateData {
   ) extends ClusterReplicationSerializable
 }
 
-trait PersistentStateData[T <: PersistentStateData[T]] {
+private[entityreplication] trait PersistentStateData[T <: PersistentStateData[T]] {
   import PersistentStateData._
 
   def currentTerm: Term
@@ -35,7 +35,7 @@ trait PersistentStateData[T <: PersistentStateData[T]] {
     PersistentState(currentTerm, votedFor, replicatedLog, lastSnapshotStatus)
 }
 
-trait VolatileStateData[T <: VolatileStateData[T]] {
+private[entityreplication] trait VolatileStateData[T <: VolatileStateData[T]] {
   def commitIndex: LogEntryIndex
   def lastApplied: LogEntryIndex
   def snapshottingProgress: SnapshottingProgress
@@ -47,7 +47,7 @@ trait VolatileStateData[T <: VolatileStateData[T]] {
   ): T
 }
 
-trait FollowerData { self: RaftMemberData =>
+private[entityreplication] trait FollowerData { self: RaftMemberData =>
   def leaderMember: Option[MemberIndex]
 
   def initializeFollowerData(): RaftMemberData = {
@@ -101,7 +101,7 @@ trait FollowerData { self: RaftMemberData =>
   protected def updateFollowerVolatileState(leaderMember: Option[MemberIndex] = leaderMember): RaftMemberData
 }
 
-trait CandidateData { self: RaftMemberData =>
+private[entityreplication] trait CandidateData { self: RaftMemberData =>
   def acceptedMembers: Set[MemberIndex]
 
   def initializeCandidateData(): RaftMemberData = {
@@ -122,7 +122,7 @@ trait CandidateData { self: RaftMemberData =>
   protected def updateCandidateVolatileState(acceptedMembers: Set[MemberIndex]): RaftMemberData
 }
 
-trait LeaderData { self: RaftMemberData =>
+private[entityreplication] trait LeaderData { self: RaftMemberData =>
   def nextIndex: Option[NextIndex]
   def matchIndex: MatchIndex
   def clients: Map[LogEntryIndex, ClientContext]
@@ -205,7 +205,7 @@ trait LeaderData { self: RaftMemberData =>
   ): RaftMemberData
 }
 
-object RaftMemberData {
+private[entityreplication] object RaftMemberData {
   import PersistentStateData._
 
   def apply(persistentState: PersistentState): RaftMemberData = {
@@ -248,7 +248,7 @@ object RaftMemberData {
     )
 }
 
-trait RaftMemberData
+private[entityreplication] trait RaftMemberData
     extends PersistentStateData[RaftMemberData]
     with VolatileStateData[RaftMemberData]
     with FollowerData
@@ -347,7 +347,7 @@ trait RaftMemberData
 
 }
 
-final case class RaftMemberDataImpl(
+private[entityreplication] final case class RaftMemberDataImpl(
     currentTerm: Term,
     votedFor: Option[MemberIndex],
     replicatedLog: ReplicatedLog,

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftProtocol.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftProtocol.scala
@@ -6,7 +6,7 @@ import lerna.akka.entityreplication.model.{ EntityInstanceId, NormalizedEntityId
 import lerna.akka.entityreplication.raft.model.{ LogEntry, LogEntryIndex }
 import lerna.akka.entityreplication.raft.snapshot.SnapshotProtocol.EntitySnapshot
 
-object RaftProtocol {
+private[entityreplication] object RaftProtocol {
 
   final case class RequestRecovery(entityId: NormalizedEntityId)
   final case class RecoveryState(events: Seq[LogEntry], snapshot: Option[EntitySnapshot])

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftSettings.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftSettings.scala
@@ -12,7 +12,7 @@ private[entityreplication] object RaftSettings {
   def apply(root: Config) = new RaftSettings(root)
 }
 
-class RaftSettings(root: Config) {
+class RaftSettings private[raft] (root: Config) {
 
   val config: Config = root.getConfig("lerna.akka.entityreplication.raft")
 

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftSettings.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftSettings.scala
@@ -8,7 +8,7 @@ import scala.jdk.DurationConverters._
 import scala.concurrent.duration.{ Duration, FiniteDuration }
 import scala.util.Random
 
-object RaftSettings {
+private[entityreplication] object RaftSettings {
   def apply(root: Config) = new RaftSettings(root)
 }
 

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftSettings.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftSettings.scala
@@ -18,7 +18,7 @@ class RaftSettings(root: Config) {
 
   val electionTimeout: FiniteDuration = config.getDuration("election-timeout").toScala
 
-  def randomizedElectionTimeout(): FiniteDuration = randomized(electionTimeout)
+  private[raft] def randomizedElectionTimeout(): FiniteDuration = randomized(electionTimeout)
 
   val heartbeatInterval: FiniteDuration = config.getDuration("heartbeat-interval").toScala
 
@@ -29,7 +29,7 @@ class RaftSettings(root: Config) {
   /**
     * 75% - 150% of duration
     */
-  def randomized(duration: FiniteDuration): FiniteDuration = {
+  private[this] def randomized(duration: FiniteDuration): FiniteDuration = {
     val randomizedDuration = duration * (randomizedMinFactor + randomizedMaxFactor * Random.nextDouble())
     FiniteDuration(randomizedDuration.toNanos, NANOSECONDS)
   }
@@ -76,7 +76,8 @@ class RaftSettings(root: Config) {
 
   val compactionLogSizeCheckInterval: FiniteDuration = config.getDuration("compaction.log-size-check-interval").toScala
 
-  def randomizedCompactionLogSizeCheckInterval(): FiniteDuration = randomized(compactionLogSizeCheckInterval)
+  private[raft] def randomizedCompactionLogSizeCheckInterval(): FiniteDuration =
+    randomized(compactionLogSizeCheckInterval)
 
   val snapshotSyncCopyingParallelism: Int = config.getInt("snapshot-sync.snapshot-copying-parallelism")
 

--- a/src/main/scala/lerna/akka/entityreplication/raft/eventsourced/CommitLogStore.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/eventsourced/CommitLogStore.scala
@@ -3,7 +3,7 @@ package lerna.akka.entityreplication.raft.eventsourced
 import lerna.akka.entityreplication.model.NormalizedShardId
 import lerna.akka.entityreplication.raft.model.LogEntryIndex
 
-trait CommitLogStore {
+private[entityreplication] trait CommitLogStore {
   private[raft] def save(
       shardId: NormalizedShardId,
       index: LogEntryIndex,

--- a/src/main/scala/lerna/akka/entityreplication/raft/eventsourced/CommitLogStoreActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/eventsourced/CommitLogStoreActor.scala
@@ -19,7 +19,7 @@ private[entityreplication] final case class Save(
     committedEvent: Any,
 ) extends ClusterReplicationSerializable
 
-object CommitLogStoreActor {
+private[entityreplication] object CommitLogStoreActor {
 
   def startClusterSharding(typeName: TypeName, system: ActorSystem): ActorRef = {
     val clusterSharding         = ClusterSharding(system)
@@ -44,7 +44,7 @@ object CommitLogStoreActor {
   private def props(typeName: TypeName): Props = Props(new CommitLogStoreActor(typeName))
 }
 
-class CommitLogStoreActor(typeName: TypeName) extends PersistentActor {
+private[entityreplication] class CommitLogStoreActor(typeName: TypeName) extends PersistentActor {
   // TODO: 複数 Raft(typeName) に対応するために typeName ごとに cassandra-journal.keyspace を分ける
   override def journalPluginId: String =
     context.system.settings.config

--- a/src/main/scala/lerna/akka/entityreplication/raft/eventsourced/InternalEvent.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/eventsourced/InternalEvent.scala
@@ -5,4 +5,4 @@ import lerna.akka.entityreplication.ClusterReplicationSerializable
 /**
   * index を揃えるために InternalEvent も永続化必要
   */
-case object InternalEvent extends ClusterReplicationSerializable
+private[entityreplication] case object InternalEvent extends ClusterReplicationSerializable

--- a/src/main/scala/lerna/akka/entityreplication/raft/eventsourced/ShardedCommitLogStore.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/eventsourced/ShardedCommitLogStore.scala
@@ -9,7 +9,7 @@ import lerna.akka.entityreplication.raft.model.LogEntryIndex
 import scala.jdk.DurationConverters._
 import scala.concurrent.duration.FiniteDuration
 
-class ShardedCommitLogStore(typeName: TypeName, system: ActorSystem) extends CommitLogStore {
+private[entityreplication] class ShardedCommitLogStore(typeName: TypeName, system: ActorSystem) extends CommitLogStore {
   import system.dispatcher
   private implicit val scheduler: Scheduler = system.scheduler
 

--- a/src/main/scala/lerna/akka/entityreplication/raft/model/ClientContext.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/model/ClientContext.scala
@@ -3,4 +3,8 @@ package lerna.akka.entityreplication.raft.model
 import akka.actor.ActorRef
 import lerna.akka.entityreplication.model.EntityInstanceId
 
-case class ClientContext(ref: ActorRef, instanceId: Option[EntityInstanceId], originSender: Option[ActorRef])
+private[entityreplication] final case class ClientContext(
+    ref: ActorRef,
+    instanceId: Option[EntityInstanceId],
+    originSender: Option[ActorRef],
+)

--- a/src/main/scala/lerna/akka/entityreplication/raft/model/EntityEvent.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/model/EntityEvent.scala
@@ -2,4 +2,4 @@ package lerna.akka.entityreplication.raft.model
 
 import lerna.akka.entityreplication.model.NormalizedEntityId
 
-final case class EntityEvent(entityId: Option[NormalizedEntityId], event: Any)
+private[entityreplication] final case class EntityEvent(entityId: Option[NormalizedEntityId], event: Any)

--- a/src/main/scala/lerna/akka/entityreplication/raft/model/LogEntry.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/model/LogEntry.scala
@@ -1,12 +1,13 @@
 package lerna.akka.entityreplication.raft.model
 
-object LogEntry {
+private[entityreplication] object LogEntry {
 
   def apply(index: LogEntryIndex, event: EntityEvent, term: Term) =
     new LogEntry(index, event, term)
 }
 
-class LogEntry(val index: LogEntryIndex, val event: EntityEvent, val term: Term) extends Serializable {
+private[entityreplication] class LogEntry(val index: LogEntryIndex, val event: EntityEvent, val term: Term)
+    extends Serializable {
   require(index > LogEntryIndex.initial())
 
   def canEqual(other: Any): Boolean = other.isInstanceOf[LogEntry]

--- a/src/main/scala/lerna/akka/entityreplication/raft/model/LogEntryIndex.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/model/LogEntryIndex.scala
@@ -2,7 +2,7 @@ package lerna.akka.entityreplication.raft.model
 
 import lerna.akka.entityreplication.raft.model.exception.SeqIndexOutOfBoundsException
 
-object LogEntryIndex {
+private[entityreplication] object LogEntryIndex {
 
   def initial(): LogEntryIndex = LogEntryIndex(0)
 
@@ -11,7 +11,8 @@ object LogEntryIndex {
   }
 }
 
-case class LogEntryIndex(private[entityreplication] val underlying: Long) extends Ordered[LogEntryIndex] {
+private[entityreplication] final case class LogEntryIndex(private[entityreplication] val underlying: Long)
+    extends Ordered[LogEntryIndex] {
   require(underlying >= 0)
 
   def next(): LogEntryIndex = copy(underlying + 1)

--- a/src/main/scala/lerna/akka/entityreplication/raft/model/MatchIndex.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/model/MatchIndex.scala
@@ -2,7 +2,7 @@ package lerna.akka.entityreplication.raft.model
 
 import lerna.akka.entityreplication.raft.routing.MemberIndex
 
-case class MatchIndex(indexes: Map[MemberIndex, LogEntryIndex] = Map()) {
+private[entityreplication] final case class MatchIndex(indexes: Map[MemberIndex, LogEntryIndex] = Map()) {
 
   def update(follower: MemberIndex, index: LogEntryIndex): MatchIndex = {
     copy(indexes + (follower -> index))

--- a/src/main/scala/lerna/akka/entityreplication/raft/model/NextIndex.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/model/NextIndex.scala
@@ -2,7 +2,10 @@ package lerna.akka.entityreplication.raft.model
 
 import lerna.akka.entityreplication.raft.routing.MemberIndex
 
-case class NextIndex(leaderLog: ReplicatedLog, indexes: Map[MemberIndex, LogEntryIndex] = Map()) {
+private[entityreplication] final case class NextIndex(
+    leaderLog: ReplicatedLog,
+    indexes: Map[MemberIndex, LogEntryIndex] = Map(),
+) {
 
   val initialLogIndex: LogEntryIndex = leaderLog.lastOption.map(_.index).getOrElse(LogEntryIndex.initial()).next()
 

--- a/src/main/scala/lerna/akka/entityreplication/raft/model/NoOp.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/model/NoOp.scala
@@ -2,4 +2,4 @@ package lerna.akka.entityreplication.raft.model
 
 import lerna.akka.entityreplication.ClusterReplicationSerializable
 
-case object NoOp extends ClusterReplicationSerializable
+private[entityreplication] case object NoOp extends ClusterReplicationSerializable

--- a/src/main/scala/lerna/akka/entityreplication/raft/model/RaftMember.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/model/RaftMember.scala
@@ -2,7 +2,7 @@ package lerna.akka.entityreplication.raft.model
 
 import akka.actor.{ ActorPath, ActorSelection }
 
-case class RaftMember(path: ActorPath, selection: ActorSelection) {
+private[entityreplication] final case class RaftMember(path: ActorPath, selection: ActorSelection) {
 
   override def toString: String = s"RaftMember(${path.toString})"
 }

--- a/src/main/scala/lerna/akka/entityreplication/raft/model/ReplicatedLog.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/model/ReplicatedLog.scala
@@ -1,13 +1,13 @@
 package lerna.akka.entityreplication.raft.model
 
-object ReplicatedLog {
+private[entityreplication] object ReplicatedLog {
 
   def apply(): ReplicatedLog = ReplicatedLog(Seq.empty)
 
   private def apply(entries: Seq[LogEntry]) = new ReplicatedLog(entries)
 }
 
-case class ReplicatedLog private[model] (
+private[entityreplication] final case class ReplicatedLog private[model] (
     entries: Seq[LogEntry],
     ancestorLastTerm: Term = Term.initial(),
     ancestorLastIndex: LogEntryIndex = LogEntryIndex.initial(),

--- a/src/main/scala/lerna/akka/entityreplication/raft/model/SnapshotStatus.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/model/SnapshotStatus.scala
@@ -1,7 +1,7 @@
 package lerna.akka.entityreplication.raft.model
 
-object SnapshotStatus {
+private[entityreplication] object SnapshotStatus {
   def empty: SnapshotStatus = SnapshotStatus(Term.initial(), LogEntryIndex.initial())
 }
 
-final case class SnapshotStatus(snapshotLastTerm: Term, snapshotLastLogIndex: LogEntryIndex)
+private[entityreplication] final case class SnapshotStatus(snapshotLastTerm: Term, snapshotLastLogIndex: LogEntryIndex)

--- a/src/main/scala/lerna/akka/entityreplication/raft/model/SnapshottingProgress.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/model/SnapshottingProgress.scala
@@ -2,7 +2,7 @@ package lerna.akka.entityreplication.raft.model
 
 import lerna.akka.entityreplication.model.NormalizedEntityId
 
-object SnapshottingProgress {
+private[entityreplication] object SnapshottingProgress {
   def empty: SnapshottingProgress =
     SnapshottingProgress(
       snapshotLastLogTerm = Term.initial(),
@@ -12,7 +12,7 @@ object SnapshottingProgress {
     )
 }
 
-case class SnapshottingProgress(
+private[entityreplication] final case class SnapshottingProgress(
     snapshotLastLogTerm: Term,
     snapshotLastLogIndex: LogEntryIndex,
     inProgressEntities: Set[NormalizedEntityId],

--- a/src/main/scala/lerna/akka/entityreplication/raft/model/Term.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/model/Term.scala
@@ -1,10 +1,10 @@
 package lerna.akka.entityreplication.raft.model
 
-object Term {
+private[entityreplication] object Term {
   def initial() = new Term(0)
 }
 
-case class Term(term: Long) extends Ordered[Term] {
+private[entityreplication] final case class Term(term: Long) extends Ordered[Term] {
   def next(): Term                      = this.copy(term = term + 1)
   def isOlderThan(other: Term): Boolean = this.term < other.term
   def isNewerThan(other: Term): Boolean = this.term > other.term

--- a/src/main/scala/lerna/akka/entityreplication/raft/model/exception/SeqIndexOutOfBoundsException.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/model/exception/SeqIndexOutOfBoundsException.scala
@@ -2,5 +2,5 @@ package lerna.akka.entityreplication.raft.model.exception
 
 import lerna.akka.entityreplication.raft.model.LogEntryIndex
 
-final case class SeqIndexOutOfBoundsException(self: LogEntryIndex, offset: LogEntryIndex)
+private[entityreplication] final case class SeqIndexOutOfBoundsException(self: LogEntryIndex, offset: LogEntryIndex)
     extends RuntimeException(s"The Seq index of $self from $offset is out of bounds")

--- a/src/main/scala/lerna/akka/entityreplication/raft/persistence/CompactionCompletedTag.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/persistence/CompactionCompletedTag.scala
@@ -3,7 +3,10 @@ package lerna.akka.entityreplication.raft.persistence
 import lerna.akka.entityreplication.model.NormalizedShardId
 import lerna.akka.entityreplication.raft.routing.MemberIndex
 
-final case class CompactionCompletedTag(memberIndex: MemberIndex, shardId: NormalizedShardId) {
+private[entityreplication] final case class CompactionCompletedTag(
+    memberIndex: MemberIndex,
+    shardId: NormalizedShardId,
+) {
   private[this] val delimiter = ":"
 
   override def toString: String = s"CompactionCompleted${delimiter}${shardId.underlying}${delimiter}${memberIndex.role}"

--- a/src/main/scala/lerna/akka/entityreplication/raft/persistence/RaftEventAdapter.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/persistence/RaftEventAdapter.scala
@@ -3,7 +3,7 @@ package lerna.akka.entityreplication.raft.persistence
 import akka.persistence.journal.{ EventAdapter, EventSeq, Tagged }
 import lerna.akka.entityreplication.raft.RaftActor.CompactionCompleted
 
-class RaftEventAdapter extends EventAdapter {
+private[entityreplication] class RaftEventAdapter extends EventAdapter {
 
   override def manifest(event: Any): String = "" // No need
 

--- a/src/main/scala/lerna/akka/entityreplication/raft/protocol/RaftCommands.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/protocol/RaftCommands.scala
@@ -5,7 +5,7 @@ import lerna.akka.entityreplication.model.NormalizedShardId
 import lerna.akka.entityreplication.raft.model._
 import lerna.akka.entityreplication.raft.routing.MemberIndex
 
-object RaftCommands {
+private[entityreplication] object RaftCommands {
 
   sealed trait RaftRequest extends ShardRequest {
     def term: Term
@@ -15,7 +15,7 @@ object RaftCommands {
     def term: Term
   }
 
-  case class RequestVote(
+  final case class RequestVote(
       shardId: NormalizedShardId,
       term: Term,
       candidate: MemberIndex,
@@ -26,13 +26,13 @@ object RaftCommands {
 
   sealed trait RequestVoteResponse extends RaftResponse
 
-  case class RequestVoteAccepted(term: Term, sender: MemberIndex)
+  final case class RequestVoteAccepted(term: Term, sender: MemberIndex)
       extends RequestVoteResponse
       with ClusterReplicationSerializable
 
-  case class RequestVoteDenied(term: Term) extends RequestVoteResponse with ClusterReplicationSerializable
+  final case class RequestVoteDenied(term: Term) extends RequestVoteResponse with ClusterReplicationSerializable
 
-  case class AppendEntries(
+  final case class AppendEntries(
       shardId: NormalizedShardId,
       term: Term,
       leader: MemberIndex,
@@ -45,11 +45,11 @@ object RaftCommands {
 
   sealed trait AppendEntriesResponse extends RaftResponse
 
-  case class AppendEntriesSucceeded(term: Term, lastLogIndex: LogEntryIndex, sender: MemberIndex)
+  final case class AppendEntriesSucceeded(term: Term, lastLogIndex: LogEntryIndex, sender: MemberIndex)
       extends AppendEntriesResponse
       with ClusterReplicationSerializable
 
-  case class AppendEntriesFailed(term: Term, sender: MemberIndex)
+  final case class AppendEntriesFailed(term: Term, sender: MemberIndex)
       extends AppendEntriesResponse
       with ClusterReplicationSerializable
 

--- a/src/main/scala/lerna/akka/entityreplication/raft/protocol/ShardRequest.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/protocol/ShardRequest.scala
@@ -2,6 +2,6 @@ package lerna.akka.entityreplication.raft.protocol
 
 import lerna.akka.entityreplication.model.NormalizedShardId
 
-trait ShardRequest {
+private[entityreplication] trait ShardRequest {
   def shardId: NormalizedShardId
 }

--- a/src/main/scala/lerna/akka/entityreplication/raft/protocol/SuspendEntity.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/protocol/SuspendEntity.scala
@@ -3,6 +3,9 @@ package lerna.akka.entityreplication.raft.protocol
 import lerna.akka.entityreplication.ClusterReplicationSerializable
 import lerna.akka.entityreplication.model.{ NormalizedEntityId, NormalizedShardId }
 
-final case class SuspendEntity(shardId: NormalizedShardId, entityId: NormalizedEntityId, stopMessage: Any)
-    extends ShardRequest
+private[entityreplication] final case class SuspendEntity(
+    shardId: NormalizedShardId,
+    entityId: NormalizedEntityId,
+    stopMessage: Any,
+) extends ShardRequest
     with ClusterReplicationSerializable

--- a/src/main/scala/lerna/akka/entityreplication/raft/protocol/TryCreateEntity.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/protocol/TryCreateEntity.scala
@@ -3,6 +3,6 @@ package lerna.akka.entityreplication.raft.protocol
 import lerna.akka.entityreplication.ClusterReplicationSerializable
 import lerna.akka.entityreplication.model.{ NormalizedEntityId, NormalizedShardId }
 
-final case class TryCreateEntity(shardId: NormalizedShardId, entityId: NormalizedEntityId)
+private[entityreplication] final case class TryCreateEntity(shardId: NormalizedShardId, entityId: NormalizedEntityId)
     extends ShardRequest
     with ClusterReplicationSerializable

--- a/src/main/scala/lerna/akka/entityreplication/raft/routing/MemberIndex.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/routing/MemberIndex.scala
@@ -2,11 +2,11 @@ package lerna.akka.entityreplication.raft.routing
 
 import java.net.URLEncoder
 
-object MemberIndex {
+private[entityreplication] object MemberIndex {
   def apply(role: String): MemberIndex                                              = new MemberIndex(URLEncoder.encode(role, "utf-8"))
   private[entityreplication] def fromEncodedValue(encodedRole: String): MemberIndex = new MemberIndex(encodedRole)
 }
 
-final case class MemberIndex private (role: String) {
+private[entityreplication] final case class MemberIndex private (role: String) {
   override def toString: String = role
 }

--- a/src/main/scala/lerna/akka/entityreplication/raft/snapshot/ShardSnapshotStore.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/snapshot/ShardSnapshotStore.scala
@@ -5,15 +5,18 @@ import lerna.akka.entityreplication.model.{ NormalizedEntityId, TypeName }
 import lerna.akka.entityreplication.raft.RaftSettings
 import lerna.akka.entityreplication.raft.routing.MemberIndex
 
-object ShardSnapshotStore {
+private[entityreplication] object ShardSnapshotStore {
 
   def props(typeName: TypeName, settings: RaftSettings, selfMemberIndex: MemberIndex): Props =
     Props(new ShardSnapshotStore(typeName, settings, selfMemberIndex))
 
 }
 
-class ShardSnapshotStore(typeName: TypeName, settings: RaftSettings, selfMemberIndex: MemberIndex)
-    extends Actor
+private[entityreplication] class ShardSnapshotStore(
+    typeName: TypeName,
+    settings: RaftSettings,
+    selfMemberIndex: MemberIndex,
+) extends Actor
     with ActorLogging {
   import SnapshotProtocol._
 

--- a/src/main/scala/lerna/akka/entityreplication/raft/snapshot/SnapshotProtocol.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/snapshot/SnapshotProtocol.scala
@@ -5,7 +5,7 @@ import lerna.akka.entityreplication.ClusterReplicationSerializable
 import lerna.akka.entityreplication.model.NormalizedEntityId
 import lerna.akka.entityreplication.raft.model.LogEntryIndex
 
-object SnapshotProtocol {
+private[entityreplication] object SnapshotProtocol {
 
   sealed trait Command {
     def entityId: NormalizedEntityId

--- a/src/main/scala/lerna/akka/entityreplication/raft/snapshot/SnapshotStore.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/snapshot/SnapshotStore.scala
@@ -8,7 +8,7 @@ import lerna.akka.entityreplication.raft.RaftSettings
 import lerna.akka.entityreplication.raft.routing.MemberIndex
 import lerna.akka.entityreplication.util.ActorIds
 
-object SnapshotStore {
+private[entityreplication] object SnapshotStore {
 
   def props(
       typeName: TypeName,
@@ -19,7 +19,7 @@ object SnapshotStore {
     Props(new SnapshotStore(typeName, entityId, settings, selfMemberIndex))
 }
 
-class SnapshotStore(
+private[entityreplication] class SnapshotStore(
     typeName: TypeName,
     entityId: NormalizedEntityId,
     settings: RaftSettings,

--- a/src/main/scala/lerna/akka/entityreplication/raft/snapshot/sync/SnapshotSyncManager.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/snapshot/sync/SnapshotSyncManager.scala
@@ -22,7 +22,7 @@ import lerna.akka.entityreplication.util.ActorIds
 
 import scala.concurrent.Future
 
-object SnapshotSyncManager {
+private[entityreplication] object SnapshotSyncManager {
 
   def props(
       typeName: TypeName,
@@ -119,7 +119,7 @@ object SnapshotSyncManager {
       with SyncFailures
 }
 
-class SnapshotSyncManager(
+private[entityreplication] class SnapshotSyncManager(
     typeName: TypeName,
     srcMemberIndex: MemberIndex,
     dstMemberIndex: MemberIndex,

--- a/src/main/scala/lerna/akka/entityreplication/util/ActorIds.scala
+++ b/src/main/scala/lerna/akka/entityreplication/util/ActorIds.scala
@@ -1,6 +1,6 @@
 package lerna.akka.entityreplication.util
 
-object ActorIds {
+private[entityreplication] object ActorIds {
 
   private[this] val delimiter = ":"
 


### PR DESCRIPTION
issue: #45 

The following APIs should keep public (reference: [akka-entity-replication/implementation_guide.md](https://github.com/lerna-stack/akka-entity-replication/blob/v1.0.0/docs/implementation_guide.md))

- ReplicationRegion
  - ExtractEntityId
  - ExtractShardId
  - Passivate
- ReplicationActor
- ClusterReplicationSettings
- ClusterReplication
- AtLeastOnceComplete

⚠️ **This change is not treated as destructive change, assuming no implementations not mentioned in the implementation guide**

## TODO

- [x] implementation
- [x] verification
   - run the demo of https://github.com/lerna-stack/nablarch-fw-batch-parallelizable-example using SNAPSHOT which was published locally
- [x] write CHANGELOG 