### PR TITLE
[Typed] Refactor RaftProtocol

### DIFF
--- a/src/main/mima-filters/1.0.0.backwards.excludes/pr-62-arrange-internal-raft-protocol.excludes
+++ b/src/main/mima-filters/1.0.0.backwards.excludes/pr-62-arrange-internal-raft-protocol.excludes
@@ -1,0 +1,33 @@
+#  We might be able to remove this filter after release mima v0.9.0:
+# 
+#      Allow ignoring package private classes · Issue #53 · lightbend/mima
+#      https://github.com/lightbend/mima/issues/53
+# 
+#  Following classes and objects are in package private object
+# 
+# object lerna.akka.entityreplication.ReplicationActor#EntityRecoveryTimeoutException does not have a correspondent in current version
+ProblemFilters.exclude[MissingClassProblem]("lerna.akka.entityreplication.ReplicationActor$EntityRecoveryTimeoutException$")
+# class lerna.akka.entityreplication.ReplicationActor#Snapshot does not have a correspondent in current version
+ProblemFilters.exclude[MissingClassProblem]("lerna.akka.entityreplication.ReplicationActor$Snapshot")
+# object lerna.akka.entityreplication.ReplicationActor#TakeSnapshot does not have a correspondent in current version
+ProblemFilters.exclude[MissingClassProblem]("lerna.akka.entityreplication.ReplicationActor$TakeSnapshot$")
+# class lerna.akka.entityreplication.ReplicationActor#EntityRecoveryTimeoutException does not have a correspondent in current version
+ProblemFilters.exclude[MissingClassProblem]("lerna.akka.entityreplication.ReplicationActor$EntityRecoveryTimeoutException")
+# object lerna.akka.entityreplication.ReplicationActor#RecoveryTimeout does not have a correspondent in current version
+ProblemFilters.exclude[MissingClassProblem]("lerna.akka.entityreplication.ReplicationActor$RecoveryTimeout$")
+# object lerna.akka.entityreplication.ReplicationActor#Snapshot does not have a correspondent in current version
+ProblemFilters.exclude[MissingClassProblem]("lerna.akka.entityreplication.ReplicationActor$Snapshot$")
+# class lerna.akka.entityreplication.ReplicationActor#TakeSnapshot does not have a correspondent in current version
+ProblemFilters.exclude[MissingClassProblem]("lerna.akka.entityreplication.ReplicationActor$TakeSnapshot")
+# method receiveEntitySnapshotResponse(lerna.akka.entityreplication.ReplicationActor#Snapshot)Unit in class lerna.akka.entityreplication.raft.RaftActor's type is different in current version, where it is (lerna.akka.entityreplication.raft.RaftProtocol#Snapshot)Unit instead of (lerna.akka.entityreplication.ReplicationActor#Snapshot)Unit
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("lerna.akka.entityreplication.raft.RaftActor.receiveEntitySnapshotResponse")
+# class lerna.akka.entityreplication.raft.RaftProtocol#ReplicationSucceeded is declared final in current version
+ProblemFilters.exclude[FinalClassProblem]("lerna.akka.entityreplication.raft.RaftProtocol$ReplicationSucceeded")
+# class lerna.akka.entityreplication.raft.RaftProtocol#Command is declared final in current version
+ProblemFilters.exclude[FinalClassProblem]("lerna.akka.entityreplication.raft.RaftProtocol$Command")
+# class lerna.akka.entityreplication.raft.RaftProtocol#Replicate is declared final in current version
+ProblemFilters.exclude[FinalClassProblem]("lerna.akka.entityreplication.raft.RaftProtocol$Replicate")
+# class lerna.akka.entityreplication.raft.RaftProtocol#ForwardedCommand is declared final in current version
+ProblemFilters.exclude[FinalClassProblem]("lerna.akka.entityreplication.raft.RaftProtocol$ForwardedCommand")
+# class lerna.akka.entityreplication.raft.RaftProtocol#Replica is declared final in current version
+ProblemFilters.exclude[FinalClassProblem]("lerna.akka.entityreplication.raft.RaftProtocol$Replica")

