### PR TITLE
Don't delete replicated log entries until CompactionCompleted event is persisted

### DIFF
--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
@@ -250,7 +250,8 @@ private[raft] class RaftActor(
               progress.snapshotLastLogIndex,
               progress.completedEntities,
             ),
-          ) { event =>
+          ) { _ =>
+            saveSnapshot(currentData.persistentState) // Note that this persistence can fail
             if (log.isInfoEnabled)
               log.info(
                 "[{}] compaction completed (term: {}, logEntryIndex: {})",
@@ -266,7 +267,6 @@ private[raft] class RaftActor(
           currentData
             .updateLastSnapshotStatus(snapshotLastTerm, snapshotLastIndex)
             .compactReplicatedLog(settings.compactionPreserveLogSize)
-        saveSnapshot(newData.persistentState) // Note that this persistence can fail
         newData
       case SnapshotSyncCompleted(snapshotLastLogTerm, snapshotLastLogIndex) =>
         stopAllEntities()

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
@@ -254,17 +254,16 @@ private[raft] class RaftActor(
               progress.snapshotLastLogIndex,
               progress.completedEntities,
             ),
-          ) { _ =>
-            if (log.isInfoEnabled)
-              log.info(
-                "[{}] compaction completed (term: {}, logEntryIndex: {})",
-                currentState,
-                progress.snapshotLastLogTerm,
-                progress.snapshotLastLogIndex,
-              )
-          }
+          ) { _ => }
         })
       case CompactionCompleted(_, _, snapshotLastTerm, snapshotLastIndex, _) =>
+        if (log.isInfoEnabled)
+          log.info(
+            "[{}] compaction completed (term: {}, logEntryIndex: {})",
+            currentState,
+            snapshotLastTerm,
+            snapshotLastIndex,
+          )
         val newData =
           currentData
             .updateLastSnapshotStatus(snapshotLastTerm, snapshotLastIndex)

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
@@ -256,17 +256,18 @@ private[raft] class RaftActor(
               progress.snapshotLastLogIndex,
               progress.completedEntities,
             ),
-          ) { _ => }
+          ) { event =>
+            if (log.isInfoEnabled)
+              log.info(
+                "[{}] compaction completed (term: {}, logEntryIndex: {})",
+                currentState,
+                progress.snapshotLastLogTerm,
+                progress.snapshotLastLogIndex,
+              )
+          }
         }
         newData
       case CompactionCompleted(_, _, snapshotLastTerm, snapshotLastIndex, _) =>
-        if (log.isInfoEnabled)
-          log.info(
-            "[{}] compaction completed (term: {}, logEntryIndex: {})",
-            currentState,
-            snapshotLastTerm,
-            snapshotLastIndex,
-          )
         val newData =
           currentData
             .updateLastSnapshotStatus(snapshotLastTerm, snapshotLastIndex)

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
@@ -239,35 +239,11 @@ private[raft] class RaftActor(
       case SnapshottingStarted(term, logEntryIndex, entityIds) =>
         currentData.startSnapshotting(term, logEntryIndex, entityIds)
       case EntitySnapshotSaved(metadata) =>
-        val newData  = currentData.recordSavedSnapshot(metadata)
-        val progress = newData.snapshottingProgress
-        if (progress.isCompleted) {
-          applyDomainEvent(
-            CompactionCompleted(
-              selfMemberIndex,
-              shardId,
-              progress.snapshotLastLogTerm,
-              progress.snapshotLastLogIndex,
-              progress.completedEntities,
-            ),
-          ) { _ =>
-            saveSnapshot(currentData.persistentState) // Note that this persistence can fail
-            if (log.isInfoEnabled)
-              log.info(
-                "[{}] compaction completed (term: {}, logEntryIndex: {})",
-                currentState,
-                progress.snapshotLastLogTerm,
-                progress.snapshotLastLogIndex,
-              )
-          }
-        }
-        newData
+        currentData.recordSavedSnapshot(metadata)
       case CompactionCompleted(_, _, snapshotLastTerm, snapshotLastIndex, _) =>
-        val newData =
-          currentData
-            .updateLastSnapshotStatus(snapshotLastTerm, snapshotLastIndex)
-            .compactReplicatedLog(settings.compactionPreserveLogSize)
-        newData
+        currentData
+          .updateLastSnapshotStatus(snapshotLastTerm, snapshotLastIndex)
+          .compactReplicatedLog(settings.compactionPreserveLogSize)
       case SnapshotSyncCompleted(snapshotLastLogTerm, snapshotLastLogIndex) =>
         stopAllEntities()
         currentData.syncSnapshot(snapshotLastLogTerm, snapshotLastLogIndex)
@@ -341,7 +317,27 @@ private[raft] class RaftActor(
     response match {
       case SnapshotProtocol.SaveSnapshotSuccess(metadata) =>
         applyDomainEvent(EntitySnapshotSaved(metadata)) { _ =>
-          // do nothing
+          val progress = currentData.snapshottingProgress
+          if (progress.isCompleted) {
+            applyDomainEvent(
+              CompactionCompleted(
+                selfMemberIndex,
+                shardId,
+                progress.snapshotLastLogTerm,
+                progress.snapshotLastLogIndex,
+                progress.completedEntities,
+              ),
+            ) { _ =>
+              saveSnapshot(currentData.persistentState) // Note that this persistence can fail
+              if (log.isInfoEnabled)
+                log.info(
+                  "[{}] compaction completed (term: {}, logEntryIndex: {})",
+                  currentState,
+                  progress.snapshotLastLogTerm,
+                  progress.snapshotLastLogIndex,
+                )
+            }
+          }
         }
       case SnapshotProtocol.SaveSnapshotFailure(_) =>
       // do nothing

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftMemberData.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftMemberData.scala
@@ -312,20 +312,13 @@ private[entityreplication] trait RaftMemberData
     )
   }
 
-  def recordSavedSnapshot(
-      snapshotMetadata: EntitySnapshotMetadata,
-  )(onComplete: SnapshottingProgress => Unit): RaftMemberData = {
+  def recordSavedSnapshot(snapshotMetadata: EntitySnapshotMetadata): RaftMemberData = {
     if (
       snapshottingProgress.isInProgress && snapshottingProgress.snapshotLastLogIndex == snapshotMetadata.logEntryIndex
     ) {
       val newProgress =
         snapshottingProgress.recordSnapshottingComplete(snapshotMetadata.logEntryIndex, snapshotMetadata.entityId)
-      if (newProgress.isCompleted) {
-        onComplete(newProgress)
-        updateVolatileState(snapshottingProgress = newProgress)
-      } else {
-        updateVolatileState(snapshottingProgress = newProgress)
-      }
+      updateVolatileState(snapshottingProgress = newProgress)
     } else {
       this
     }


### PR DESCRIPTION
`ReplicatedLog` is a state which should be persisted.
However, the `EntitySnapshotSaved` event is not persisted.
Compacting the `ReplicatedLog` by `EntitySnapshotSaved` event means that `RaftActor` will not be able to reproduce the compacted log after the restore.

Saving a snapshot of the `RaftActor` state can reproduce the compacted log.
So we should compact the log by the `ComplactionCompleted` event which is persisted.