### PR TITLE
Take snapshots of entities only that have been updated since the last compaction

### DIFF
--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftMemberData.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftMemberData.scala
@@ -291,11 +291,12 @@ private[entityreplication] trait RaftMemberData
   def resolveSnapshotTargets(): (Term, LogEntryIndex, Set[NormalizedEntityId]) = {
     replicatedLog.termAt(lastApplied) match {
       case Some(lastAppliedTerm) =>
-        (
-          lastAppliedTerm,
-          lastApplied,
-          replicatedLog.sliceEntriesFromHead(lastApplied).flatMap(_.event.entityId.toSeq).toSet,
-        )
+        val entityIds =
+          replicatedLog
+            .sliceEntries(lastSnapshotStatus.snapshotLastLogIndex.next(), lastApplied)
+            .flatMap(_.event.entityId.toSeq)
+            .toSet
+        (lastAppliedTerm, lastApplied, entityIds)
       case None =>
         // This exception is not thrown unless there is a bug
         throw new IllegalStateException(s"Term not found at lastApplied: $lastApplied")


### PR DESCRIPTION
Reducing IO to save snapshots by ignoring logs already has been included in the snapshot.

`ReplicatedLog` contains the newly added events from the last compaction and the surviving events by the `compaction.preserve-log-size` setting.

It is necessary to apply the newly added events to the snapshot, but it is not necessary to apply the surviving events already included in the snapshots.

We can determine logs already included in the snapshots by `snapshotLastTerm` and `snapshotLastIndex`:

> ```scala
>       case CompactionCompleted(_, _, snapshotLastTerm, snapshotLastIndex, _) =>
>         currentData.updateLastSnapshotStatus(snapshotLastTerm, snapshotLastIndex)
> ```
> **[akka-entity-replication/RaftActor.scala at v2.0.0 · lerna-stack/akka-entity-replication](https://github.com/lerna-stack/akka-entity-replication/blob/v2.0.0/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala#L264-L265)**

The `snapshotLastTerm` and `snapshotLastIndex` are resolved by `resolveSnapshotTargets`.

> ```scala
>   def resolveSnapshotTargets(): (Term, LogEntryIndex, Set[NormalizedEntityId]) = {
>     replicatedLog.termAt(lastApplied) match {
>       case Some(lastAppliedTerm) =>
>         (
>           lastAppliedTerm,
>           lastApplied,
>           replicatedLog.sliceEntriesFromHead(lastApplied).flatMap(_.event.entityId.toSeq).toSet,
>         )
>       case None =>
>         // This exception is not thrown unless there is a bug
>         throw new IllegalStateException(s"Term not found at lastApplied: $lastApplied")
>     }
>   }
> ```
> **[akka-entity-replication/RaftMemberData.scala at v2.0.0 · lerna-stack/akka-entity-replication](https://github.com/lerna-stack/akka-entity-replication/blob/v2.0.0/src/main/scala/lerna/akka/entityreplication/raft/RaftMemberData.scala#L291-L303)**