### PR TITLE
 termAt doesn't return Term.initial() for LogEntryIndex.initial() after ancestor is changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - TestKit throws "Shard received unexpected message" exception after the entity passivated [PR#100](https://github.com/lerna-stack/akka-entity-replication/pull/100)
+- Starting a follower member later than leader completes a compaction may break ReplicatedLog of the follower [#105](https://github.com/lerna-stack/akka-entity-replication/issues/105)
 
 ## [v2.0.0] - 2021-07-16
 [v2.0.0]: https://github.com/lerna-stack/akka-entity-replication/compare/v1.0.0...v2.0.0

--- a/src/main/scala/lerna/akka/entityreplication/raft/model/ReplicatedLog.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/model/ReplicatedLog.scala
@@ -57,9 +57,8 @@ private[entityreplication] final case class ReplicatedLog private[model] (
 
   def termAt(logEntryIndex: LogEntryIndex): Option[Term] =
     logEntryIndex match {
-      case initialLogIndex if initialLogIndex == LogEntryIndex.initial() => Option(Term.initial())
-      case `ancestorLastIndex`                                           => Option(ancestorLastTerm)
-      case logEntryIndex                                                 => get(logEntryIndex).map(_.term)
+      case `ancestorLastIndex` => Option(ancestorLastTerm)
+      case logEntryIndex       => get(logEntryIndex).map(_.term)
     }
 
   def merge(thatEntries: Seq[LogEntry], prevLogIndex: LogEntryIndex): ReplicatedLog = {

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorSpecBase.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorSpecBase.scala
@@ -34,6 +34,7 @@ trait RaftActorSpecBase extends ActorSpec { self: TestKit =>
       settings: RaftSettings = RaftSettings(defaultRaftConfig),
       replicationActor: ActorRef = Actor.noSender,
       typeName: TypeName = TypeName.from("dummy"),
+      entityId: NormalizedEntityId = NormalizedEntityId.from("dummy"),
   ): RaftTestFSMRef = {
     val replicationActorProps = Props(new Actor() {
       override def receive: Receive = {
@@ -46,7 +47,7 @@ trait RaftActorSpecBase extends ActorSpec { self: TestKit =>
       }
     })
     val extractEntityId: PartialFunction[ReplicationRegion.Msg, (NormalizedEntityId, ReplicationRegion.Msg)] = {
-      case msg => (NormalizedEntityId.from("dummy"), msg)
+      case msg => (entityId, msg)
     }
     val ref = system.actorOf(
       Props(

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorSpecBase.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorSpecBase.scala
@@ -17,13 +17,11 @@ trait RaftActorSpecBase extends ActorSpec { self: TestKit =>
   import RaftActor._
 
   protected val config: Config = system.settings.config
-  protected val defaultRaftSettings: RaftSettings = RaftSettings(
-    ConfigFactory
-      .parseString("""
+  protected val defaultRaftConfig: Config = ConfigFactory
+    .parseString("""
     // electionTimeout がテスト中に自動で発生しないようにする
     lerna.akka.entityreplication.raft.election-timeout = 999999s
-    """).withFallback(config),
-  )
+    """).withFallback(config)
 
   type RaftTestFSMRef = ActorRef
 
@@ -33,7 +31,7 @@ trait RaftActorSpecBase extends ActorSpec { self: TestKit =>
       region: ActorRef = TestProbe().ref,
       selfMemberIndex: MemberIndex = MemberIndex("test-index"),
       otherMemberIndexes: Set[MemberIndex] = Set(),
-      settings: RaftSettings = defaultRaftSettings,
+      settings: RaftSettings = RaftSettings(defaultRaftConfig),
       replicationActor: ActorRef = Actor.noSender,
       typeName: TypeName = TypeName.from("dummy"),
   ): RaftTestFSMRef = {

--- a/src/test/scala/lerna/akka/entityreplication/testkit/CustomTestProbe.scala
+++ b/src/test/scala/lerna/akka/entityreplication/testkit/CustomTestProbe.scala
@@ -5,15 +5,15 @@ import akka.testkit.TestProbe
 object CustomTestProbe {
 
   implicit class CustomTestProbe(testProbe: TestProbe) {
-    def fishMatchMessagesWhile(messages: Int)(f: PartialFunction[Any, Unit]): Unit = {
-      var count = 0
+    def fishForMessageN[T](messages: Int)(f: PartialFunction[Any, T]): Seq[T] = {
+      var fishedMessages = Seq.empty[T]
       testProbe.fishForMessage() {
         case msg if f.isDefinedAt(msg) =>
-          f(msg)
-          count = count + 1
-          count >= messages
+          fishedMessages :+= f(msg)
+          fishedMessages.sizeIs >= messages
         case _ => false // ignore
       }
+      fishedMessages
     }
   }
 }

--- a/src/test/scala/lerna/akka/entityreplication/testkit/CustomTestProbe.scala
+++ b/src/test/scala/lerna/akka/entityreplication/testkit/CustomTestProbe.scala
@@ -1,0 +1,19 @@
+package lerna.akka.entityreplication.testkit
+
+import akka.testkit.TestProbe
+
+object CustomTestProbe {
+
+  implicit class CustomTestProbe(testProbe: TestProbe) {
+    def fishMatchMessagesWhile(messages: Int)(f: PartialFunction[Any, Unit]): Unit = {
+      var count = 0
+      testProbe.fishForMessage() {
+        case msg if f.isDefinedAt(msg) =>
+          f(msg)
+          count = count + 1
+          count >= messages
+        case _ => false // ignore
+      }
+    }
+  }
+}

--- a/src/test/scala/lerna/akka/entityreplication/testkit/CustomTestProbeSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/testkit/CustomTestProbeSpec.scala
@@ -7,7 +7,7 @@ import lerna.akka.entityreplication.raft.ActorSpec
 class CustomTestProbeSpec extends TestKit(ActorSystem("CustomTestProbeSpec")) with ActorSpec {
   import CustomTestProbe._
 
-  "CustomTestProbe.fishMatchMessagesWhile" should {
+  "CustomTestProbe.fishForMessageN" should {
 
     "pass when the probe receives messages that match the condition" in {
       val probe = TestProbe()
@@ -15,7 +15,7 @@ class CustomTestProbeSpec extends TestKit(ActorSystem("CustomTestProbeSpec")) wi
       probe.ref ! "match"
 
       var called = false
-      probe.fishMatchMessagesWhile(messages = 1) {
+      probe.fishForMessageN(messages = 1) {
         case "match" =>
           called = true
       }
@@ -28,7 +28,7 @@ class CustomTestProbeSpec extends TestKit(ActorSystem("CustomTestProbeSpec")) wi
       probe.ref ! "invalid"
 
       intercept[AssertionError] {
-        probe.fishMatchMessagesWhile(messages = 1) {
+        probe.fishForMessageN(messages = 1) {
           case "match" =>
         }
       }
@@ -42,7 +42,7 @@ class CustomTestProbeSpec extends TestKit(ActorSystem("CustomTestProbeSpec")) wi
       probe.ref ! "match"
 
       var called = false
-      probe.fishMatchMessagesWhile(messages = 1) {
+      probe.fishForMessageN(messages = 1) {
         case "match" =>
           called = true
       }
@@ -56,11 +56,25 @@ class CustomTestProbeSpec extends TestKit(ActorSystem("CustomTestProbeSpec")) wi
       probe.ref ! "match"
 
       var count = 0
-      probe.fishMatchMessagesWhile(messages = 2) {
+      probe.fishForMessageN(messages = 2) {
         case "match" =>
           count = count + 1
       }
       count should be(2)
+    }
+
+    "return the values the PartialFunction provided to verify coverage of the patterns matched" in {
+      val probe = TestProbe()
+
+      probe.ref ! "first"
+      probe.ref ! "second"
+
+      probe.fishForMessageN(messages = 2) {
+        case msg @ "first" =>
+          msg
+        case msg @ "second" =>
+          msg
+      } should contain theSameElementsInOrderAs Seq("first", "second")
     }
   }
 }

--- a/src/test/scala/lerna/akka/entityreplication/testkit/CustomTestProbeSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/testkit/CustomTestProbeSpec.scala
@@ -1,0 +1,66 @@
+package lerna.akka.entityreplication.testkit
+
+import akka.actor.ActorSystem
+import akka.testkit.{ TestKit, TestProbe }
+import lerna.akka.entityreplication.raft.ActorSpec
+
+class CustomTestProbeSpec extends TestKit(ActorSystem("CustomTestProbeSpec")) with ActorSpec {
+  import CustomTestProbe._
+
+  "CustomTestProbe.fishMatchMessagesWhile" should {
+
+    "pass when the probe receives messages that match the condition" in {
+      val probe = TestProbe()
+
+      probe.ref ! "match"
+
+      var called = false
+      probe.fishMatchMessagesWhile(messages = 1) {
+        case "match" =>
+          called = true
+      }
+      called should be(true)
+    }
+
+    "throw AssertionError when the probe doesn't receive any messages that match the condition" in {
+      val probe = TestProbe()
+
+      probe.ref ! "invalid"
+
+      intercept[AssertionError] {
+        probe.fishMatchMessagesWhile(messages = 1) {
+          case "match" =>
+        }
+      }
+    }
+
+    "ignore messages that doesn't match the condition" in {
+      val probe = TestProbe()
+
+      probe.ref ! "ignore"
+      probe.ref ! "ignore"
+      probe.ref ! "match"
+
+      var called = false
+      probe.fishMatchMessagesWhile(messages = 1) {
+        case "match" =>
+          called = true
+      }
+      called should be(true)
+    }
+
+    "call the function until the count of matched messages reaches 'messages' parameter" in {
+      val probe = TestProbe()
+
+      probe.ref ! "match"
+      probe.ref ! "match"
+
+      var count = 0
+      probe.fishMatchMessagesWhile(messages = 2) {
+        case "match" =>
+          count = count + 1
+      }
+      count should be(2)
+    }
+  }
+}


### PR DESCRIPTION
Fixes #105

## Locations that uses `termAt`

### publishAppendEntries

> ```scala
>   private[this] def publishAppendEntries(): Unit = {
>     resetHeartbeatTimeoutTimer()
>     otherMemberIndexes.foreach { memberIndex =>
>       val nextIndex    = currentData.nextIndexFor(memberIndex)
>       val prevLogIndex = nextIndex.prev()
>       val prevLogTerm  = currentData.replicatedLog.termAt(prevLogIndex)
> ```
> **[akka-entity-replication/Leader.scala at v2.0.0 · lerna-stack/akka-entity-replication](https://github.com/lerna-stack/akka-entity-replication/blob/v2.0.0/src/main/scala/lerna/akka/entityreplication/raft/Leader.scala#L215-L220)**

affected part of #105

### hasMatchLogEntry

> ```scala
>   def hasMatchLogEntry(prevLogIndex: LogEntryIndex, prevLogTerm: Term): Boolean = {
>     // リーダーにログが無い場合は LogEntryIndex.initial が送られてくる。
>     // そのケースでは AppendEntries が成功したとみなしたいので、
>     // prevLogIndex が LogEntryIndex.initial の場合はマッチするログが存在するとみなす
>     prevLogIndex == LogEntryIndex.initial() || replicatedLog.termAt(prevLogIndex).contains(prevLogTerm)
>   }
> ```
> **[akka-entity-replication/RaftMemberData.scala at v2.0.0 · lerna-stack/akka-entity-replication](https://github.com/lerna-stack/akka-entity-replication/blob/v2.0.0/src/main/scala/lerna/akka/entityreplication/raft/RaftMemberData.scala#L280-L285)**

No impact, because `termAt` doesn't take `prevLogIndex` if it is `LogEntryIndex.initial()`.

### resolveSnapshotTargets

> ```scala
>   def resolveSnapshotTargets(): (Term, LogEntryIndex, Set[NormalizedEntityId]) = {
>     replicatedLog.termAt(lastApplied) match {
>       case Some(lastAppliedTerm) =>
>         (
>           lastAppliedTerm,
>           lastApplied,
>           replicatedLog.sliceEntriesFromHead(lastApplied).flatMap(_.event.entityId.toSeq).toSet,
>         )
>       case None =>
>         // This exception is not thrown unless there is a bug
>         throw new IllegalStateException(s"Term not found at lastApplied: $lastApplied")
>     }
>   }
> ```
> **[akka-entity-replication/RaftMemberData.scala at v2.0.0 · lerna-stack/akka-entity-replication](https://github.com/lerna-stack/akka-entity-replication/blob/v2.0.0/src/main/scala/lerna/akka/entityreplication/raft/RaftMemberData.scala#L291-L303)**

No impact, because `resoveSnapshotTargets` isn't call when `lastApplied` is `LogEntryIndex.initial()`.
`hasLogEntriesThatCanBeCompacted` should return false in the situation.

> ```scala
>     if (
>       currentData.replicatedLog.entries.size >= settings.compactionLogSizeThreshold
>       && currentData.hasLogEntriesThatCanBeCompacted
>     ) {
>       val (term, logEntryIndex, entityIds) = currentData.resolveSnapshotTargets
> ```
> **[akka-entity-replication/RaftActor.scala at v2.0.0 · lerna-stack/akka-entity-replication](https://github.com/lerna-stack/akka-entity-replication/blob/v2.0.0/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala#L380-L384)**

> ```scala
>   def hasLogEntriesThatCanBeCompacted: Boolean = {
>     replicatedLog.sliceEntriesFromHead(lastApplied).nonEmpty
>   }
> ```
> **[akka-entity-replication/RaftMemberData.scala at v2.0.0 · lerna-stack/akka-entity-replication](https://github.com/lerna-stack/akka-entity-replication/blob/v2.0.0/src/main/scala/lerna/akka/entityreplication/raft/RaftMemberData.scala#L287-L289)**

`sliceEntriesFromHead` passed following test:

```scala
      val logEntries = Seq(
        LogEntry(LogEntryIndex(1), EntityEvent(None, "a"), Term(1)),
        LogEntry(LogEntryIndex(2), EntityEvent(None, "b"), Term(1)),
        LogEntry(LogEntryIndex(3), EntityEvent(None, "c"), Term(1)),
      )

      val log = new ReplicatedLog(logEntries)

      log.sliceEntriesFromHead(to = LogEntryIndex.initial()) should be(empty)
```