### PR TITLE
Evaluate log operations only when the log level is enabled

### DIFF
--- a/src/main/scala/lerna/akka/entityreplication/ReplicationActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/ReplicationActor.scala
@@ -59,7 +59,8 @@ trait ReplicationActor[StateData] extends Actor with Stash with akka.lerna.Stash
         case RecoveryTimeout =>
           // to restart
           // TODO: BackoffSupervisor を使ってカスケード障害を回避する
-          if (log.isInfoEnabled) log.info("Entity (name: {}) recovering timed out. It will be retried later.", self.path.name)
+          if (log.isInfoEnabled)
+            log.info("Entity (name: {}) recovering timed out. It will be retried later.", self.path.name)
           throw EntityRecoveryTimeoutException(self.path)
 
         case RecoveryState(logEntries, maybeSnapshot) =>

--- a/src/main/scala/lerna/akka/entityreplication/ReplicationActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/ReplicationActor.scala
@@ -59,7 +59,7 @@ trait ReplicationActor[StateData] extends Actor with Stash with akka.lerna.Stash
         case RecoveryTimeout =>
           // to restart
           // TODO: BackoffSupervisor を使ってカスケード障害を回避する
-          log.info("Entity (name: {}) recovering timed out. It will be retried later.", self.path.name)
+          if (log.isInfoEnabled) log.info("Entity (name: {}) recovering timed out. It will be retried later.", self.path.name)
           throw EntityRecoveryTimeoutException(self.path)
 
         case RecoveryState(logEntries, maybeSnapshot) =>
@@ -88,7 +88,7 @@ trait ReplicationActor[StateData] extends Actor with Stash with akka.lerna.Stash
           receive.applyOrElse[Any, Unit](
             command,
             command => {
-              log.warning("unhandled {} by receiveCommand", command)
+              if (log.isWarningEnabled) log.warning("unhandled {} by receiveCommand", command)
             },
           )
 
@@ -161,7 +161,7 @@ trait ReplicationActor[StateData] extends Actor with Stash with akka.lerna.Stash
       receiveReplica.applyOrElse[Any, Unit](
         event,
         event => {
-          log.warning("unhandled {} by receiveReplica", event)
+          if (log.isWarningEnabled) log.warning("unhandled {} by receiveReplica", event)
         },
       )
       lastAppliedLogEntryIndex = logEntryIndex

--- a/src/main/scala/lerna/akka/entityreplication/ReplicationRegion.scala
+++ b/src/main/scala/lerna/akka/entityreplication/ReplicationRegion.scala
@@ -100,7 +100,7 @@ private[entityreplication] class ReplicationRegion(
       val decide = super.supervisorStrategy.decider(e)
       decide match {
         case directive =>
-          if (log.isErrorEnabled) log.error(e, s"$directive")
+          if (log.isErrorEnabled) log.error(e, "{}", directive)
       }
       decide
   }

--- a/src/main/scala/lerna/akka/entityreplication/ReplicationRegion.scala
+++ b/src/main/scala/lerna/akka/entityreplication/ReplicationRegion.scala
@@ -237,7 +237,8 @@ private[entityreplication] class ReplicationRegion(
       )
       handleRoutingCommand(DeliverSomewhere(Command(message)))
     } else {
-      if (log.isWarningEnabled) log.warning("The message [{}] was dropped because its shard ID could not be extracted", message)
+      if (log.isWarningEnabled)
+        log.warning("The message [{}] was dropped because its shard ID could not be extracted", message)
     }
   }
 