--- a/src/main/scala/lerna/akka/entityreplication/ReplicationActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/ReplicationActor.scala
@@ -83,7 +83,7 @@ trait ReplicationActor[StateData] extends Actor with Stash with akka.lerna.Stash
 
     override def stateReceive(receive: Receive, message: Any): Unit =
       message match {
-        case Command(command) =>
+        case ProcessCommand(command) =>
           receive.applyOrElse[Any, Unit](
             command,
             command => {

--- a/src/main/scala/lerna/akka/entityreplication/ReplicationActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/ReplicationActor.scala
@@ -2,7 +2,7 @@ package lerna.akka.entityreplication
 
 import java.util.concurrent.atomic.AtomicInteger
 
-import akka.actor.{ Actor, ActorPath, ActorRef, Cancellable, Stash }
+import akka.actor.{ Actor, Cancellable, Stash }
 import akka.event.Logging
 import lerna.akka.entityreplication.model.{ EntityInstanceId, NormalizedEntityId }
 import lerna.akka.entityreplication.raft.RaftProtocol._
@@ -15,18 +15,9 @@ private[entityreplication] object ReplicationActor {
   private[this] val instanceIdCounter = new AtomicInteger(1)
 
   private def generateInstanceId(): EntityInstanceId = EntityInstanceId(instanceIdCounter.getAndIncrement())
-
-  private[entityreplication] final case class TakeSnapshot(metadata: EntitySnapshotMetadata, replyTo: ActorRef)
-  private[entityreplication] final case class Snapshot(metadata: EntitySnapshotMetadata, state: EntityState)
-
-  private final case object RecoveryTimeout
-
-  private[entityreplication] final case class EntityRecoveryTimeoutException(entityPath: ActorPath)
-      extends RuntimeException
 }
 
 trait ReplicationActor[StateData] extends Actor with Stash with akka.lerna.StashFactory {
-  import ReplicationActor._
   import context.dispatcher
 
   private val internalStash = createStash()

--- a/src/main/scala/lerna/akka/entityreplication/raft/Candidate.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/Candidate.scala
@@ -1,6 +1,5 @@
 package lerna.akka.entityreplication.raft
 
-import lerna.akka.entityreplication.ReplicationActor
 import lerna.akka.entityreplication.raft.RaftProtocol._
 import lerna.akka.entityreplication.raft.protocol.RaftCommands._
 import lerna.akka.entityreplication.raft.protocol.{ SuspendEntity, TryCreateEntity }
@@ -42,7 +41,7 @@ private[raft] trait Candidate { this: RaftActor =>
     case response: SnapshotProtocol.FetchSnapshotResponse => receiveFetchSnapshotResponse(response)
     case SuspendEntity(_, entityId, stopMessage)          => suspendEntity(entityId, stopMessage)
     case SnapshotTick                                     => handleSnapshotTick()
-    case response: ReplicationActor.Snapshot              => receiveEntitySnapshotResponse(response)
+    case response: Snapshot                               => receiveEntitySnapshotResponse(response)
     case response: SnapshotProtocol.SaveSnapshotResponse  => receiveSaveSnapshotResponse(response)
     case _: akka.persistence.SaveSnapshotSuccess          => // ignore
     case _: akka.persistence.SaveSnapshotFailure          => // ignore: no problem because events exist even if snapshot saving failed

--- a/src/main/scala/lerna/akka/entityreplication/raft/Follower.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/Follower.scala
@@ -5,7 +5,7 @@ import lerna.akka.entityreplication.raft.protocol.RaftCommands._
 import lerna.akka.entityreplication.raft.protocol.{ SuspendEntity, TryCreateEntity }
 import lerna.akka.entityreplication.raft.snapshot.SnapshotProtocol
 import lerna.akka.entityreplication.raft.snapshot.sync.SnapshotSyncManager
-import lerna.akka.entityreplication.{ ReplicationActor, ReplicationRegion }
+import lerna.akka.entityreplication.ReplicationRegion
 
 private[raft] trait Follower { this: RaftActor =>
   import RaftActor._
@@ -32,7 +32,7 @@ private[raft] trait Follower { this: RaftActor =>
     case response: SnapshotProtocol.FetchSnapshotResponse => receiveFetchSnapshotResponse(response)
     case SuspendEntity(_, entityId, stopMessage)          => suspendEntity(entityId, stopMessage)
     case SnapshotTick                                     => handleSnapshotTick()
-    case response: ReplicationActor.Snapshot              => receiveEntitySnapshotResponse(response)
+    case response: Snapshot                               => receiveEntitySnapshotResponse(response)
     case response: SnapshotProtocol.SaveSnapshotResponse  => receiveSaveSnapshotResponse(response)
     case _: akka.persistence.SaveSnapshotSuccess          => // ignore
     case _: akka.persistence.SaveSnapshotFailure          => // ignore: no problem because events exist even if snapshot saving failed

--- a/src/main/scala/lerna/akka/entityreplication/raft/Leader.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/Leader.scala
@@ -8,7 +8,7 @@ import lerna.akka.entityreplication.raft.protocol.RaftCommands._
 import lerna.akka.entityreplication.raft.protocol.{ SuspendEntity, TryCreateEntity }
 import lerna.akka.entityreplication.raft.snapshot.SnapshotProtocol
 import lerna.akka.entityreplication.raft.snapshot.sync.SnapshotSyncManager
-import lerna.akka.entityreplication.{ ReplicationActor, ReplicationRegion }
+import lerna.akka.entityreplication.ReplicationRegion
 
 private[raft] trait Leader { this: RaftActor =>
   import RaftActor._
@@ -35,7 +35,7 @@ private[raft] trait Leader { this: RaftActor =>
     case response: SnapshotProtocol.FetchSnapshotResponse     => receiveFetchSnapshotResponse(response)
     case SuspendEntity(_, entityId, stopMessage)              => suspendEntity(entityId, stopMessage)
     case SnapshotTick                                         => handleSnapshotTick()
-    case response: ReplicationActor.Snapshot                  => receiveEntitySnapshotResponse(response)
+    case response: Snapshot                                   => receiveEntitySnapshotResponse(response)
     case response: SnapshotProtocol.SaveSnapshotResponse      => receiveSaveSnapshotResponse(response)
     case _: akka.persistence.SaveSnapshotSuccess              => // ignore
     case _: akka.persistence.SaveSnapshotFailure              => // ignore: no problem because events exist even if snapshot saving failed

--- a/src/main/scala/lerna/akka/entityreplication/raft/Leader.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/Leader.scala
@@ -177,7 +177,7 @@ private[raft] trait Leader { this: RaftActor =>
         if (currentData.currentTermIsCommitted) {
           val (entityId, cmd) = extractEntityId(message)
           broadcast(TryCreateEntity(shardId, entityId))
-          replicationActor(entityId) forward Command(cmd)
+          replicationActor(entityId) forward ProcessCommand(cmd)
         } else {
           // The commands will be released after initial NoOp event was committed
           stash()

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
@@ -3,7 +3,6 @@ package lerna.akka.entityreplication.raft
 import akka.actor.{ ActorRef, Cancellable, Props, Stash }
 import akka.persistence.RuntimePluginConfig
 import com.typesafe.config.{ Config, ConfigFactory }
-import lerna.akka.entityreplication.ReplicationActor.Snapshot
 import lerna.akka.entityreplication.ReplicationRegion.Msg
 import lerna.akka.entityreplication.model.{ NormalizedEntityId, NormalizedShardId, TypeName }
 import lerna.akka.entityreplication.raft.RaftProtocol.{ Replicate, _ }
@@ -15,7 +14,7 @@ import lerna.akka.entityreplication.raft.snapshot.SnapshotProtocol
 import lerna.akka.entityreplication.raft.snapshot.SnapshotProtocol.EntitySnapshotMetadata
 import lerna.akka.entityreplication.raft.snapshot.sync.SnapshotSyncManager
 import lerna.akka.entityreplication.util.ActorIds
-import lerna.akka.entityreplication.{ ClusterReplicationSerializable, ReplicationActor, ReplicationRegion }
+import lerna.akka.entityreplication.{ ClusterReplicationSerializable, ReplicationRegion }
 
 private[entityreplication] object RaftActor {
 
@@ -397,7 +396,7 @@ private[raft] class RaftActor(
   def requestTakeSnapshots(logEntryIndex: LogEntryIndex, entityIds: Set[NormalizedEntityId]): Unit = {
     entityIds.foreach { entityId =>
       val metadata = EntitySnapshotMetadata(entityId, logEntryIndex)
-      replicationActor(entityId) ! ReplicationActor.TakeSnapshot(metadata, self)
+      replicationActor(entityId) ! TakeSnapshot(metadata, self)
     }
   }
 

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftProtocol.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftProtocol.scala
@@ -1,10 +1,14 @@
 package lerna.akka.entityreplication.raft
 
-import akka.actor.ActorRef
+import akka.actor.{ ActorPath, ActorRef }
 import lerna.akka.entityreplication.ClusterReplicationSerializable
 import lerna.akka.entityreplication.model.{ EntityInstanceId, NormalizedEntityId }
 import lerna.akka.entityreplication.raft.model.{ LogEntry, LogEntryIndex }
-import lerna.akka.entityreplication.raft.snapshot.SnapshotProtocol.EntitySnapshot
+import lerna.akka.entityreplication.raft.snapshot.SnapshotProtocol.{
+  EntitySnapshot,
+  EntitySnapshotMetadata,
+  EntityState,
+}
 
 private[entityreplication] object RaftProtocol {
 
@@ -43,4 +47,11 @@ private[entityreplication] object RaftProtocol {
 
   case class ReplicationSucceeded(event: Any, logEntryIndex: LogEntryIndex, instanceId: Option[EntityInstanceId])
       extends ReplicationResponse
+
+  final case class TakeSnapshot(metadata: EntitySnapshotMetadata, replyTo: ActorRef)
+  final case class Snapshot(metadata: EntitySnapshotMetadata, state: EntityState)
+
+  final case object RecoveryTimeout
+
+  final case class EntityRecoveryTimeoutException(entityPath: ActorPath) extends RuntimeException
 }

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftProtocol.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftProtocol.scala
@@ -18,9 +18,9 @@ private[entityreplication] object RaftProtocol {
   final case class RequestRecovery(entityId: NormalizedEntityId)                          extends RaftActorCommand
   final case class RecoveryState(events: Seq[LogEntry], snapshot: Option[EntitySnapshot]) extends EntityCommand
 
-  case class Command(command: Any)              extends ClusterReplicationSerializable with RaftActorCommand with EntityCommand
-  case class ForwardedCommand(command: Command) extends ClusterReplicationSerializable with RaftActorCommand
-  case class Replica(logEntry: LogEntry)        extends EntityCommand
+  final case class Command(command: Any)              extends ClusterReplicationSerializable with RaftActorCommand with EntityCommand
+  final case class ForwardedCommand(command: Command) extends ClusterReplicationSerializable with RaftActorCommand
+  final case class Replica(logEntry: LogEntry)        extends EntityCommand
 
   object Replicate {
     def apply(
@@ -38,7 +38,7 @@ private[entityreplication] object RaftProtocol {
     }
   }
 
-  case class Replicate(
+  final case class Replicate(
       event: Any,
       replyTo: ActorRef,
       entityId: Option[NormalizedEntityId],
@@ -48,7 +48,7 @@ private[entityreplication] object RaftProtocol {
 
   sealed trait ReplicationResponse
 
-  case class ReplicationSucceeded(event: Any, logEntryIndex: LogEntryIndex, instanceId: Option[EntityInstanceId])
+  final case class ReplicationSucceeded(event: Any, logEntryIndex: LogEntryIndex, instanceId: Option[EntityInstanceId])
       extends ReplicationResponse
       with EntityCommand
 

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftProtocol.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftProtocol.scala
@@ -18,7 +18,8 @@ private[entityreplication] object RaftProtocol {
   final case class RequestRecovery(entityId: NormalizedEntityId)                          extends RaftActorCommand
   final case class RecoveryState(events: Seq[LogEntry], snapshot: Option[EntitySnapshot]) extends EntityCommand
 
-  final case class Command(command: Any)              extends ClusterReplicationSerializable with RaftActorCommand with EntityCommand
+  final case class ProcessCommand(command: Any)       extends EntityCommand
+  final case class Command(command: Any)              extends ClusterReplicationSerializable with RaftActorCommand
   final case class ForwardedCommand(command: Command) extends ClusterReplicationSerializable with RaftActorCommand
   final case class Replica(logEntry: LogEntry)        extends EntityCommand
 

--- a/src/main/scala/lerna/akka/entityreplication/testkit/TestReplicationActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/testkit/TestReplicationActor.scala
@@ -27,6 +27,6 @@ protected[testkit] class TestReplicationActor(replicationActorProps: Props) exte
     case Terminated(`replicationActor`) =>
       context.stop(self)
     case message =>
-      replicationActor forward Command(message)
+      replicationActor forward ProcessCommand(message)
   }
 }

--- a/src/test/scala/lerna/akka/entityreplication/ReplicationActorSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/ReplicationActorSpec.scala
@@ -148,7 +148,7 @@ class ReplicationActorSpec extends TestKit(ActorSystem("ReplicationActorSpec", c
       }
       // Do not send RecoveryState to replicationActor
       raftActorProbe.expectMsgType[RequestRecovery]
-      testProbe.expectMsgType[ReplicationActor.EntityRecoveryTimeoutException]
+      testProbe.expectMsgType[EntityRecoveryTimeoutException]
       raftActorProbe.expectMsgType[RequestRecovery]
     }
   }

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorCandidateSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorCandidateSpec.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import akka.testkit.{ TestKit, TestProbe }
 import lerna.akka.entityreplication.ReplicationRegion
 import lerna.akka.entityreplication.model.{ NormalizedEntityId, NormalizedShardId }
-import lerna.akka.entityreplication.raft.RaftProtocol.{ Command, ForwardedCommand }
+import lerna.akka.entityreplication.raft.RaftProtocol.{ Command, ForwardedCommand, ProcessCommand }
 import lerna.akka.entityreplication.raft.model._
 import lerna.akka.entityreplication.raft.protocol.RaftCommands._
 import lerna.akka.entityreplication.raft.routing.MemberIndex
@@ -223,7 +223,7 @@ class RaftActorCandidateSpec extends TestKit(ActorSystem()) with RaftActorSpecBa
       leader ! AppendEntriesSucceeded(term, lastLogIndex, follower2MemberIndex)
 
       // the leader forwards the command to ReplicationActor
-      replicationActor.expectMsg(Command(SomeCommand))
+      replicationActor.expectMsg(ProcessCommand(SomeCommand))
     }
 
     "AppendEntries の prevLogIndex/prevLogTerm に一致するログエントリがある場合は AppendEntriesSucceeded" in {

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorSpec.scala
@@ -3,7 +3,7 @@ package lerna.akka.entityreplication.raft
 import akka.actor.ActorSystem
 import akka.testkit.{ TestKit, TestProbe }
 import com.typesafe.config.ConfigFactory
-import lerna.akka.entityreplication.ReplicationActor.{ Snapshot, TakeSnapshot }
+import lerna.akka.entityreplication.raft.RaftProtocol._
 import lerna.akka.entityreplication.model.NormalizedEntityId
 import lerna.akka.entityreplication.raft.model.{ EntityEvent, LogEntry, LogEntryIndex, Term }
 import lerna.akka.entityreplication.raft.snapshot.SnapshotProtocol._


### PR DESCRIPTION
related issue: #44 

Akka Typed API requires clarification of commands that actors can receive.

This PR arranges `ReplicationActor` commands mainly.