### PR TITLE
✨feat: Distribute the shards to nodes fairly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 [Unreleased]: https://github.com/lerna-stack/akka-entity-replication/compare/.v1.0.0...master
 
+### Breaking Change
+
+- Change the shard-distribution-strategy to distribute shard (`RaftActor`) more evenly [PR#82](https://github.com/lerna-stack/akka-entity-replication/pull/82)
+
+  ⚠️ This change does not allow rolling updates. You have to update your system by stopping the whole cluster.
+
 ### Added
 - Java11 support
 - Add new typed API based on Akka Typed [PR#79](https://github.com/lerna-stack/akka-entity-replication/pull/79)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ To use this library, you must add a dependency into your sbt project, add the fo
 
 **Stable Release**
 
-[![Maven Central](https://img.shields.io/maven-central/v/com.lerna-stack/akka-entity-replication_2.13?color=%23005cb2&label=stable)](https://mvnrepository.com/artifact/com.lerna-stack/akka-entity-replication)
+[![Maven Central](https://img.shields.io/maven-central/v/com.lerna-stack/akka-entity-replication_2.13?color=%23005cb2&label=stable)](https://mvnrepository.com/artifact/com.lerna-stack/akka-entity-replication) 
+
+⚠️ `v2.0.0` will contain breaking changes. For more details see [CHANGELOG](./CHANGELOG.md).
 
 ```scala
 libraryDependencies += "com.lerna-stack" %% "akka-entity-replication" % "X.X.X"


### PR DESCRIPTION
RaftActor should be distributed to nodes fairly to distribute the load.

- This change allows to construct large size cluster more than 50 nodes per DC
- We can expect to distribute the load more evenly and reliable by using LeastShardAllocationStrategy 
of akka-cluster-sharding assertively instead of hash value distribution

Currently, `RaftActor`s are distributed with hash value as an entity of `cluster-sharding`. The entities can be distributed unevenly even if shards of `cluster-sharding` are distibured evenly by `LeastShardAllocationStrategy`.
By creating one entity (`RaftActor`) per one shard on `cluster-sharding`, `LeastShardAllocationStrategy` can manage distribution of `RaftActor` directly.