### PR TITLE
👷chore: Bump up mima version to 0.9.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,4 +12,4 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.3")
 
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.8.1")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.9.0")


### PR DESCRIPTION
We will be able to avoid false positives of binary compatibility check by the change bellow

> Ignore package private classes #53 / #583 by @dwijnand
>
> **[Release 0.9.0 · lightbend/mima](https://github.com/lightbend/mima/releases/tag/0.9.0)**

## Example

Changes a package-private method

```diff
diff --git a/src/main/scala/lerna/akka/entityreplication/raft/model/LogEntry.scala b/src/main/scala/lerna/akka/entityreplication/raft/model/LogEntry.scala
index f260c105..692560cd 100644
--- a/src/main/scala/lerna/akka/entityreplication/raft/model/LogEntry.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/model/LogEntry.scala
@@ -2,7 +2,7 @@ package lerna.akka.entityreplication.raft.model
 
 private[entityreplication] object LogEntry {
 
-  def apply(index: LogEntryIndex, event: EntityEvent, term: Term) =
+  def apply(index: LogEntryIndex, event: EntityEvent, term: Term, test: Option[String] = None) =
     new LogEntry(index, event, term)
 }
```

**mima 0.8.1** - binary compatibility check fails (false positive: users can't see this change)
```
[error] akka-entity-replication: Failed binary compatibility check against com.lerna-stack:akka-entity-replication_2.13:1.0.0! Found 2 potential problems (filtered 18)
[error]  * method apply(lerna.akka.entityreplication.raft.model.LogEntryIndex,lerna.akka.entityreplication.raft.model.EntityEvent,lerna.akka.entityreplication.raft.model.Term)lerna.akka.entityreplication.raft.model.LogEntry in object lerna.akka.entityreplication.raft.model.LogEntry does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.akka.entityreplication.raft.model.LogEntry.apply")
[error]  * static method apply(lerna.akka.entityreplication.raft.model.LogEntryIndex,lerna.akka.entityreplication.raft.model.EntityEvent,lerna.akka.entityreplication.raft.model.Term)lerna.akka.entityreplication.raft.model.LogEntry in class lerna.akka.entityreplication.raft.model.LogEntry does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.akka.entityreplication.raft.model.LogEntry.apply")
[error] java.lang.RuntimeException: Failed binary compatibility check against com.lerna-stack:akka-entity-replication_2.13:1.0.0! Found 2 potential problems (filtered 18)
  ...
[error] (mimaReportBinaryIssues) Failed binary compatibility check against com.lerna-stack:akka-entity-replication_2.13:1.0.0! Found 2 potential problems (filtered 18)
```
**mima 0.9.0** (This branch) - binary compatibility check succeeds
```
[info] set current project to akka-entity-replication (in build file:/C:/Users/..../workspace/lerna-stack/akka-entity-replication/)
[success] Total time: 3 s, completed 2021/05/06 15:41:50
```