### PR TITLE
Test against Java 8 and Java 11 on the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         java: [ '8', '11' ]
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v2
       with:
@@ -51,7 +51,7 @@ jobs:
 
     - name: Run integration tests
       continue-on-error: true # results are reported by action-junit-report
-      run: sh ./scripts/run-multijvm-test.sh 3
+      run: sh ./scripts/run-multijvm-test.sh 6
 
     - name: Publish test report
       uses: mikepenz/action-junit-report@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,10 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
-
+    name: Test (Java ${{ matrix.java }})
+    strategy:
+      matrix:
+        java: [ '8', '11' ]
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v2
@@ -22,10 +25,11 @@ jobs:
         # https://github.com/dwijnand/sbt-dynver/tree/v4.1.1#previous-version-detection
         fetch-depth: 0
 
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v2
       with:
-        java-version: 1.8
+        distribution: 'zulu'
+        java-version: ${{ matrix.java }}
 
     # https://www.scala-sbt.org/1.x/docs/GitHub-Actions-with-sbt.html#Caching
     - name: Coursier cache
@@ -52,7 +56,7 @@ jobs:
     - name: Publish test report
       uses: mikepenz/action-junit-report@v2
       with:
-        check_name: ScalaTest Report
+        check_name: ScalaTest Report (Java ${{ matrix.java }})
         report_paths: 'target/**test-reports/TEST-*.xml'
         github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 [Unreleased]: https://github.com/lerna-stack/akka-entity-replication/compare/.v1.0.0...master
 
+### Added
+- Java11 support
+
 ### Removed
 
 - Made internal APIs private

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ libraryDependencies += "com.lerna-stack" %% "akka-entity-replication" % "X.X.X-S
 ```
 
 These versions of akka-entity-replication depends on **Akka 2.6.x**. It has been published for Scala 2.13.
+akka-entity-replication is tested with OpenJDK8 and OpenJDK11.
 
 **NOTE**: akka-entity-replication uses Akka's internal API.
 It is recommended that you use the same version of Akka as akka-entity-replication for your application to avoid compatibility issues.


### PR DESCRIPTION
Closes https://github.com/lerna-stack/akka-entity-replication/issues/89

I've upgraded setup-java to v2.
We can see the migration guide on the below link.
[setup-java/switching-to-v2.md at main · actions/setup-java](https://github.com/actions/setup-java/blob/main/docs/switching-to-v2.md)

We can run tests against different Java versions using `strategy.matrix`.
The following documents are helpful for us.
- [Testing against different Java versions | actions/setup-java: Set up your GitHub Actions workflow with a specific version of Java](https://github.com/actions/setup-java#testing-against-different-java-versions)
- [`jobs.<job_id>.strategy.matrix` | Workflow syntax for GitHub Actions - GitHub Docs](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix)