### PR TITLE
👷chore: Enable CI on feature branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, feature/** ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, feature/** ]
 
 env:
   SBT_OPTS: -Dlerna.enable.discipline


### PR DESCRIPTION
We use "feature branches" that named `feature/*` for implementing large features.