### PR TITLE
Release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-[Unreleased]: https://github.com/lerna-stack/akka-entity-replication/compare/v1.0.0...master
+[Unreleased]: https://github.com/lerna-stack/akka-entity-replication/compare/v2.0.0...master
+
+
+## [v2.0.0] - 2021-07-16
+[v2.0.0]: https://github.com/lerna-stack/akka-entity-replication/compare/v1.0.0...v2.0.0
 
 ### Breaking Change
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-[Unreleased]: https://github.com/lerna-stack/akka-entity-replication/compare/.v1.0.0...master
+[Unreleased]: https://github.com/lerna-stack/akka-entity-replication/compare/v1.0.0...master
 
 ### Breaking Change
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To use this library, you must add a dependency into your sbt project, add the fo
 
 [![Maven Central](https://img.shields.io/maven-central/v/com.lerna-stack/akka-entity-replication_2.13?color=%23005cb2&label=stable)](https://mvnrepository.com/artifact/com.lerna-stack/akka-entity-replication) 
 
-⚠️ `v2.0.0` will contain breaking changes. For more details see [CHANGELOG](./CHANGELOG.md).
+⚠️ `v2.0.0` contains breaking changes. For more details see [CHANGELOG](./CHANGELOG.md).
 
 ```scala
 libraryDependencies += "com.lerna-stack" %% "akka-entity-replication" % "X.X.X"


### PR DESCRIPTION
waiting for merge https://github.com/lerna-stack/akka-entity-replication/pull/96 ```Add deprecated annotation to untyped APIs by negokaz · Pull Request #96 · lerna-stack/akka-entity-replication```

close https://github.com/lerna-stack/akka-entity-replication/issues/44 ```Support typed actor · Issue #44 · lerna-stack/akka-entity-replication```

No unnecessary v1.0.0 left
```
$ git grep --fixed-string 1.0.0
CHANGELOG.md:The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
CHANGELOG.md:[v2.0.0]: https://github.com/lerna-stack/akka-entity-replication/compare/v1.0.0...v2.0.0
CHANGELOG.md:## [v1.0.0] - 2021-03-29
CHANGELOG.md:[v1.0.0]: https://github.com/lerna-stack/akka-entity-replication/compare/v0.1.1...v1.0.0
```

## TODO(after merge)
- [ ] create tag `v2.0.0` 
  - auto release [.github/workflows/release.yml](https://github.com/lerna-stack/akka-entity-replication/blob/master/.github/workflows/release.yml)