### PR TITLE
🔨refactor: Hide internal APIs

### DIFF
--- a/src/main/scala/lerna/akka/entityreplication/typed/internal/ReplicatedEntityTypeKeyImpl.scala
+++ b/src/main/scala/lerna/akka/entityreplication/typed/internal/ReplicatedEntityTypeKeyImpl.scala
@@ -2,7 +2,7 @@ package lerna.akka.entityreplication.typed.internal
 
 import lerna.akka.entityreplication.typed.ReplicatedEntityTypeKey
 
-final case class ReplicatedEntityTypeKeyImpl[Command](name: String, messageClassName: String)
+private[entityreplication] final case class ReplicatedEntityTypeKeyImpl[Command](name: String, messageClassName: String)
     extends ReplicatedEntityTypeKey[Command] {
   override def toString: String = s"ReplicatedEntityTypeKey[$messageClassName]($name)"
 }

--- a/src/main/scala/lerna/akka/entityreplication/typed/internal/ReplicationId.scala
+++ b/src/main/scala/lerna/akka/entityreplication/typed/internal/ReplicationId.scala
@@ -9,7 +9,7 @@ private[entityreplication] object ReplicationId {
     ReplicationIdImpl(entityTypeKey, NormalizedEntityId.from(entityId))
 }
 
-trait ReplicationId[Command] {
+private[entityreplication] trait ReplicationId[Command] {
 
   def entityTypeKey: ReplicatedEntityTypeKey[Command]
 

--- a/src/main/scala/lerna/akka/entityreplication/typed/internal/behavior/ReplicatedEntityBehaviorImpl.scala
+++ b/src/main/scala/lerna/akka/entityreplication/typed/internal/behavior/ReplicatedEntityBehaviorImpl.scala
@@ -14,7 +14,7 @@ import lerna.akka.entityreplication.typed.internal.behavior.ReplicatedEntityBeha
 import java.util.concurrent.atomic.AtomicInteger
 import scala.util.control.NonFatal
 
-object ReplicatedEntityBehaviorImpl {
+private[entityreplication] object ReplicatedEntityBehaviorImpl {
 
   private[this] val instanceIdCounter = new AtomicInteger(1)
 

--- a/src/main/scala/lerna/akka/entityreplication/typed/internal/effect/EffectBuilderImpl.scala
+++ b/src/main/scala/lerna/akka/entityreplication/typed/internal/effect/EffectBuilderImpl.scala
@@ -6,7 +6,7 @@ import lerna.akka.entityreplication.typed.{ Effect, EffectBuilder }
 
 import scala.collection.immutable
 
-object EffectBuilderImpl {
+private[entityreplication] object EffectBuilderImpl {
 
   def unhandled[Event, State](mainEffect: MainEffect[Event, State]): EffectBuilder[Event, State] =
     new EffectBuilderImpl(mainEffect, immutable.Seq(new UnhandledEffect[State]))


### PR DESCRIPTION
Internal APIs should not expose.
The APIs in `internal` package are used by only internal implementations.