### PR TITLE
chore: ScalaPB version up

### DIFF
--- a/project/scalapb.sbt
+++ b/project/scalapb.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("com.thesamet"                    % "sbt-protoc"     % "1.0.2")
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.10.11"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.3"

--- a/src/main/mima-filters/1.0.0.backwards.excludes/pr-92-version-up-scalapb.excludes
+++ b/src/main/mima-filters/1.0.0.backwards.excludes/pr-92-version-up-scalapb.excludes
@@ -1,0 +1,4 @@
+# Automatically generated code
+# It is not supposed to be called by the library user.
+# Serialization compatibility is guaranteed by Protocol Buffers.
+ProblemFilters.exclude[Problem]("lerna.akka.entityreplication.protobuf.msg.*")


### PR DESCRIPTION
scalapb/ScalaPB: Protocol buffer compiler for Scala.
https://github.com/scalapb/ScalaPB

## Changelog
- [ScalaPB/CHANGELOG.md at master · scalapb/ScalaPB](https://github.com/scalapb/ScalaPB/blob/master/CHANGELOG.md)


## 理由
`lerna-app-library` と組み合わせて使う場合に実行時エラーとなったため。

```
java.lang.NoClassDefFoundError: scalapb/HasBuilder
        at java.lang.ClassLoader.defineClass1(Native Method)
        at java.lang.ClassLoader.defineClass(Unknown Source)
        at java.security.SecureClassLoader.defineClass(Unknown Source)
        at java.net.URLClassLoader.defineClass(Unknown Source)
        at java.net.URLClassLoader.access$100(Unknown Source)
        at java.net.URLClassLoader$1.run(Unknown Source)
        at java.net.URLClassLoader$1.run(Unknown Source)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.net.URLClassLoader.findClass(Unknown Source)
        at java.lang.ClassLoader.loadClass(Unknown Source)
        at sun.misc.Launcher$AppClassLoader.loadClass(Unknown Source)
        at java.lang.ClassLoader.loadClass(Unknown Source)
        at lerna.akka.entityreplication.protobuf.ClusterReplicationSerializer.lerna$akka$entityreplication$protobuf$ClusterReplicationSerializer$$begunNewTermToBinary(ClusterReplicationSerializer.scala:212)
```

```scala
object RequestVote extends scala.AnyRef with scalapb.GeneratedMessageCompanion[lerna.akka.entityreplication.protobuf.msg.RequestVote] with scalapb.HasBuilder[lerna.akka.entityreplication.protobuf.msg.RequestVote] with java.io.Serializable {
```

## 関連
https://github.com/lerna-stack/lerna-app-library/pull/27 ```chore: ScalaPB version up by tksugimoto · Pull Request #27 · lerna-stack/lerna-app-library```