### PR TITLE
Bump up akka version to 2.6.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 [Unreleased]: https://github.com/lerna-stack/akka-entity-replication/compare/v2.0.0...master
 
+### Changed
+- Bump up Akka version to 2.6.17 [PR#98](https://github.com/lerna-stack/akka-entity-replication/pull/98)
+
+  This change will show you deserialization warnings during the rolling update, it's safe to ignore. 
+  For more details, see [Akka 2.6.16 release note](https://akka.io/blog/news/2021/08/19/akka-2.6.16-released#rolling-upgrades)
 
 ## [v2.0.0] - 2021-07-16
 [v2.0.0]: https://github.com/lerna-stack/akka-entity-replication/compare/v1.0.0...v2.0.0

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import org.scalafmt.sbt.ScalafmtPlugin.scalafmtConfigSettings
 
 resolvers += "dnvriend" at "https://dl.bintray.com/dnvriend/maven"
 
-lazy val akkaVersion = "2.6.12"
+lazy val akkaVersion = "2.6.17"
 
 lazy val lerna = (project in file("."))
   .enablePlugins(


### PR DESCRIPTION
# Check Akka release notes

https://github.com/akka/akka/releases

## Notable changes

### [Akka 2.6.13 Released | Akka](https://akka.io/blog/news/2021/02/23/akka-2.6.13-released)

> Note that this release may need your project to upgrade to the latest Scala version to compile (Scala 2.13.4+ or 2.12.13+) because of an issue with the @nowarn annotation #30018. If not compilation may fail with this error:
>
> **[Akka 2.6.13 Released | Akka](https://akka.io/blog/news/2021/02/23/akka-2.6.13-released#:~:text=Note,:)**

We have already used scala 2.13.4.

> ```
>         scalaVersion := "2.13.4",
> ```
> **[akka-entity-replication/build.sbt at v2.0.0 · lerna-stack/akka-entity-replication](https://github.com/lerna-stack/akka-entity-replication/blob/v2.0.0/build.sbt#L17)**

### [Akka 2.6.14 Released | Akka](https://akka.io/blog/news/2021/04/08/akka-2.6.14-released)

> It is possible that the Jackson upgrade from 2.10 to 2.11 is not completely source and binary compatible. We have inspected the Jackson changelogs and have not found any obvious issues. If you do use more advanced Jackson features such as custom modules where you interface with more of the Jackson APIs or have third party dependencies depending on Jackson of a different version it is important that you carefully test your application when upgrading.
>
> **[Akka 2.6.14 Released | Akka](https://akka.io/blog/news/2021/04/08/akka-2.6.14-released#:~:text=It%20is,upgrading.)**

akka-entity-replicaton doesn't depend on akka-serialization-jackson.

> ```scala
>     libraryDependencies ++= Seq(
>         "com.typesafe.akka" %% "akka-cluster-typed"    % akkaVersion,
>         "com.typesafe.akka" %% "akka-stream"           % akkaVersion,
>         "com.typesafe.akka" %% "akka-cluster"          % akkaVersion,
>         "com.typesafe.akka" %% "akka-cluster-sharding" % akkaVersion,
>         "com.typesafe.akka" %% "akka-persistence"      % akkaVersion,
>         // persistence-query 2.6.x を明示的に指定しないとエラーになる。
>         // 恐らく akka-persistence-inmemory の影響である。
>         "com.typesafe.akka" %% "akka-persistence-query"   % akkaVersion,
>         "com.typesafe.akka" %% "akka-actor-testkit-typed" % akkaVersion % Optional,
>         // multi-jvm:test can't resolve [Optional] dependency
>         "com.typesafe.akka" %% "akka-actor-testkit-typed" % akkaVersion % Test,
>         "io.altoo"          %% "akka-kryo-serialization"  % "1.1.5"     % Test,
>         "com.typesafe.akka" %% "akka-slf4j"               % akkaVersion % Test,
>         "ch.qos.logback"     % "logback-classic"          % "1.2.3"     % Test,
>         "org.scalatest"     %% "scalatest"                % "3.0.9"     % Test,
>         "com.typesafe.akka" %% "akka-multi-node-testkit"  % akkaVersion % Test,
>         // akka-persistence-inmemory が 2.6.x 系に対応していない。
>         // TODO 2.6.x 系に対応できる方法に変更する。
>         "com.github.dnvriend" %% "akka-persistence-inmemory" % "2.5.15.2" % Test,
>       ),
> ```
> **[akka-entity-replication/build.sbt at v2.0.0 · lerna-stack/akka-entity-replication](https://github.com/lerna-stack/akka-entity-replication/blob/v2.0.0/build.sbt#L35-L55)**

### [Akka 2.6.15 Released | Akka](https://akka.io/blog/news/2021/06/10/akka-2.6.15-released)

Nothing

### [Akka 2.6.16 Released - including Durable State persistence | Akka](https://akka.io/blog/news/2021/08/19/akka-2.6.16-released)

> Rolling upgrades
> This release includes a new Akka Cluster Sharding internal message that is used whenever a shard region is terminated (see #30402). If you run a rolling upgrade, you might see deserialization warnings for message RegionStopped in the logs of the oldest node (the one holding the shard coordinator). It’s safe to ignore those warnings during the upgrade.
>
> **[Akka 2.6.16 Released - including Durable State persistence | Akka](https://akka.io/blog/news/2021/08/19/akka-2.6.16-released#:~:text=Rolling%20upgrades,upgrade.)**

We should mention it in changelog.

### [Akka 2.6.17 Released | Akka](https://akka.io/blog/news/2021/10/15/akka-2.6.17-released)

Nothing

# Anything depends on Akka 2.6.12

Nothing

```
❯ git grep 2.6.12 | wc -l
0
```

# Integration testing with sample application

We will test using the SNAPSHOT version that is going to be released after this PR is merged.