@@ -290,11 +291,12 @@ private[entityreplication] class ReplicationRegion(
   private[this] def memberIndexOf(member: Member): Option[MemberIndex] = {
     val maybeMemberIndex = allMemberIndexes.find(i => member.roles.contains(i.role))
     if (maybeMemberIndex.isEmpty) {
-      if (log.isWarningEnabled) log.warning(
-        "Member {} has no any role of MemberIndexes ({}). This member will be ignored",
-        member,
-        allMemberIndexes,
-      )
+      if (log.isWarningEnabled)
+        log.warning(
+          "Member {} has no any role of MemberIndexes ({}). This member will be ignored",
+          member,
+          allMemberIndexes,
+        )
     }
     maybeMemberIndex
   }

--- a/src/main/scala/lerna/akka/entityreplication/raft/Candidate.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/Candidate.scala
@@ -12,7 +12,8 @@ private[raft] trait Candidate { this: RaftActor =>
   def candidateBehavior: Receive = {
 
     case ElectionTimeout =>
-      if (log.isInfoEnabled) log.info("[Candidate] Election timeout at {}. Retrying leader election.", currentData.currentTerm)
+      if (log.isInfoEnabled)
+        log.info("[Candidate] Election timeout at {}. Retrying leader election.", currentData.currentTerm)
       val newTerm = currentData.currentTerm.next()
       cancelElectionTimeoutTimer()
       broadcast(

--- a/src/main/scala/lerna/akka/entityreplication/raft/Candidate.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/Candidate.scala
@@ -52,7 +52,7 @@ private[raft] trait Candidate { this: RaftActor =>
     request match {
 
       case RequestVote(_, term, candidate, _, _) if term == currentData.currentTerm && candidate == selfMemberIndex =>
-        if (log.isDebugEnabled) log.debug(s"=== [Candidate] accept self RequestVote ===")
+        if (log.isDebugEnabled) log.debug("=== [Candidate] accept self RequestVote ===")
         applyDomainEvent(Voted(term, selfMemberIndex)) { _ =>
           sender() ! RequestVoteAccepted(term, selfMemberIndex)
         }
@@ -61,7 +61,7 @@ private[raft] trait Candidate { this: RaftActor =>
           if term.isNewerThan(
             currentData.currentTerm,
           ) && lastLogTerm >= currentData.replicatedLog.lastLogTerm && lastLogIndex >= currentData.replicatedLog.lastLogIndex =>
-        if (log.isDebugEnabled) log.debug(s"=== [Candidate] accept RequestVote($term, $otherCandidate) ===")
+        if (log.isDebugEnabled) log.debug("=== [Candidate] accept RequestVote({}, {}) ===", term, otherCandidate)
         cancelElectionTimeoutTimer()
         applyDomainEvent(Voted(term, otherCandidate)) { domainEvent =>
           sender() ! RequestVoteAccepted(domainEvent.term, selfMemberIndex)
@@ -69,7 +69,7 @@ private[raft] trait Candidate { this: RaftActor =>
         }
 
       case request: RequestVote =>
-        if (log.isDebugEnabled) log.debug(s"=== [Candidate] deny $request ===")
+        if (log.isDebugEnabled) log.debug("=== [Candidate] deny {} ===", request)
         if (request.term.isNewerThan(currentData.currentTerm)) {
           cancelElectionTimeoutTimer()
           applyDomainEvent(DetectedNewTerm(request.term)) { _ =>
@@ -129,7 +129,7 @@ private[raft] trait Candidate { this: RaftActor =>
 
       case appendEntries: AppendEntries =>
         if (currentData.hasMatchLogEntry(appendEntries.prevLogIndex, appendEntries.prevLogTerm)) {
-          if (log.isDebugEnabled) log.debug(s"=== [Candidate] append $appendEntries ===")
+          if (log.isDebugEnabled) log.debug("=== [Candidate] append {} ===", appendEntries)
           cancelElectionTimeoutTimer()
           if (appendEntries.entries.isEmpty && appendEntries.term == currentData.currentTerm) {
             // do not persist event when no need
@@ -155,7 +155,7 @@ private[raft] trait Candidate { this: RaftActor =>
             }
           }
         } else { // prevLogIndex と prevLogTerm がマッチするエントリが無かった
-          if (log.isDebugEnabled) log.debug(s"=== [Candidate] could not append $appendEntries ===")
+          if (log.isDebugEnabled) log.debug("=== [Candidate] could not append {} ===", appendEntries)
           cancelElectionTimeoutTimer()
           if (appendEntries.term == currentData.currentTerm) {
             applyDomainEvent(DetectedLeaderMember(appendEntries.leader)) { _ =>

--- a/src/main/scala/lerna/akka/entityreplication/raft/Follower.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/Follower.scala
@@ -14,9 +14,9 @@ private[raft] trait Follower { this: RaftActor =>
 
     case ElectionTimeout =>
       if (currentData.leaderMember.isEmpty) {
-        log.debug(s"=== [Follower] election timeout ===")
+        if (log.isDebugEnabled) log.debug(s"=== [Follower] election timeout ===")
       } else {
-        log.warning("[{}] election timeout. Leader will be changed", currentState)
+        if (log.isWarningEnabled) log.warning("[{}] election timeout. Leader will be changed", currentState)
       }
       requestVote(currentData)
 
@@ -42,12 +42,12 @@ private[raft] trait Follower { this: RaftActor =>
     request match {
 
       case request: RequestVote if request.term.isOlderThan(currentData.currentTerm) =>
-        log.debug(s"=== [Follower] deny $request ===")
+        if (log.isDebugEnabled) log.debug(s"=== [Follower] deny $request ===")
         sender() ! RequestVoteDenied(currentData.currentTerm)
 
       case request: RequestVote
           if request.lastLogTerm < currentData.replicatedLog.lastLogTerm || request.lastLogIndex < currentData.replicatedLog.lastLogIndex =>
-        log.debug(s"=== [Follower] deny $request ===")
+        if (log.isDebugEnabled) log.debug(s"=== [Follower] deny $request ===")
         if (request.term.isNewerThan(currentData.currentTerm)) {
           applyDomainEvent(DetectedNewTerm(request.term)) { _ =>
             sender() ! RequestVoteDenied(currentData.currentTerm)
@@ -57,7 +57,7 @@ private[raft] trait Follower { this: RaftActor =>
         }
 
       case request: RequestVote if request.term.isNewerThan(currentData.currentTerm) =>
-        log.debug(s"=== [Follower] accept $request ===")
+        if (log.isDebugEnabled) log.debug(s"=== [Follower] accept $request ===")
         cancelElectionTimeoutTimer()
         applyDomainEvent(Voted(request.term, request.candidate)) { domainEvent =>
           sender() ! RequestVoteAccepted(domainEvent.term, selfMemberIndex)
@@ -65,7 +65,7 @@ private[raft] trait Follower { this: RaftActor =>
         }
 
       case request: RequestVote if !currentData.alreadyVotedOthers(request.candidate) =>
-        log.debug(s"=== [Follower] accept $request ===")
+        if (log.isDebugEnabled) log.debug(s"=== [Follower] accept $request ===")
         cancelElectionTimeoutTimer()
         applyDomainEvent(Voted(request.term, request.candidate)) { domainEvent =>
           sender() ! RequestVoteAccepted(domainEvent.term, selfMemberIndex)
@@ -73,7 +73,7 @@ private[raft] trait Follower { this: RaftActor =>
         }
 
       case request: RequestVote =>
-        log.debug(s"=== [Follower] deny $request ===")
+        if (log.isDebugEnabled) log.debug(s"=== [Follower] deny $request ===")
         sender() ! RequestVoteDenied(currentData.currentTerm)
     }
 
@@ -85,7 +85,7 @@ private[raft] trait Follower { this: RaftActor =>
 
       case appendEntries: AppendEntries =>
         if (currentData.hasMatchLogEntry(appendEntries.prevLogIndex, appendEntries.prevLogTerm)) {
-          log.debug(s"=== [Follower] append $appendEntries ===")
+          if (log.isDebugEnabled) log.debug(s"=== [Follower] append $appendEntries ===")
           cancelElectionTimeoutTimer()
           if (appendEntries.entries.isEmpty && appendEntries.term == currentData.currentTerm) {
             // do not persist event when no need
@@ -111,7 +111,7 @@ private[raft] trait Follower { this: RaftActor =>
             }
           }
         } else { // prevLogIndex と prevLogTerm がマッチするエントリが無かった
-          log.debug(s"=== [Follower] could not append $appendEntries ===")
+          if (log.isDebugEnabled) log.debug(s"=== [Follower] could not append $appendEntries ===")
           cancelElectionTimeoutTimer()
           if (appendEntries.term == currentData.currentTerm) {
             applyDomainEvent(DetectedLeaderMember(appendEntries.leader)) { _ =>
@@ -132,7 +132,7 @@ private[raft] trait Follower { this: RaftActor =>
   private[this] def handleCommand(command: Command): Unit =
     (currentData.leaderMember, currentData.votedFor) match {
       case (Some(leader), _) =>
-        log.debug(s"=== [Follower] forward $command to $leader ===")
+        if (log.isDebugEnabled) log.debug(s"=== [Follower] forward $command to $leader ===")
         region forward ReplicationRegion.DeliverTo(leader, ForwardedCommand(command))
       case (None, _) =>
         stash()

--- a/src/main/scala/lerna/akka/entityreplication/raft/Leader.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/Leader.scala
@@ -48,7 +48,7 @@ private[raft] trait Leader { this: RaftActor =>
           if term.isNewerThan(
             currentData.currentTerm,
           ) && lastLogTerm >= currentData.replicatedLog.lastLogTerm && lastLogIndex >= currentData.replicatedLog.lastLogIndex =>
-        log.debug(s"=== [Leader] accept RequestVote($term, $candidate) ===")
+        if (log.isDebugEnabled) log.debug(s"=== [Leader] accept RequestVote($term, $candidate) ===")
         cancelHeartbeatTimeoutTimer()
         applyDomainEvent(Voted(term, candidate)) { domainEvent =>
           sender() ! RequestVoteAccepted(domainEvent.term, selfMemberIndex)
@@ -56,7 +56,7 @@ private[raft] trait Leader { this: RaftActor =>
         }
 
       case request: RequestVote =>
-        log.debug(s"=== [Leader] deny $request ===")
+        if (log.isDebugEnabled) log.debug(s"=== [Leader] deny $request ===")
         if (request.term.isNewerThan(currentData.currentTerm)) {
           cancelHeartbeatTimeoutTimer()
           applyDomainEvent(DetectedNewTerm(request.term)) { _ =>
@@ -88,7 +88,7 @@ private[raft] trait Leader { this: RaftActor =>
       case appendEntries: AppendEntries if appendEntries.term.isNewerThan(currentData.currentTerm) =>
         if (currentData.hasMatchLogEntry(appendEntries.prevLogIndex, appendEntries.prevLogTerm)) {
           cancelHeartbeatTimeoutTimer()
-          log.debug(s"=== [Leader] append $appendEntries ===")
+          if (log.isDebugEnabled) log.debug(s"=== [Leader] append $appendEntries ===")
           applyDomainEvent(AppendedEntries(appendEntries.term, appendEntries.entries, appendEntries.prevLogIndex)) {
             domainEvent =>
               applyDomainEvent(FollowedLeaderCommit(appendEntries.leader, appendEntries.leaderCommit)) { _ =>
@@ -101,7 +101,7 @@ private[raft] trait Leader { this: RaftActor =>
               }
           }
         } else { // prevLogIndex と prevLogTerm がマッチするエントリが無かった
-          log.debug(s"=== [Leader] could not append $appendEntries ===")
+          if (log.isDebugEnabled) log.debug(s"=== [Leader] could not append $appendEntries ===")
           cancelHeartbeatTimeoutTimer()
           applyDomainEvent(DetectedNewTerm(appendEntries.term)) { domainEvent =>
             applyDomainEvent(DetectedLeaderMember(appendEntries.leader)) { _ =>
@@ -131,7 +131,7 @@ private[raft] trait Leader { this: RaftActor =>
         }
 
       case succeeded: AppendEntriesSucceeded if succeeded.term.isNewerThan(currentData.currentTerm) =>
-        log.warning("Unexpected message received: {} (currentTerm: {})", succeeded, currentData.currentTerm)
+        if (log.isWarningEnabled) log.warning("Unexpected message received: {} (currentTerm: {})", succeeded, currentData.currentTerm)
 
       case succeeded: AppendEntriesSucceeded if succeeded.term.isOlderThan(currentData.currentTerm) =>
       // ignore: Follower always synchronizes Term before replying, so it does not happen normally
@@ -163,7 +163,7 @@ private[raft] trait Leader { this: RaftActor =>
         applyDomainEvent(SucceededAppendEntries(follower, succeeded.dstLatestSnapshotLastLogLogIndex)) { _ => }
 
       case succeeded: InstallSnapshotSucceeded if succeeded.term.isNewerThan(currentData.currentTerm) =>
-        log.warning("Unexpected message received: {} (currentTerm: {})", succeeded, currentData.currentTerm)
+        if (log.isWarningEnabled) log.warning("Unexpected message received: {} (currentTerm: {})", succeeded, currentData.currentTerm)
 
       case succeeded: InstallSnapshotSucceeded =>
         assert(succeeded.term.isOlderThan(currentData.currentTerm))
@@ -205,7 +205,7 @@ private[raft] trait Leader { this: RaftActor =>
       // ignore: no-op replication when become leader
 
       case ReplicationSucceeded(unknownEvent, _, _) =>
-        log.warning("unknown event: {}", unknownEvent)
+        if (log.isWarningEnabled) log.warning("unknown event: {}", unknownEvent)
     }
 
   private[this] def startEntityPassivationProcess(entityPath: ActorPath, stopMessage: Any): Unit = {
@@ -264,7 +264,7 @@ private[raft] trait Leader { this: RaftActor =>
               ),
             )
         }
-      log.debug(s"=== [Leader] publish ${messages.mkString(",")} to $memberIndex ===")
+      if (log.isDebugEnabled) log.debug(s"=== [Leader] publish ${messages.mkString(",")} to $memberIndex ===")
       messages.foreach(region ! ReplicationRegion.DeliverTo(memberIndex, _))
     }
   }

--- a/src/main/scala/lerna/akka/entityreplication/raft/Leader.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/Leader.scala
@@ -48,7 +48,7 @@ private[raft] trait Leader { this: RaftActor =>
           if term.isNewerThan(
             currentData.currentTerm,
           ) && lastLogTerm >= currentData.replicatedLog.lastLogTerm && lastLogIndex >= currentData.replicatedLog.lastLogIndex =>
-        if (log.isDebugEnabled) log.debug(s"=== [Leader] accept RequestVote($term, $candidate) ===")
+        if (log.isDebugEnabled) log.debug("=== [Leader] accept RequestVote({}, {}) ===", term, candidate)
         cancelHeartbeatTimeoutTimer()
         applyDomainEvent(Voted(term, candidate)) { domainEvent =>
           sender() ! RequestVoteAccepted(domainEvent.term, selfMemberIndex)
@@ -56,7 +56,7 @@ private[raft] trait Leader { this: RaftActor =>
         }
 
       case request: RequestVote =>
-        if (log.isDebugEnabled) log.debug(s"=== [Leader] deny $request ===")
+        if (log.isDebugEnabled) log.debug("=== [Leader] deny {} ===", request)
         if (request.term.isNewerThan(currentData.currentTerm)) {
           cancelHeartbeatTimeoutTimer()
           applyDomainEvent(DetectedNewTerm(request.term)) { _ =>
@@ -88,7 +88,7 @@ private[raft] trait Leader { this: RaftActor =>
       case appendEntries: AppendEntries if appendEntries.term.isNewerThan(currentData.currentTerm) =>
         if (currentData.hasMatchLogEntry(appendEntries.prevLogIndex, appendEntries.prevLogTerm)) {
           cancelHeartbeatTimeoutTimer()
-          if (log.isDebugEnabled) log.debug(s"=== [Leader] append $appendEntries ===")
+          if (log.isDebugEnabled) log.debug("=== [Leader] append {} ===", appendEntries)
           applyDomainEvent(AppendedEntries(appendEntries.term, appendEntries.entries, appendEntries.prevLogIndex)) {
             domainEvent =>
               applyDomainEvent(FollowedLeaderCommit(appendEntries.leader, appendEntries.leaderCommit)) { _ =>
@@ -101,7 +101,7 @@ private[raft] trait Leader { this: RaftActor =>
               }
           }
         } else { // prevLogIndex と prevLogTerm がマッチするエントリが無かった
-          if (log.isDebugEnabled) log.debug(s"=== [Leader] could not append $appendEntries ===")
+          if (log.isDebugEnabled) log.debug("=== [Leader] could not append {} ===", appendEntries)
           cancelHeartbeatTimeoutTimer()
           applyDomainEvent(DetectedNewTerm(appendEntries.term)) { domainEvent =>
             applyDomainEvent(DetectedLeaderMember(appendEntries.leader)) { _ =>
@@ -266,7 +266,7 @@ private[raft] trait Leader { this: RaftActor =>
               ),
             )
         }
-      if (log.isDebugEnabled) log.debug(s"=== [Leader] publish ${messages.mkString(",")} to $memberIndex ===")
+      if (log.isDebugEnabled) log.debug("=== [Leader] publish {} to {} ===", messages.mkString(","), memberIndex)
       messages.foreach(region ! ReplicationRegion.DeliverTo(memberIndex, _))
     }
   }

--- a/src/main/scala/lerna/akka/entityreplication/raft/Leader.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/Leader.scala
@@ -131,7 +131,8 @@ private[raft] trait Leader { this: RaftActor =>
         }
 
       case succeeded: AppendEntriesSucceeded if succeeded.term.isNewerThan(currentData.currentTerm) =>
-        if (log.isWarningEnabled) log.warning("Unexpected message received: {} (currentTerm: {})", succeeded, currentData.currentTerm)
+        if (log.isWarningEnabled)
+          log.warning("Unexpected message received: {} (currentTerm: {})", succeeded, currentData.currentTerm)
 
       case succeeded: AppendEntriesSucceeded if succeeded.term.isOlderThan(currentData.currentTerm) =>
       // ignore: Follower always synchronizes Term before replying, so it does not happen normally
@@ -163,7 +164,8 @@ private[raft] trait Leader { this: RaftActor =>
         applyDomainEvent(SucceededAppendEntries(follower, succeeded.dstLatestSnapshotLastLogLogIndex)) { _ => }
 
       case succeeded: InstallSnapshotSucceeded if succeeded.term.isNewerThan(currentData.currentTerm) =>
-        if (log.isWarningEnabled) log.warning("Unexpected message received: {} (currentTerm: {})", succeeded, currentData.currentTerm)
+        if (log.isWarningEnabled)
+          log.warning("Unexpected message received: {} (currentTerm: {})", succeeded, currentData.currentTerm)
 
       case succeeded: InstallSnapshotSucceeded =>
         assert(succeeded.term.isOlderThan(currentData.currentTerm))

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
@@ -150,11 +150,12 @@ private[raft] class RaftActor(
 
   protected[this] def replicationActor(entityId: NormalizedEntityId): ActorRef = {
     context.child(entityId.underlying).getOrElse {
-      if (log.isDebugEnabled) log.debug(
-        "=== [{}] created an entity ({}) ===",
-        currentState,
-        entityId,
-      )
+      if (log.isDebugEnabled)
+        log.debug(
+          "=== [{}] created an entity ({}) ===",
+          currentState,
+          entityId,
+        )
       val props = replicationActorProps(new ReplicationActorContext(entityId.raw, self))
       context.actorOf(props, entityId.underlying)
     }
@@ -193,12 +194,13 @@ private[raft] class RaftActor(
       case BecameCandidate() =>
         currentData.initializeCandidateData()
       case BecameLeader() =>
-        if (log.isInfoEnabled) log.info(
-          "[Leader] New leader was elected (term: {}, lastLogTerm: {}, lastLogIndex: {})",
-          currentData.currentTerm,
-          currentData.replicatedLog.lastLogTerm,
-          currentData.replicatedLog.lastLogIndex,
-        )
+        if (log.isInfoEnabled)
+          log.info(
+            "[Leader] New leader was elected (term: {}, lastLogTerm: {}, lastLogIndex: {})",
+            currentData.currentTerm,
+            currentData.replicatedLog.lastLogTerm,
+            currentData.replicatedLog.lastLogIndex,
+          )
         currentData.initializeLeaderData()
       case DetectedLeaderMember(leaderMember) =>
         currentData.detectLeaderMember(leaderMember)
@@ -253,12 +255,13 @@ private[raft] class RaftActor(
             ),
           ) { _ =>
             saveSnapshot(currentData.persistentState) // Note that this persistence can fail
-            if (log.isInfoEnabled) log.info(
-              "[{}] compaction completed (term: {}, logEntryIndex: {})",
-              currentState,
-              progress.snapshotLastLogTerm,
-              progress.snapshotLastLogIndex,
-            )
+            if (log.isInfoEnabled)
+              log.info(
+                "[{}] compaction completed (term: {}, logEntryIndex: {})",
+                currentState,
+                progress.snapshotLastLogTerm,
+                progress.snapshotLastLogIndex,
+              )
           }
         })
       case CompactionCompleted(_, _, snapshotLastTerm, snapshotLastIndex, _) =>
@@ -373,7 +376,8 @@ private[raft] class RaftActor(
         if (log.isDebugEnabled) log.debug(s"=== [$currentState] applying $event to ReplicationActor ===")
         replicationActor(entityId) ! Replica(logEntry)
       case EntityEvent(None, event) =>
-        if (log.isWarningEnabled) log.warning(s"=== [$currentState] $event was not applied, because it is not assigned any entity ===")
+        if (log.isWarningEnabled)
+          log.warning(s"=== [$currentState] $event was not applied, because it is not assigned any entity ===")
     }
 
   def handleSnapshotTick(): Unit = {
@@ -383,12 +387,13 @@ private[raft] class RaftActor(
     ) {
       val (term, logEntryIndex, entityIds) = currentData.resolveSnapshotTargets()
       applyDomainEvent(SnapshottingStarted(term, logEntryIndex, entityIds)) { _ =>
-        if (log.isInfoEnabled) log.info(
-          "[{}] compaction started (logEntryIndex: {}, number of entities: {})",
-          currentState,
-          logEntryIndex,
-          entityIds.size,
-        )
+        if (log.isInfoEnabled)
+          log.info(
+            "[{}] compaction started (logEntryIndex: {}, number of entities: {})",
+            currentState,
+            logEntryIndex,
+            entityIds.size,
+          )
         requestTakeSnapshots(logEntryIndex, entityIds)
       }
     }
@@ -487,10 +492,11 @@ private[raft] class RaftActor(
     context.children.filterNot(c => excludes.exists(c.path.name.startsWith)).foreach { child =>
       context.stop(child)
     }
-    if (log.isDebugEnabled) log.debug(
-      "=== [{}] stopped all entities ===",
-      currentState,
-    )
+    if (log.isDebugEnabled)
+      log.debug(
+        "=== [{}] stopped all entities ===",
+        currentState,
+      )
   }
 
   override def postStop(): Unit = {

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
@@ -231,7 +231,8 @@ private[raft] class RaftActor(
             })
             entries.foreach {
               case (logEntry, Some(client)) =>
-                if (log.isDebugEnabled) log.debug(s"=== [Leader] committed $logEntry and will notify it to $client ===")
+                if (log.isDebugEnabled)
+                  log.debug("=== [Leader] committed {} and will notify it to {} ===", logEntry, client)
                 client.ref.tell(
                   ReplicationSucceeded(logEntry.event.event, logEntry.index, client.instanceId),
                   client.originSender.getOrElse(ActorRef.noSender),
@@ -310,7 +311,7 @@ private[raft] class RaftActor(
   }
 
   def suspendEntity(entityId: NormalizedEntityId, stopMessage: Any): Unit = {
-    if (log.isDebugEnabled) log.debug(s"=== [$currentState] suspend entity '$entityId' with $stopMessage ===")
+    if (log.isDebugEnabled) log.debug("=== [{}] suspend entity '{}' with {} ===", currentState, entityId, stopMessage)
     replicationActor(entityId) ! stopMessage
   }
 
@@ -335,7 +336,7 @@ private[raft] class RaftActor(
   def resetElectionTimeoutTimer(): Unit = {
     cancelElectionTimeoutTimer()
     val timeout = settings.randomizedElectionTimeout()
-    if (log.isDebugEnabled) log.debug(s"=== [$currentState] election-timeout after ${timeout.toMillis} ms ===")
+    if (log.isDebugEnabled) log.debug("=== [{}] election-timeout after {} ms ===", currentState, timeout.toMillis)
     electionTimeoutTimer = Some(context.system.scheduler.scheduleOnce(timeout, self, ElectionTimeout))
   }
 
@@ -348,7 +349,7 @@ private[raft] class RaftActor(
   def resetHeartbeatTimeoutTimer(): Unit = {
     cancelHeartbeatTimeoutTimer()
     val timeout = settings.heartbeatInterval
-    if (log.isDebugEnabled) log.debug(s"=== [Leader] Heartbeat after ${settings.heartbeatInterval.toMillis} ms ===")
+    if (log.isDebugEnabled) log.debug("=== [Leader] Heartbeat after {} ms ===", settings.heartbeatInterval.toMillis)
     heartbeatTimeoutTimer = Some(context.system.scheduler.scheduleOnce(timeout, self, HeartbeatTimeout))
   }
 
@@ -365,7 +366,7 @@ private[raft] class RaftActor(
   }
 
   def broadcast(message: Any): Unit = {
-    if (log.isDebugEnabled) log.debug(s"=== [$currentState] broadcast $message ===")
+    if (log.isDebugEnabled) log.debug("=== [{}] broadcast {} ===", currentState, message)
     region ! ReplicationRegion.Broadcast(message)
   }
 
@@ -373,11 +374,11 @@ private[raft] class RaftActor(
     logEntry.event match {
       case EntityEvent(_, NoOp) => // NoOp は replicationActor には関係ないので転送しない
       case EntityEvent(Some(entityId), event) =>
-        if (log.isDebugEnabled) log.debug(s"=== [$currentState] applying $event to ReplicationActor ===")
+        if (log.isDebugEnabled) log.debug("=== [{}] applying {} to ReplicationActor ===", currentState, event)
         replicationActor(entityId) ! Replica(logEntry)
       case EntityEvent(None, event) =>
         if (log.isWarningEnabled)
-          log.warning(s"=== [$currentState] $event was not applied, because it is not assigned any entity ===")
+          log.warning("=== [{}] {} was not applied, because it is not assigned any entity ===", currentState, event)
     }
 
   def handleSnapshotTick(): Unit = {

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftActorBase.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftActorBase.scala
@@ -60,20 +60,20 @@ private[raft] trait RaftActorBase extends PersistentActor with ActorLogging {
             val persistingTimeMillis     = (endNanoTime - startNanoTime) / 1000000
             val electionTimeoutMinMillis = settings.electionTimeoutMin.toMillis
             if (persistingTimeMillis > settings.electionTimeoutMin.toMillis) {
-              log.warning(
+              if (log.isWarningEnabled) log.warning(
                 s"[{}] persisting time ({} ms) is grater than minimum of election-timeout ({} ms)",
                 currentState,
                 persistingTimeMillis,
                 electionTimeoutMinMillis,
               )
             } else {
-              log.debug(s"=== [$currentState] persisting time: $persistingTimeMillis ms ===")
+              if (log.isDebugEnabled) log.debug(s"=== [$currentState] persisting time: $persistingTimeMillis ms ===")
             }
             _currentData = updateState(event)
             f(domainEvent)
           } catch {
             case e: Exception =>
-              log.error(e, "persisted event handling failed")
+              if (log.isErrorEnabled) log.error(e, "persisted event handling failed")
               throw e
           }
         }
@@ -83,7 +83,7 @@ private[raft] trait RaftActorBase extends PersistentActor with ActorLogging {
     }
 
   protected def become(state: State): Unit = {
-    log.debug("=== Transition: {} -> {} ===", currentState, state)
+    if (log.isDebugEnabled) log.debug("=== Transition: {} -> {} ===", currentState, state)
     if (onTransition.isDefinedAt((currentState, state))) {
       onTransition((currentState, state))
     }

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftActorBase.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftActorBase.scala
@@ -62,13 +62,14 @@ private[raft] trait RaftActorBase extends PersistentActor with ActorLogging {
             if (persistingTimeMillis > settings.electionTimeoutMin.toMillis) {
               if (log.isWarningEnabled)
                 log.warning(
-                  s"[{}] persisting time ({} ms) is grater than minimum of election-timeout ({} ms)",
+                  "[{}] persisting time ({} ms) is grater than minimum of election-timeout ({} ms)",
                   currentState,
                   persistingTimeMillis,
                   electionTimeoutMinMillis,
                 )
             } else {
-              if (log.isDebugEnabled) log.debug(s"=== [$currentState] persisting time: $persistingTimeMillis ms ===")
+              if (log.isDebugEnabled)
+                log.debug("=== [{}] persisting time: {} ms ===", currentState, persistingTimeMillis)
             }
             _currentData = updateState(event)
             f(domainEvent)

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftActorBase.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftActorBase.scala
@@ -60,12 +60,13 @@ private[raft] trait RaftActorBase extends PersistentActor with ActorLogging {
             val persistingTimeMillis     = (endNanoTime - startNanoTime) / 1000000
             val electionTimeoutMinMillis = settings.electionTimeoutMin.toMillis
             if (persistingTimeMillis > settings.electionTimeoutMin.toMillis) {
-              if (log.isWarningEnabled) log.warning(
-                s"[{}] persisting time ({} ms) is grater than minimum of election-timeout ({} ms)",
-                currentState,
-                persistingTimeMillis,
-                electionTimeoutMinMillis,
-              )
+              if (log.isWarningEnabled)
+                log.warning(
+                  s"[{}] persisting time ({} ms) is grater than minimum of election-timeout ({} ms)",
+                  currentState,
+                  persistingTimeMillis,
+                  electionTimeoutMinMillis,
+                )
             } else {
               if (log.isDebugEnabled) log.debug(s"=== [$currentState] persisting time: $persistingTimeMillis ms ===")
             }

--- a/src/main/scala/lerna/akka/entityreplication/raft/snapshot/SnapshotStore.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/snapshot/SnapshotStore.scala
@@ -85,7 +85,7 @@ private[entityreplication] class SnapshotStore(
     case command: Command =>
       command match {
         case cmd: SaveSnapshot =>
-          log.warning(
+          if (log.isWarningEnabled) log.warning(
             s"Saving snapshot for an entity (${cmd.entityId}) currently. Consider to increase log-size-threshold or log-size-check-interval.",
           )
         case FetchSnapshot(_, replyTo) =>
@@ -97,7 +97,7 @@ private[entityreplication] class SnapshotStore(
       replyTo ! SaveSnapshotSuccess(snapshot.metadata)
       context.become(hasSnapshot(snapshot))
     case failure: persistence.SaveSnapshotFailure =>
-      log.warning("Saving snapshot failed - {}: {}", failure.cause.getClass.getCanonicalName, failure.cause.getMessage)
+      if (log.isWarningEnabled) log.warning("Saving snapshot failed - {}: {}", failure.cause.getClass.getCanonicalName, failure.cause.getMessage)
       replyTo ! SaveSnapshotFailure(snapshot.metadata)
   }
 

--- a/src/main/scala/lerna/akka/entityreplication/raft/snapshot/SnapshotStore.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/snapshot/SnapshotStore.scala
@@ -87,7 +87,8 @@ private[entityreplication] class SnapshotStore(
         case cmd: SaveSnapshot =>
           if (log.isWarningEnabled)
             log.warning(
-              s"Saving snapshot for an entity (${cmd.entityId}) currently. Consider to increase log-size-threshold or log-size-check-interval.",
+              "Saving snapshot for an entity ({}) currently. Consider to increase log-size-threshold or log-size-check-interval.",
+              cmd.entityId,
             )
         case FetchSnapshot(_, replyTo) =>
           prevSnapshot.foreach { s =>

--- a/src/main/scala/lerna/akka/entityreplication/raft/snapshot/SnapshotStore.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/snapshot/SnapshotStore.scala
@@ -85,9 +85,10 @@ private[entityreplication] class SnapshotStore(
     case command: Command =>
       command match {
         case cmd: SaveSnapshot =>
-          if (log.isWarningEnabled) log.warning(
-            s"Saving snapshot for an entity (${cmd.entityId}) currently. Consider to increase log-size-threshold or log-size-check-interval.",
-          )
+          if (log.isWarningEnabled)
+            log.warning(
+              s"Saving snapshot for an entity (${cmd.entityId}) currently. Consider to increase log-size-threshold or log-size-check-interval.",
+            )
         case FetchSnapshot(_, replyTo) =>
           prevSnapshot.foreach { s =>
             replyTo ! SnapshotProtocol.SnapshotFound(s)
@@ -97,7 +98,12 @@ private[entityreplication] class SnapshotStore(
       replyTo ! SaveSnapshotSuccess(snapshot.metadata)
       context.become(hasSnapshot(snapshot))
     case failure: persistence.SaveSnapshotFailure =>
-      if (log.isWarningEnabled) log.warning("Saving snapshot failed - {}: {}", failure.cause.getClass.getCanonicalName, failure.cause.getMessage)
+      if (log.isWarningEnabled)
+        log.warning(
+          "Saving snapshot failed - {}: {}",
+          failure.cause.getClass.getCanonicalName,
+          failure.cause.getMessage,
+        )
       replyTo ! SaveSnapshotFailure(snapshot.metadata)
   }
 

--- a/src/main/scala/lerna/akka/entityreplication/raft/snapshot/sync/SnapshotSyncManager.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/snapshot/sync/SnapshotSyncManager.scala
@@ -180,11 +180,12 @@ private[entityreplication] class SnapshotSyncManager(
         dstLatestSnapshotLastLogIndex,
         srcMemberIndex,
       )
-      if (log.isInfoEnabled) log.info(
-        "Snapshot synchronization already completed: " +
-        s"(typeName: $typeName, memberIndex: $srcMemberIndex, snapshotLastLogTerm: ${srcLatestSnapshotLastLogTerm.term}, snapshotLastLogIndex: $srcLatestSnapshotLastLogIndex)" +
-        s" -> (typeName: $typeName, memberIndex: $dstMemberIndex, snapshotLastLogTerm: ${dstLatestSnapshotLastLogTerm.term}, snapshotLastLogIndex: $dstLatestSnapshotLastLogIndex)",
-      )
+      if (log.isInfoEnabled)
+        log.info(
+          "Snapshot synchronization already completed: " +
+          s"(typeName: $typeName, memberIndex: $srcMemberIndex, snapshotLastLogTerm: ${srcLatestSnapshotLastLogTerm.term}, snapshotLastLogIndex: $srcLatestSnapshotLastLogIndex)" +
+          s" -> (typeName: $typeName, memberIndex: $dstMemberIndex, snapshotLastLogTerm: ${dstLatestSnapshotLastLogTerm.term}, snapshotLastLogIndex: $dstLatestSnapshotLastLogIndex)",
+        )
       context.stop(self)
 
     case SyncSnapshot(
@@ -204,11 +205,12 @@ private[entityreplication] class SnapshotSyncManager(
       this.killSwitch = Option(killSwitch)
       result pipeTo self
       context.become(synchronizing(replyTo, dstLatestSnapshotLastLogTerm, dstLatestSnapshotLastLogIndex))
-      if (log.isInfoEnabled) log.info(
-        "Snapshot synchronization started: " +
-        s"(typeName: $typeName, memberIndex: $srcMemberIndex, snapshotLastLogTerm: ${srcLatestSnapshotLastLogTerm.term}, snapshotLastLogIndex: $srcLatestSnapshotLastLogIndex)" +
-        s" -> (typeName: $typeName, memberIndex: $dstMemberIndex, snapshotLastLogTerm: ${dstLatestSnapshotLastLogTerm.term}, snapshotLastLogIndex: $dstLatestSnapshotLastLogIndex)",
-      )
+      if (log.isInfoEnabled)
+        log.info(
+          "Snapshot synchronization started: " +
+          s"(typeName: $typeName, memberIndex: $srcMemberIndex, snapshotLastLogTerm: ${srcLatestSnapshotLastLogTerm.term}, snapshotLastLogIndex: $srcLatestSnapshotLastLogIndex)" +
+          s" -> (typeName: $typeName, memberIndex: $dstMemberIndex, snapshotLastLogTerm: ${dstLatestSnapshotLastLogTerm.term}, snapshotLastLogIndex: $dstLatestSnapshotLastLogIndex)",
+        )
 
     case _: akka.persistence.SaveSnapshotSuccess =>
       context.stop(self)
@@ -237,32 +239,35 @@ private[entityreplication] class SnapshotSyncManager(
               completeAll.snapshotLastLogIndex,
               srcMemberIndex,
             )
-            if (log.isInfoEnabled) log.info(
-              "Snapshot synchronization completed: " +
-              s"(typeName: $typeName, memberIndex: $srcMemberIndex)" +
-              s" -> (typeName: $typeName, memberIndex: $dstMemberIndex, snapshotLastLogTerm: ${dstLatestSnapshotLastLogTerm.term}, snapshotLastLogIndex: $dstLatestSnapshotLastLogIndex)",
-            )
+            if (log.isInfoEnabled)
+              log.info(
+                "Snapshot synchronization completed: " +
+                s"(typeName: $typeName, memberIndex: $srcMemberIndex)" +
+                s" -> (typeName: $typeName, memberIndex: $dstMemberIndex, snapshotLastLogTerm: ${dstLatestSnapshotLastLogTerm.term}, snapshotLastLogIndex: $dstLatestSnapshotLastLogIndex)",
+              )
           }
         case _: SyncIncomplete =>
           this.killSwitch = None
           replyTo ! SyncSnapshotFailed()
-          if (log.isInfoEnabled) log.info(
-            "Snapshot synchronization is incomplete: " +
-            s"(typeName: $typeName, memberIndex: $srcMemberIndex)" +
-            s" -> (typeName: $typeName, memberIndex: $dstMemberIndex, snapshotLastLogTerm: ${dstLatestSnapshotLastLogTerm.term}, snapshotLastLogIndex: $dstLatestSnapshotLastLogIndex)",
-          )
+          if (log.isInfoEnabled)
+            log.info(
+              "Snapshot synchronization is incomplete: " +
+              s"(typeName: $typeName, memberIndex: $srcMemberIndex)" +
+              s" -> (typeName: $typeName, memberIndex: $dstMemberIndex, snapshotLastLogTerm: ${dstLatestSnapshotLastLogTerm.term}, snapshotLastLogIndex: $dstLatestSnapshotLastLogIndex)",
+            )
           context.stop(self)
       }
 
     case Status.Failure(e) =>
       this.killSwitch = None
       replyTo ! SyncSnapshotFailed()
-      if (log.isWarningEnabled) log.warning(
-        "Snapshot synchronization aborted: " +
-        s"(typeName: $typeName, memberIndex: $srcMemberIndex)" +
-        s" -> (typeName: $typeName, memberIndex: $dstMemberIndex, snapshotLastLogTerm: ${dstLatestSnapshotLastLogTerm.term}, snapshotLastLogIndex: $dstLatestSnapshotLastLogIndex)" +
-        s" cause: $e",
-      )
+      if (log.isWarningEnabled)
+        log.warning(
+          "Snapshot synchronization aborted: " +
+          s"(typeName: $typeName, memberIndex: $srcMemberIndex)" +
+          s" -> (typeName: $typeName, memberIndex: $dstMemberIndex, snapshotLastLogTerm: ${dstLatestSnapshotLastLogTerm.term}, snapshotLastLogIndex: $dstLatestSnapshotLastLogIndex)" +
+          s" cause: $e",
+        )
       context.stop(self)
 
     case _: akka.persistence.SaveSnapshotSuccess => // ignore: previous execution result

--- a/src/main/scala/lerna/akka/entityreplication/raft/snapshot/sync/SnapshotSyncManager.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/snapshot/sync/SnapshotSyncManager.scala
@@ -182,9 +182,9 @@ private[entityreplication] class SnapshotSyncManager(
       )
       if (log.isInfoEnabled)
         log.info(
-          "Snapshot synchronization already completed: " +
-          s"(typeName: $typeName, memberIndex: $srcMemberIndex, snapshotLastLogTerm: ${srcLatestSnapshotLastLogTerm.term}, snapshotLastLogIndex: $srcLatestSnapshotLastLogIndex)" +
-          s" -> (typeName: $typeName, memberIndex: $dstMemberIndex, snapshotLastLogTerm: ${dstLatestSnapshotLastLogTerm.term}, snapshotLastLogIndex: $dstLatestSnapshotLastLogIndex)",
+          "Snapshot synchronization already completed: {} -> {}",
+          s"(typeName: $typeName, memberIndex: $srcMemberIndex, snapshotLastLogTerm: ${srcLatestSnapshotLastLogTerm.term}, snapshotLastLogIndex: $srcLatestSnapshotLastLogIndex)",
+          s"(typeName: $typeName, memberIndex: $dstMemberIndex, snapshotLastLogTerm: ${dstLatestSnapshotLastLogTerm.term}, snapshotLastLogIndex: $dstLatestSnapshotLastLogIndex)",
         )
       context.stop(self)
 
@@ -207,9 +207,9 @@ private[entityreplication] class SnapshotSyncManager(
       context.become(synchronizing(replyTo, dstLatestSnapshotLastLogTerm, dstLatestSnapshotLastLogIndex))
       if (log.isInfoEnabled)
         log.info(
-          "Snapshot synchronization started: " +
-          s"(typeName: $typeName, memberIndex: $srcMemberIndex, snapshotLastLogTerm: ${srcLatestSnapshotLastLogTerm.term}, snapshotLastLogIndex: $srcLatestSnapshotLastLogIndex)" +
-          s" -> (typeName: $typeName, memberIndex: $dstMemberIndex, snapshotLastLogTerm: ${dstLatestSnapshotLastLogTerm.term}, snapshotLastLogIndex: $dstLatestSnapshotLastLogIndex)",
+          "Snapshot synchronization started: {} -> {}",
+          s"(typeName: $typeName, memberIndex: $srcMemberIndex, snapshotLastLogTerm: ${srcLatestSnapshotLastLogTerm.term}, snapshotLastLogIndex: $srcLatestSnapshotLastLogIndex)",
+          s"(typeName: $typeName, memberIndex: $dstMemberIndex, snapshotLastLogTerm: ${dstLatestSnapshotLastLogTerm.term}, snapshotLastLogIndex: $dstLatestSnapshotLastLogIndex)",
         )
 
     case _: akka.persistence.SaveSnapshotSuccess =>
@@ -241,9 +241,9 @@ private[entityreplication] class SnapshotSyncManager(
             )
             if (log.isInfoEnabled)
               log.info(
-                "Snapshot synchronization completed: " +
-                s"(typeName: $typeName, memberIndex: $srcMemberIndex)" +
-                s" -> (typeName: $typeName, memberIndex: $dstMemberIndex, snapshotLastLogTerm: ${dstLatestSnapshotLastLogTerm.term}, snapshotLastLogIndex: $dstLatestSnapshotLastLogIndex)",
+                "Snapshot synchronization completed: {} -> {}",
+                s"(typeName: $typeName, memberIndex: $srcMemberIndex)",
+                s"(typeName: $typeName, memberIndex: $dstMemberIndex, snapshotLastLogTerm: ${dstLatestSnapshotLastLogTerm.term}, snapshotLastLogIndex: $dstLatestSnapshotLastLogIndex)",
               )
           }
         case _: SyncIncomplete =>
@@ -251,9 +251,9 @@ private[entityreplication] class SnapshotSyncManager(
           replyTo ! SyncSnapshotFailed()
           if (log.isInfoEnabled)
             log.info(
-              "Snapshot synchronization is incomplete: " +
-              s"(typeName: $typeName, memberIndex: $srcMemberIndex)" +
-              s" -> (typeName: $typeName, memberIndex: $dstMemberIndex, snapshotLastLogTerm: ${dstLatestSnapshotLastLogTerm.term}, snapshotLastLogIndex: $dstLatestSnapshotLastLogIndex)",
+              "Snapshot synchronization is incomplete: {} -> {}",
+              s"(typeName: $typeName, memberIndex: $srcMemberIndex)",
+              s"(typeName: $typeName, memberIndex: $dstMemberIndex, snapshotLastLogTerm: ${dstLatestSnapshotLastLogTerm.term}, snapshotLastLogIndex: $dstLatestSnapshotLastLogIndex)",
             )
           context.stop(self)
       }
@@ -263,10 +263,10 @@ private[entityreplication] class SnapshotSyncManager(
       replyTo ! SyncSnapshotFailed()
       if (log.isWarningEnabled)
         log.warning(
-          "Snapshot synchronization aborted: " +
-          s"(typeName: $typeName, memberIndex: $srcMemberIndex)" +
-          s" -> (typeName: $typeName, memberIndex: $dstMemberIndex, snapshotLastLogTerm: ${dstLatestSnapshotLastLogTerm.term}, snapshotLastLogIndex: $dstLatestSnapshotLastLogIndex)" +
-          s" cause: $e",
+          "Snapshot synchronization aborted: {} -> {} cause: {}",
+          s"(typeName: $typeName, memberIndex: $srcMemberIndex)",
+          s"(typeName: $typeName, memberIndex: $dstMemberIndex, snapshotLastLogTerm: ${dstLatestSnapshotLastLogTerm.term}, snapshotLastLogIndex: $dstLatestSnapshotLastLogIndex)",
+          e,
         )
       context.stop(self)
 

--- a/src/main/scala/lerna/akka/entityreplication/raft/snapshot/sync/SnapshotSyncManager.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/snapshot/sync/SnapshotSyncManager.scala
@@ -180,7 +180,7 @@ private[entityreplication] class SnapshotSyncManager(
         dstLatestSnapshotLastLogIndex,
         srcMemberIndex,
       )
-      log.info(
+      if (log.isInfoEnabled) log.info(
         "Snapshot synchronization already completed: " +
         s"(typeName: $typeName, memberIndex: $srcMemberIndex, snapshotLastLogTerm: ${srcLatestSnapshotLastLogTerm.term}, snapshotLastLogIndex: $srcLatestSnapshotLastLogIndex)" +
         s" -> (typeName: $typeName, memberIndex: $dstMemberIndex, snapshotLastLogTerm: ${dstLatestSnapshotLastLogTerm.term}, snapshotLastLogIndex: $dstLatestSnapshotLastLogIndex)",
@@ -204,7 +204,7 @@ private[entityreplication] class SnapshotSyncManager(
       this.killSwitch = Option(killSwitch)
       result pipeTo self
       context.become(synchronizing(replyTo, dstLatestSnapshotLastLogTerm, dstLatestSnapshotLastLogIndex))
-      log.info(
+      if (log.isInfoEnabled) log.info(
         "Snapshot synchronization started: " +
         s"(typeName: $typeName, memberIndex: $srcMemberIndex, snapshotLastLogTerm: ${srcLatestSnapshotLastLogTerm.term}, snapshotLastLogIndex: $srcLatestSnapshotLastLogIndex)" +
         s" -> (typeName: $typeName, memberIndex: $dstMemberIndex, snapshotLastLogTerm: ${dstLatestSnapshotLastLogTerm.term}, snapshotLastLogIndex: $dstLatestSnapshotLastLogIndex)",
@@ -237,7 +237,7 @@ private[entityreplication] class SnapshotSyncManager(
               completeAll.snapshotLastLogIndex,
               srcMemberIndex,
             )
-            log.info(
+            if (log.isInfoEnabled) log.info(
               "Snapshot synchronization completed: " +
               s"(typeName: $typeName, memberIndex: $srcMemberIndex)" +
               s" -> (typeName: $typeName, memberIndex: $dstMemberIndex, snapshotLastLogTerm: ${dstLatestSnapshotLastLogTerm.term}, snapshotLastLogIndex: $dstLatestSnapshotLastLogIndex)",
@@ -246,7 +246,7 @@ private[entityreplication] class SnapshotSyncManager(
         case _: SyncIncomplete =>
           this.killSwitch = None
           replyTo ! SyncSnapshotFailed()
-          log.info(
+          if (log.isInfoEnabled) log.info(
             "Snapshot synchronization is incomplete: " +
             s"(typeName: $typeName, memberIndex: $srcMemberIndex)" +
             s" -> (typeName: $typeName, memberIndex: $dstMemberIndex, snapshotLastLogTerm: ${dstLatestSnapshotLastLogTerm.term}, snapshotLastLogIndex: $dstLatestSnapshotLastLogIndex)",
@@ -257,7 +257,7 @@ private[entityreplication] class SnapshotSyncManager(
     case Status.Failure(e) =>
       this.killSwitch = None
       replyTo ! SyncSnapshotFailed()
-      log.warning(
+      if (log.isWarningEnabled) log.warning(
         "Snapshot synchronization aborted: " +
         s"(typeName: $typeName, memberIndex: $srcMemberIndex)" +
         s" -> (typeName: $typeName, memberIndex: $dstMemberIndex, snapshotLastLogTerm: ${dstLatestSnapshotLastLogTerm.term}, snapshotLastLogIndex: $dstLatestSnapshotLastLogIndex)" +

--- a/src/main/scala/lerna/akka/entityreplication/typed/internal/behavior/Recovering.scala
+++ b/src/main/scala/lerna/akka/entityreplication/typed/internal/behavior/Recovering.scala
@@ -39,7 +39,7 @@ private[entityreplication] class Recovering[Command, Event, State](
               scheduler.cancel(RecoveryTimeoutTimer)
               receiveRecoveryState(command)
             case RaftProtocol.RecoveryTimeout =>
-              context.log.info(
+              if (context.log.isInfoEnabled) context.log.info(
                 "Entity (name: {}) recovering timed out. It will be retried later.",
                 setup.entityContext.entityId,
               )

--- a/src/main/scala/lerna/akka/entityreplication/typed/internal/behavior/Recovering.scala
+++ b/src/main/scala/lerna/akka/entityreplication/typed/internal/behavior/Recovering.scala
@@ -39,10 +39,11 @@ private[entityreplication] class Recovering[Command, Event, State](
               scheduler.cancel(RecoveryTimeoutTimer)
               receiveRecoveryState(command)
             case RaftProtocol.RecoveryTimeout =>
-              if (context.log.isInfoEnabled) context.log.info(
-                "Entity (name: {}) recovering timed out. It will be retried later.",
-                setup.entityContext.entityId,
-              )
+              if (context.log.isInfoEnabled)
+                context.log.info(
+                  "Entity (name: {}) recovering timed out. It will be retried later.",
+                  setup.entityContext.entityId,
+                )
               // TODO: Enable backoff to prevent cascade failures
               throw RaftProtocol.EntityRecoveryTimeoutException(context.self.path)
             case command: RaftProtocol.ProcessCommand =>

--- a/src/main/scala/lerna/akka/entityreplication/typed/internal/behavior/ReplicatedEntityBehaviorImpl.scala
+++ b/src/main/scala/lerna/akka/entityreplication/typed/internal/behavior/ReplicatedEntityBehaviorImpl.scala
@@ -36,7 +36,7 @@ private[entityreplication] final case class ReplicatedEntityBehaviorImpl[Command
       Behaviors.intercept(() => interceptor)(createBehavior(entityContext.shard, settings)).narrow
     } catch {
       case NonFatal(e) =>
-        ctx.asScala.log.error("ReplicatedEntityBehavior initialization failed", e)
+        if (ctx.asScala.log.isErrorEnabled) ctx.asScala.log.error("ReplicatedEntityBehavior initialization failed", e)
         Behaviors.stopped
     }
   }

--- a/src/main/scala/lerna/akka/entityreplication/util/AtLeastOnceComplete.scala
+++ b/src/main/scala/lerna/akka/entityreplication/util/AtLeastOnceComplete.scala
@@ -32,12 +32,13 @@ object AtLeastOnceComplete {
         destination ask { replyTo: typed.ActorRef[Reply] =>
           val msg = message(replyTo)
           if (retrying) {
-            if (logging.isWarningEnabled) logging.warning(
-              "Destination {} did not reply to a message in {}. Retrying to send the message [{}].",
-              destination,
-              retryInterval,
-              msg,
-            )
+            if (logging.isWarningEnabled)
+              logging.warning(
+                "Destination {} did not reply to a message in {}. Retrying to send the message [{}].",
+                destination,
+                retryInterval,
+                msg,
+              )
           }
           msg
         }
@@ -66,12 +67,13 @@ object AtLeastOnceComplete {
         destination askWithStatus { replyTo: typed.ActorRef[StatusReply[Reply]] =>
           val msg = message(replyTo)
           if (retrying) {
-            if (logging.isWarningEnabled) logging.warning(
-              "Destination {} did not reply to a message in {}. Retrying to send the message [{}].",
-              destination,
-              retryInterval,
-              msg,
-            )
+            if (logging.isWarningEnabled)
+              logging.warning(
+                "Destination {} did not reply to a message in {}. Retrying to send the message [{}].",
+                destination,
+                retryInterval,
+                msg,
+              )
           }
           msg
         }
@@ -90,12 +92,13 @@ object AtLeastOnceComplete {
     internalAskTo(
       { (retrying: Boolean) =>
         if (retrying) {
-          if (logging.isWarningEnabled) logging.warning(
-            "Destination {} did not reply to a message in {}. Retrying to send the message [{}].",
-            destination,
-            retryInterval,
-            message,
-          )
+          if (logging.isWarningEnabled)
+            logging.warning(
+              "Destination {} did not reply to a message in {}. Retrying to send the message [{}].",
+              destination,
+              retryInterval,
+              message,
+            )
         }
         destination ? message
       },

--- a/src/main/scala/lerna/akka/entityreplication/util/AtLeastOnceComplete.scala
+++ b/src/main/scala/lerna/akka/entityreplication/util/AtLeastOnceComplete.scala
@@ -32,7 +32,7 @@ object AtLeastOnceComplete {
         destination ask { replyTo: typed.ActorRef[Reply] =>
           val msg = message(replyTo)
           if (retrying) {
-            logging.warning(
+            if (logging.isWarningEnabled) logging.warning(
               "Destination {} did not reply to a message in {}. Retrying to send the message [{}].",
               destination,
               retryInterval,
@@ -66,7 +66,7 @@ object AtLeastOnceComplete {
         destination askWithStatus { replyTo: typed.ActorRef[StatusReply[Reply]] =>
           val msg = message(replyTo)
           if (retrying) {
-            logging.warning(
+            if (logging.isWarningEnabled) logging.warning(
               "Destination {} did not reply to a message in {}. Retrying to send the message [{}].",
               destination,
               retryInterval,
@@ -90,7 +90,7 @@ object AtLeastOnceComplete {
     internalAskTo(
       { (retrying: Boolean) =>
         if (retrying) {
-          logging.warning(
+          if (logging.isWarningEnabled) logging.warning(
             "Destination {} did not reply to a message in {}. Retrying to send the message [{}].",
             destination,
             retryInterval,


### PR DESCRIPTION
Building log messages unconditionally may consume CPU resources needlessly.

Akka logging API doesn't place arguments to log message template if the log level is disabled.

> The log message may contain argument placeholders {}, which will be substituted if the log level is enabled.
>
> **[Logging • Akka Documentation](https://doc.akka.io/docs/akka/2.6.17/typed/logging.html#:~:text=The%20log%20message,is%20enabled.)**

However, we disable all logging operations with an if statement when the log level is disabled to minimize execution cost.

- Placeholder arguments are not by-name parameters. They are evaluated immediately. It can be costly to build arguments
- We don't have to worry about forgetting to add an if statement when adding a new parameter.

This change doesn't affect users, so we don't have to notify users about this change by Changelog.