### PR TITLE
[Typed] Improve AtLeastOnceComplete API

### DIFF
--- a/src/main/scala/lerna/akka/entityreplication/util/AtLeastOnceComplete.scala
+++ b/src/main/scala/lerna/akka/entityreplication/util/AtLeastOnceComplete.scala
@@ -4,7 +4,7 @@ import akka.actor.{ ActorRef, ActorSystem }
 import akka.actor.typed
 import akka.actor.typed.RecipientRef
 import akka.event.Logging
-import akka.pattern.ask
+import akka.pattern.{ ask, StatusReply }
 import akka.util.Timeout
 
 import scala.concurrent.duration.FiniteDuration
@@ -15,6 +15,12 @@ object AtLeastOnceComplete {
   def askTo[Message, Reply](
       destination: RecipientRef[Message],
       message: typed.ActorRef[Reply] => Message,
+      retryInterval: FiniteDuration,
+  )(implicit system: typed.ActorSystem[_], timeout: Timeout): Future[Reply] = ???
+
+  def askWithStatusTo[Message, Reply](
+      destination: RecipientRef[Message],
+      message: typed.ActorRef[StatusReply[Reply]] => Message,
       retryInterval: FiniteDuration,
   )(implicit system: typed.ActorSystem[_], timeout: Timeout): Future[Reply] = ???
 

--- a/src/main/scala/lerna/akka/entityreplication/util/AtLeastOnceComplete.scala
+++ b/src/main/scala/lerna/akka/entityreplication/util/AtLeastOnceComplete.scala
@@ -12,12 +12,27 @@ import scala.concurrent.{ Future, Promise }
 
 object AtLeastOnceComplete {
 
+  /**
+    * Asks the destination with retrying until timeout.
+    * The message will be sent multiple times for each retryInterval.
+    * It will stop when it receives the response from the destination.
+    * Note that the destination may be receive the same message even if it responds due to a delay in message arrival.
+    * The returned Future will be completed with an [[akka.pattern.AskTimeoutException]] after the given timeout has expired.
+    */
   def askTo[Message, Reply](
       destination: RecipientRef[Message],
       message: typed.ActorRef[Reply] => Message,
       retryInterval: FiniteDuration,
   )(implicit system: typed.ActorSystem[_], timeout: Timeout): Future[Reply] = ???
 
+  /**
+    * Asks the destination with retrying until timeout.
+    * The message will be sent multiple times for each retryInterval.
+    * It will stop when it receives the response from the destination.
+    * Note that the destination may be receive the same message even if it responds due to a delay in message arrival.
+    * The returned Future will be completed with an [[akka.pattern.AskTimeoutException]] after the given timeout has expired.
+    * The Future will also failed if a [[akka.pattern.StatusReply.Error]] arrives.
+    */
   def askWithStatusTo[Message, Reply](
       destination: RecipientRef[Message],
       message: typed.ActorRef[StatusReply[Reply]] => Message,

--- a/src/main/scala/lerna/akka/entityreplication/util/AtLeastOnceComplete.scala
+++ b/src/main/scala/lerna/akka/entityreplication/util/AtLeastOnceComplete.scala
@@ -2,10 +2,10 @@ package lerna.akka.entityreplication.util
 
 import akka.actor.{ ActorRef, ActorSystem }
 import akka.actor.typed
+import akka.actor.typed.RecipientRef
 import akka.event.Logging
 import akka.pattern.ask
 import akka.util.Timeout
-import lerna.akka.entityreplication.typed.ReplicatedEntityRef
 
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ Future, Promise }
@@ -13,7 +13,7 @@ import scala.concurrent.{ Future, Promise }
 object AtLeastOnceComplete {
 
   def askTo[Message, Reply](
-      destination: ReplicatedEntityRef[Message],
+      destination: RecipientRef[Message],
       message: typed.ActorRef[Reply] => Message,
       retryInterval: FiniteDuration,
   )(implicit system: typed.ActorSystem[_], timeout: Timeout): Future[Reply] = ???


### PR DESCRIPTION
related issue: #44 

`EntityRef` and `ActorRef` are both `RecipientRef`.

We will be able to write both following patterns.

```scala
val entityRef: ReplicatedEntityRef[Fizz] = ???
AtLeastOnceComplete.askTo(entityRef, Fizz(_), retryInterval = 100.millis)
```
```scala
val region: ActorRef[ReplicationEnvelope[Fizz]] = ???
AtLeastOnceComplete.askTo(region, ReplicationEnvelope(entityId = "buzz", Fizz(_)), retryInterval = 100.millis)
```