### PR TITLE
🐞fix: Can not get journalPluginAdditionalConfig after overriding RaftJournalPluginId

### DIFF
--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftSettingsImpl.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftSettingsImpl.scala
@@ -27,7 +27,6 @@ private[entityreplication] final case class RaftSettingsImpl(
     snapshotSyncPersistenceOperationTimeout: FiniteDuration,
     clusterShardingConfig: Config,
     journalPluginId: String,
-    journalPluginAdditionalConfig: Config,
     snapshotStorePluginId: String,
     queryPluginId: String,
     eventSourcedJournalPluginId: String,
@@ -38,6 +37,13 @@ private[entityreplication] final case class RaftSettingsImpl(
 
   override private[raft] def randomizedCompactionLogSizeCheckInterval(): FiniteDuration =
     RaftSettingsImpl.randomized(compactionLogSizeCheckInterval)
+
+  override def journalPluginAdditionalConfig: Config =
+    ConfigFactory.parseMap {
+      Map(
+        journalPluginId -> config.getObject("persistence.journal-plugin-additional"),
+      ).asJava
+    }
 
   override private[entityreplication] def withJournalPluginId(pluginId: String): RaftSettings =
     copy(journalPluginId = pluginId)
@@ -122,13 +128,6 @@ private[entityreplication] object RaftSettingsImpl {
 
     val journalPluginId: String = config.getString("persistence.journal.plugin")
 
-    val journalPluginAdditionalConfig: Config =
-      ConfigFactory.parseMap {
-        Map(
-          journalPluginId -> config.getObject("persistence.journal-plugin-additional"),
-        ).asJava
-      }
-
     val snapshotStorePluginId: String = config.getString("persistence.snapshot-store.plugin")
 
     val queryPluginId: String = config.getString("persistence.query.plugin")
@@ -154,7 +153,6 @@ private[entityreplication] object RaftSettingsImpl {
       snapshotSyncPersistenceOperationTimeout = snapshotSyncPersistenceOperationTimeout,
       clusterShardingConfig = clusterShardingConfig,
       journalPluginId = journalPluginId,
-      journalPluginAdditionalConfig = journalPluginAdditionalConfig,
       snapshotStorePluginId = snapshotStorePluginId,
       queryPluginId = queryPluginId,
       eventSourcedJournalPluginId = eventSourcedJournalPluginId,

--- a/src/test/scala/lerna/akka/entityreplication/ClusterReplicationSettingsSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/ClusterReplicationSettingsSpec.scala
@@ -62,6 +62,21 @@ class ClusterReplicationSettingsSpec extends WordSpec with Matchers {
       modifiedSettings.raftSettings.journalPluginId should be(expectedPluginId)
     }
 
+    "return config which contains settings of journal-plugin-additional by raftSettings.journalPluginAdditionalConfig after overriding RaftJournalPluginId" in {
+      val localConfig = ConfigFactory
+        .parseString("""
+        lerna.akka.entityreplication.raft.persistence.journal-plugin-additional {
+          additional-setting = "ok"
+        }               
+        """).withFallback(config)
+      val settings         = ClusterReplicationSettingsImpl(localConfig, correctClusterRoles.headOption.toSet)
+      val expectedPluginId = "new-raft-journal-plugin-id"
+      val modifiedSettings = settings.withRaftJournalPluginId(expectedPluginId)
+      modifiedSettings.raftSettings.journalPluginAdditionalConfig.getString(
+        "new-raft-journal-plugin-id.additional-setting",
+      ) should be("ok")
+    }
+
     "change value of raftSettings.snapshotStorePluginId by withRaftSnapshotPluginId" in {
       val settings         = ClusterReplicationSettingsImpl(config, correctClusterRoles.headOption.toSet)
       val expectedPluginId = "new-raft-snapshot-plugin-id"


### PR DESCRIPTION
`withRaftJournalPluginId` does not update `journalPluginAdditionalConfig`, so we can't load correct journal config.