### PR TITLE
Raft actors start automatically after an initialization of `ClusterReplication`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 [Unreleased]: https://github.com/lerna-stack/akka-entity-replication/compare/v2.0.0...master
 
+### Added
+- Efficient recovery of commit log store, which is on the query side [#112](https://github.com/lerna-stack/akka-entity-replication/issues/112)
+
+  This change will improve the performance of the recovery on the query side.
+  You should migrate settings described at [Migration Guide](docs/migration_guide.md#210-from-200).
+
+- Raft actors start automatically after an initialization of `ClusterReplication` [#118](https://github.com/lerna-stack/akka-entity-replication/issues/118)
+
+  This feature is enabled only by using `typed.ClusterReplication`.
+  It is highly recommended that you switch using the typed API since the classic API was deprecated.
+
 ### Changed
 - Bump up Akka version to 2.6.17 [PR#98](https://github.com/lerna-stack/akka-entity-replication/pull/98)
 
   This change will show you deserialization warnings during the rolling update, it's safe to ignore. 
   For more details, see [Akka 2.6.16 release note](https://akka.io/blog/news/2021/08/19/akka-2.6.16-released#rolling-upgrades)
-
-- Efficient recovery of commit log store, which is on the query side [PR#112](https://github.com/lerna-stack/akka-entity-replication/issues/112)
-
-  This change will improve the performance of the recovery on the query side.
-  You should migrate settings described at [Migration Guide](docs/migration_guide.md#210-from-200).
 
 ### Fixed
 - TestKit throws "Shard received unexpected message" exception after the entity passivated [PR#100](https://github.com/lerna-stack/akka-entity-replication/pull/100)

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ For more information on how to implement an application using this library, plea
 - [Implementation Guide](docs/typed/implementation_guide.md)
 - [Testing Guide](docs/typed/testing_guide.md)
 
+**NOTE**: It is highly recommended that you carefully do cluster operations.
+For more details, please refer to [Operation Guide](docs/operation_guide.md).
+
 ## For Contributors
 
 [CONTRIBUTING](CONTRIBUTING.md) may help us.

--- a/docs/operation_guide.md
+++ b/docs/operation_guide.md
@@ -1,0 +1,68 @@
+# Operation Guide
+
+**Principle: Don't terminate all Raft members at the same time.**
+
+To achieve this principle, you carefully do cluster operations.
+This document supposes that you will use three `multi-raft-roles` (`replica-group-1`, `replica-group-2`, `replica-group-3`).
+
+
+## Start a new cluster
+The important point is to start only one node in at least one role.
+
+A possible full cluster start operation is the following:
+* Start a node (or multiple nodes) with role `replica-group-1`.
+* Start a node (or multiple nodes) with role `replica-group-2`.
+* Start exactly one node with `replica-group-3`.
+
+You can do the above operations simultaneously.
+You have to wait for all Raft members to be running
+before adding more nodes with `replica-group-3`.
+The waiting time depends on your settings, such as the following:
+* `lerna.akka.entityreplication.raft.election-timeout`
+* `lerna.akka.entityreplication.raft.heartbeat-interval`
+* `lerna.akka.entityreplication.raft.number-of-shards`
+* `lerna.akka.entityreplication.raft.raft-actor-auto-start`
+
+
+## Add nodes
+Don't add nodes with different roles at the same time.
+
+Any of the following operations is possible:
+* Add a node (or multiple nodes) with `replica-group-1`.
+* Add a node (or multiple nodes) with `replica-group-2`.
+* Add a node (or multiple nodes) with `replica-group-3`.
+
+You **should not** do the above operations simultaneously.
+You have to wait for all Raft members to be running
+before adding more nodes or removing nodes.
+The waiting time depends on your settings, such as the following:
+* `lerna.akka.entityreplication.raft.election-timeout`
+* `lerna.akka.entityreplication.raft.heartbeat-interval`
+
+Any of the following operations is possible but **not recommended**.
+It is because you cannot ensure that any of nodes with untouched roles won't crash.
+* Add nodes with `replica-group-1` and nodes with `replica-group-2`.
+* Add nodes with `replica-group-2` and nodes with `replica-group-3`.
+* Add nodes with `replica-group-3` and nodes with `replica-group-1`.
+
+
+## Remove nodes
+Don't remove nodes with different roles at the same time.
+
+Any of the following operations is possible:
+* Remove a node (or multiple nodes) with `replica-group-1`.
+* Remove a node (or multiple nodes) with `replica-group-2`.
+* Remove a node (or multiple nodes) with `replica-group-3`.
+
+You **should not** do the above operations simultaneously.
+You have to wait for all Raft members to be running
+before adding nodes or removing more nodes.
+Waiting time depends on your settings, such as the following:
+* `lerna.akka.entityreplication.raft.election-timeout`
+* `lerna.akka.entityreplication.raft.heartbeat-interval`
+
+Any of the following operations is possible but **not recommended**.
+It is because you cannot ensure that any of nodes with untouched roles won't crash.
+* Remove nodes with `replica-group-1` and nodes with `replica-group-2`.
+* Remove nodes with `replica-group-2` and nodes with `replica-group-3`.
+* Remove nodes with `replica-group-3` and nodes with `replica-group-1`.

--- a/src/main/mima-filters/2.0.0.backwards.excludes/pr-119-raft-actor-auto-start.excludes
+++ b/src/main/mima-filters/2.0.0.backwards.excludes/pr-119-raft-actor-auto-start.excludes
@@ -1,0 +1,6 @@
+# It is safe to exclude the following since ClusterReplicationGuardian is package-private.
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.akka.entityreplication.ClusterReplicationGuardian#Start.copy")
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.akka.entityreplication.ClusterReplicationGuardian#Start.this")
+ProblemFilters.exclude[MissingTypesProblem]("lerna.akka.entityreplication.ClusterReplicationGuardian$Start$")
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.akka.entityreplication.ClusterReplicationGuardian#Start.apply")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("lerna.akka.entityreplication.ClusterReplicationGuardian#Start.unapply")

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -63,6 +63,14 @@ lerna.akka.entityreplication {
       // Maximum number of messages that are buffered by a ShardRegion actor.
       // Make it smaller than the default value to discard messages that are too old.
       buffer-size = 1000
+
+      // akka-entity-replication always enables Remember Entities.
+      // It's not possible to overwite this `remember-entities` setting.
+      // akka-entity-replication enables this setting automatically even if it was disabled.
+      remember-entities = on
+      // `ddata` mode is a good choice if you use typed ClusterReplication.
+      remember-entities-store = ddata
+
     }
 
     // Raft actors will start automatically after initialization of ClusterReplication.

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -68,8 +68,11 @@ lerna.akka.entityreplication {
       // It's not possible to overwite this `remember-entities` setting.
       // akka-entity-replication enables this setting automatically even if it was disabled.
       remember-entities = on
-      // `ddata` mode is a good choice if you use typed ClusterReplication.
-      remember-entities-store = ddata
+
+      // akka-entity-replication always uses `ddata` mode.
+      // It's not possible to overwrite this `remember-entities-store` setting.
+      // akka-entity-replication throws an exception when creating RaftSettings if this setting is not `ddata`.
+      remember-entities-store = "ddata"
 
     }
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -63,14 +63,6 @@ lerna.akka.entityreplication {
       // Maximum number of messages that are buffered by a ShardRegion actor.
       // Make it smaller than the default value to discard messages that are too old.
       buffer-size = 1000
-
-      // akka-entity-replication always enables Remember Entities.
-      // It's not possible to overwite this `remember-entities` setting.
-      // akka-entity-replication enables this setting automatically even if it was disabled.
-      remember-entities = on
-      // `ddata` mode is a good choice if you use typed ClusterReplication.
-      remember-entities-store = ddata
-
     }
 
     // Raft actors will start automatically after initialization of ClusterReplication.

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -69,11 +69,11 @@ lerna.akka.entityreplication {
     // This feature will be enabled only if you will use typed ClusterReplication.
     raft-actor-auto-start {
       // Frequency at which a batch of Raft actors will start
-      frequency = 200ms
+      frequency = 3s
       // The number of Raft actors to be started at a specified interval
       number-of-actors = 5
       // ClusterReplication retries start requests with this interval if it does not receive replies.
-      retry-interval = 100ms
+      retry-interval = 5s
     }
 
     // data persistent settings

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -68,11 +68,8 @@ lerna.akka.entityreplication {
       // It's not possible to overwite this `remember-entities` setting.
       // akka-entity-replication enables this setting automatically even if it was disabled.
       remember-entities = on
-
-      // akka-entity-replication always uses `ddata` mode.
-      // It's not possible to overwrite this `remember-entities-store` setting.
-      // akka-entity-replication throws an exception when creating RaftSettings if this setting is not `ddata`.
-      remember-entities-store = "ddata"
+      // `ddata` mode is a good choice if you use typed ClusterReplication.
+      remember-entities-store = ddata
 
     }
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -65,6 +65,17 @@ lerna.akka.entityreplication {
       buffer-size = 1000
     }
 
+    // Raft actors will start automatically after initialization of ClusterReplication.
+    // This feature will be enabled only if you will use typed ClusterReplication.
+    raft-actor-auto-start {
+      // Frequency at which a batch of Raft actors will start
+      frequency = 200ms
+      // The number of Raft actors to be started at a specified interval
+      number-of-actors = 5
+      // ClusterReplication retries start requests with this interval if it does not receive replies.
+      retry-interval = 100ms
+    }
+
     // data persistent settings
     persistence {
       // Absolute path to the journal plugin configuration entry.

--- a/src/main/scala/lerna/akka/entityreplication/ReplicationRegion.scala
+++ b/src/main/scala/lerna/akka/entityreplication/ReplicationRegion.scala
@@ -294,9 +294,9 @@ private[entityreplication] class ReplicationRegion(
     // Only the oldest node should trigger all possible Raft actor starts.
     // Newer nodes don't have to trigger starts since the oldest has already done such triggers.
     // This optimization reduces unnecessary message exchanges.
+    val membersInSelfRegion = regions(selfMemberIndex).toVector
     def isOldest: Boolean = {
-      val membersInSelfRegion = regions(selfMemberIndex).toVector
-      val oldestMember        = membersInSelfRegion.minOption(Member.ageOrdering)
+      val oldestMember = membersInSelfRegion.minOption(Member.ageOrdering)
       Option(cluster.selfMember) == oldestMember
     }
     val shouldTriggerStarting = possibleRaftActorIds.nonEmpty && isOldest
@@ -310,6 +310,11 @@ private[entityreplication] class ReplicationRegion(
       context.spawn[Nothing](
         ReplicationRegionRaftActorStarter(shardRegion, possibleRaftActorIds, settings.raftSettings),
         "RaftActorStarter",
+      )
+      log.info(
+        "Started ReplicationRegionRaftActorStarter for Shard Region [{}] (members: [{}])",
+        shardRegion,
+        membersInSelfRegion,
       )
     }
   }

--- a/src/main/scala/lerna/akka/entityreplication/ReplicationRegion.scala
+++ b/src/main/scala/lerna/akka/entityreplication/ReplicationRegion.scala
@@ -151,11 +151,7 @@ private[entityreplication] class ReplicationRegion(
         typeName = raftShardingTypeName(typeName, memberIndex),
         entityProps = createRaftActorProps(),
         settings = ClusterShardingSettings(settings.raftSettings.clusterShardingConfig)
-          .withRole(memberIndex.role)
-          // All Raft actors should always be running
-          // since they perform some processing (e.g. event sourcing) in parallel with user requests.
-          // RememberEntities ensures that all Raft actors restart after a rebalance or entity crash.
-          .withRememberEntities(true),
+          .withRole(memberIndex.role),
         extractEntityId,
         extractShardId,
       )

--- a/src/main/scala/lerna/akka/entityreplication/ReplicationRegion.scala
+++ b/src/main/scala/lerna/akka/entityreplication/ReplicationRegion.scala
@@ -151,7 +151,11 @@ private[entityreplication] class ReplicationRegion(
         typeName = raftShardingTypeName(typeName, memberIndex),
         entityProps = createRaftActorProps(),
         settings = ClusterShardingSettings(settings.raftSettings.clusterShardingConfig)
-          .withRole(memberIndex.role),
+          .withRole(memberIndex.role)
+          // All Raft actors should always be running
+          // since they perform some processing (e.g. event sourcing) in parallel with user requests.
+          // RememberEntities ensures that all Raft actors restart after a rebalance or entity crash.
+          .withRememberEntities(true),
         extractEntityId,
         extractShardId,
       )

--- a/src/main/scala/lerna/akka/entityreplication/ReplicationRegionRaftActorStarter.scala
+++ b/src/main/scala/lerna/akka/entityreplication/ReplicationRegionRaftActorStarter.scala
@@ -1,0 +1,105 @@
+package lerna.akka.entityreplication
+
+import akka.actor.NoSerializationVerificationNeeded
+import akka.actor.typed.scaladsl.adapter.TypedActorRefOps
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors }
+import akka.actor.typed.{ ActorRef, Behavior }
+import akka.cluster.sharding.ShardRegion
+import akka.{ actor => classic }
+import lerna.akka.entityreplication.raft.RaftSettings
+
+import scala.concurrent.duration.DurationInt
+
+/** Triggers all specified Raft actor starts.
+  *
+  * This actor trigger a start at a constant rate.
+  * After this actor triggers all starts, it will stop itself.
+  */
+private[entityreplication] object ReplicationRegionRaftActorStarter {
+
+  private sealed trait Command extends NoSerializationVerificationNeeded
+
+  /** Triggers a batch of Raft actor starts. */
+  private case object StartBatch extends Command
+
+  /** Re-sends starts that hasn't ACKed yet. */
+  private case object ResendUnAckedStartEntity extends Command
+
+  /** Informs that starting the entity with the given EntityId triggered. */
+  private final case class ClassicStartEntityAck(entityId: ShardRegion.EntityId) extends Command
+
+  def apply(
+      shardRegion: classic.ActorRef,
+      ids: Set[ShardRegion.EntityId],
+      settings: RaftSettings,
+  ): Behavior[Nothing] = {
+    Behaviors
+      .setup[Command] { context =>
+        val startEntityAckAdapter =
+          context.messageAdapter[ShardRegion.StartEntityAck](ack => ClassicStartEntityAck(ack.entityId))
+        Behaviors.withTimers { timers =>
+          timers.startTimerWithFixedDelay(StartBatch, 0.milli, settings.raftActorAutoStartFrequency)
+          timers.startTimerWithFixedDelay(ResendUnAckedStartEntity, settings.raftActorAutoStartRetryInterval)
+          val starter = new ReplicationRegionRaftActorStarter(
+            context,
+            shardRegion,
+            startEntityAckAdapter,
+            settings.raftActorAutoStartNumberOfActors,
+          )
+          starter.behavior(ids, Set.empty)
+        }
+      }.narrow[Nothing]
+  }
+
+}
+
+private[entityreplication] final class ReplicationRegionRaftActorStarter private (
+    context: ActorContext[ReplicationRegionRaftActorStarter.Command],
+    shardRegion: classic.ActorRef,
+    startEntityAckAdapter: ActorRef[ShardRegion.StartEntityAck],
+    batchSize: Int,
+) {
+  import ReplicationRegionRaftActorStarter._
+
+  private def behavior(
+      remainingIds: Set[ShardRegion.EntityId],
+      ackWaitingIds: Set[ShardRegion.EntityId],
+  ): Behavior[Command] = {
+    val isDone = remainingIds.isEmpty && ackWaitingIds.isEmpty
+    if (isDone) {
+      Behaviors.stopped { () =>
+        context.log.info("Triggered starting all Raft actors on Shard Region [{}]", shardRegion)
+      }
+    } else {
+      Behaviors.receiveMessage {
+        case StartBatch =>
+          val (newBatch, newRemainingIds) = remainingIds.splitAt(batchSize)
+          val newAckWaitingIds            = ackWaitingIds.union(newBatch)
+          newBatch.foreach(sendStartEntity)
+          context.log.info("Sent StartEntity(s) to trigger [{}] Raft actors starting.", newBatch.size)
+          behavior(newRemainingIds, newAckWaitingIds)
+        case ClassicStartEntityAck(entityId) =>
+          context.log.debug("Received StartEntityAck [{}].", entityId)
+          val newAckWaitingIds = ackWaitingIds - entityId
+          behavior(remainingIds, newAckWaitingIds)
+        case ResendUnAckedStartEntity =>
+          context.log.info(
+            "Found [{}] Raft actors waiting for StartEntityAck. Resends StartEntity for those actors.",
+            ackWaitingIds.size,
+          )
+          ackWaitingIds.foreach(sendStartEntity)
+          Behaviors.same
+      }
+    }
+  }
+
+  /** Sends StartEntity to the Shard Region.
+    *
+    * This actor will receives StartEntityAck from the Shard Region.
+    */
+  private def sendStartEntity(entityId: ShardRegion.EntityId): Unit = {
+    val message = ShardRegion.StartEntity(entityId)
+    shardRegion.tell(message, startEntityAckAdapter.toClassic)
+  }
+
+}

--- a/src/main/scala/lerna/akka/entityreplication/ReplicationRegionRaftActorStarter.scala
+++ b/src/main/scala/lerna/akka/entityreplication/ReplicationRegionRaftActorStarter.scala
@@ -69,6 +69,7 @@ private[entityreplication] final class ReplicationRegionRaftActorStarter private
     if (isDone) {
       Behaviors.stopped { () =>
         context.log.info("Triggered starting all Raft actors on Shard Region [{}]", shardRegion)
+        context.log.info("Stops itself [{}]", context.self)
       }
     } else {
       Behaviors.receiveMessage {

--- a/src/main/scala/lerna/akka/entityreplication/ReplicationRegionRaftActorStarter.scala
+++ b/src/main/scala/lerna/akka/entityreplication/ReplicationRegionRaftActorStarter.scala
@@ -83,11 +83,13 @@ private[entityreplication] final class ReplicationRegionRaftActorStarter private
           val newAckWaitingIds = ackWaitingIds - entityId
           behavior(remainingIds, newAckWaitingIds)
         case ResendUnAckedStartEntity =>
-          context.log.info(
-            "Found [{}] Raft actors waiting for StartEntityAck. Resends StartEntity for those actors.",
-            ackWaitingIds.size,
-          )
-          ackWaitingIds.foreach(sendStartEntity)
+          if (ackWaitingIds.nonEmpty) {
+            context.log.info(
+              "Found [{}] Raft actors waiting for StartEntityAck. Resends StartEntity for those actors.",
+              ackWaitingIds.size,
+            )
+            ackWaitingIds.foreach(sendStartEntity)
+          }
           Behaviors.same
       }
     }

--- a/src/main/scala/lerna/akka/entityreplication/ReplicationRegionRaftActorStarter.scala
+++ b/src/main/scala/lerna/akka/entityreplication/ReplicationRegionRaftActorStarter.scala
@@ -75,8 +75,10 @@ private[entityreplication] final class ReplicationRegionRaftActorStarter private
         case StartBatch =>
           val (newBatch, newRemainingIds) = remainingIds.splitAt(batchSize)
           val newAckWaitingIds            = ackWaitingIds.union(newBatch)
-          newBatch.foreach(sendStartEntity)
-          context.log.info("Sent StartEntity(s) to trigger [{}] Raft actors starting.", newBatch.size)
+          if (newBatch.nonEmpty) {
+            newBatch.foreach(sendStartEntity)
+            context.log.info("Sent StartEntity(s) to trigger [{}] Raft actors starting.", newBatch.size)
+          }
           behavior(newRemainingIds, newAckWaitingIds)
         case ClassicStartEntityAck(entityId) =>
           context.log.debug("Received StartEntityAck [{}].", entityId)

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftSettings.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftSettings.scala
@@ -48,6 +48,12 @@ trait RaftSettings {
 
   def clusterShardingConfig: Config
 
+  def raftActorAutoStartFrequency: FiniteDuration
+
+  def raftActorAutoStartNumberOfActors: Int
+
+  def raftActorAutoStartRetryInterval: FiniteDuration
+
   def journalPluginId: String
 
   def journalPluginAdditionalConfig: Config

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftSettingsImpl.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftSettingsImpl.scala
@@ -1,6 +1,5 @@
 package lerna.akka.entityreplication.raft
 
-import akka.cluster.sharding.ClusterShardingSettings
 import com.typesafe.config.{ Config, ConfigFactory }
 
 import java.util.concurrent.TimeUnit.NANOSECONDS
@@ -133,12 +132,7 @@ private[entityreplication] object RaftSettingsImpl {
     val snapshotSyncPersistenceOperationTimeout: FiniteDuration =
       config.getDuration("snapshot-sync.persistence-operation-timeout").toScala
 
-    val clusterShardingConfig: Config                    = config.getConfig("sharding")
-    val clusterShardingSettings: ClusterShardingSettings = ClusterShardingSettings(clusterShardingConfig)
-    require(
-      clusterShardingSettings.rememberEntitiesStore == "ddata",
-      s"remember-entities-store (${clusterShardingSettings.rememberEntitiesStore}) should always be `ddata`.",
-    )
+    val clusterShardingConfig: Config = config.getConfig("sharding")
 
     val raftActorAutoStartFrequency: FiniteDuration =
       config.getDuration("raft-actor-auto-start.frequency").toScala

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftSettingsImpl.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftSettingsImpl.scala
@@ -1,5 +1,6 @@
 package lerna.akka.entityreplication.raft
 
+import akka.cluster.sharding.ClusterShardingSettings
 import com.typesafe.config.{ Config, ConfigFactory }
 
 import java.util.concurrent.TimeUnit.NANOSECONDS
@@ -132,7 +133,12 @@ private[entityreplication] object RaftSettingsImpl {
     val snapshotSyncPersistenceOperationTimeout: FiniteDuration =
       config.getDuration("snapshot-sync.persistence-operation-timeout").toScala
 
-    val clusterShardingConfig: Config = config.getConfig("sharding")
+    val clusterShardingConfig: Config                    = config.getConfig("sharding")
+    val clusterShardingSettings: ClusterShardingSettings = ClusterShardingSettings(clusterShardingConfig)
+    require(
+      clusterShardingSettings.rememberEntitiesStore == "ddata",
+      s"remember-entities-store (${clusterShardingSettings.rememberEntitiesStore}) should always be `ddata`.",
+    )
 
     val raftActorAutoStartFrequency: FiniteDuration =
       config.getDuration("raft-actor-auto-start.frequency").toScala

--- a/src/main/scala/lerna/akka/entityreplication/typed/internal/ClusterReplicationImpl.scala
+++ b/src/main/scala/lerna/akka/entityreplication/typed/internal/ClusterReplicationImpl.scala
@@ -31,6 +31,9 @@ private[entityreplication] class ClusterReplicationImpl(system: ActorSystem[_]) 
       case ReplicationEnvelope(entityId, _) =>
         Math.abs(entityId.hashCode % settings.raftSettings.numberOfShards).toString
     }
+    val possibleShardIds: Set[untyped.ReplicationRegion.ShardId] = {
+      (0 until settings.raftSettings.numberOfShards).map(_.toString).toSet
+    }
     val interceptor = new BehaviorInterceptor[RaftProtocol.EntityCommand, Any] {
       override def aroundReceive(
           ctx: TypedActorContext[RaftProtocol.EntityCommand],
@@ -62,6 +65,7 @@ private[entityreplication] class ClusterReplicationImpl(system: ActorSystem[_]) 
           settings = settings,
           extractEntityId = extractEntityId,
           extractShardId = extractShardId,
+          possibleShardIds = possibleShardIds,
         )
     region.toTyped
   }

--- a/src/multi-jvm/resources/multi-jvm-testing.conf
+++ b/src/multi-jvm/resources/multi-jvm-testing.conf
@@ -44,9 +44,9 @@ lerna.akka.entityreplication.raft.number-of-shards = 5
 # All Raft actors will start automatically if typed.ClusterReplication.init is used.
 # Overwrite related settings to stabilize tests and reduce the test time.
 lerna.akka.entityreplication.raft.raft-actor-auto-start {
-  frequency = 100ms
+  frequency = 200ms
   number-of-actors = 2
-  retry-interval = 50ms
+  retry-interval = 500ms
 }
 
 lerna.akka.entityreplication.raft {

--- a/src/multi-jvm/resources/multi-jvm-testing.conf
+++ b/src/multi-jvm/resources/multi-jvm-testing.conf
@@ -38,6 +38,17 @@ akka.actor.testkit.typed {
 
 lerna.akka.entityreplication.raft.election-timeout = 1000 ms
 
+# Use the small number of shards to stabilize tests.
+lerna.akka.entityreplication.raft.number-of-shards = 5
+
+# All Raft actors will start automatically if typed.ClusterReplication.init is used.
+# Overwrite related settings to stabilize tests and reduce the test time.
+lerna.akka.entityreplication.raft.raft-actor-auto-start {
+  frequency = 100ms
+  number-of-actors = 2
+  retry-interval = 50ms
+}
+
 lerna.akka.entityreplication.raft {
   persistence {
     journal.plugin = "akka.persistence.journal.proxy"

--- a/src/multi-jvm/scala/lerna/akka/entityreplication/ReplicationRegionSpec.scala
+++ b/src/multi-jvm/scala/lerna/akka/entityreplication/ReplicationRegionSpec.scala
@@ -200,6 +200,7 @@ class ReplicationRegionSpec extends MultiNodeSpec(ReplicationRegionSpecConfig) w
               ClusterReplicationSettings.create(system),
               DummyReplicationActor.extractEntityId,
               DummyReplicationActor.extractShardId,
+              possibleShardIds = Set.empty,
               maybeCommitLogStore = None,
             ) {
               override def createRaftActorProps(): Props =

--- a/src/multi-jvm/scala/lerna/akka/entityreplication/raft/RaftActorMultiNodeSpec.scala
+++ b/src/multi-jvm/scala/lerna/akka/entityreplication/raft/RaftActorMultiNodeSpec.scala
@@ -595,6 +595,7 @@ class RaftActorMultiNodeSpec extends MultiNodeSpec(RaftActorSpecConfig) with STM
           ClusterReplicationSettings.create(system),
           extractEntityId,
           extractShardId,
+          possibleShardIds = Set.empty,
           maybeCommitLogStore = None,
         ) {
           override def createRaftActorProps(): Props = {

--- a/src/multi-jvm/scala/lerna/akka/entityreplication/typed/ClusterReplicationMultiNodeSpec.scala
+++ b/src/multi-jvm/scala/lerna/akka/entityreplication/typed/ClusterReplicationMultiNodeSpec.scala
@@ -79,22 +79,20 @@ abstract class ClusterReplicationMultiNodeSpec
           ShardRegion.ShardState(raftActorId, Set(raftActorId))
         }))
       }
-      Set(node1, node2, node3).foreach { node =>
-        runOn(node) {
-          val shardingTypeName = {
-            val clusterReplicationTypeName = GetEntityContextEntity.typeKey.name
-            ReplicationRegion.raftShardingTypeName(clusterReplicationTypeName, memberIndexes(node))
-          }
-          awaitAssert(
-            {
-              // We have to get the shard region in this awaitAssert assertion
-              // since the getting shard region would also succeed eventually.
-              ClusterSharding(system).shardRegion(shardingTypeName) ! ShardRegion.GetShardRegionState
-              expectMsg(expectedShardRegionState)
-            },
-            max = autoStartTimeout,
-          )
+      runOn(node1, node2, node3) {
+        val shardingTypeName = {
+          val clusterReplicationTypeName = GetEntityContextEntity.typeKey.name
+          ReplicationRegion.raftShardingTypeName(clusterReplicationTypeName, memberIndexes(myself))
         }
+        awaitAssert(
+          {
+            // We have to get the shard region in this awaitAssert assertion
+            // since the getting shard region would also succeed eventually.
+            ClusterSharding(system).shardRegion(shardingTypeName) ! ShardRegion.GetShardRegionState
+            expectMsg(expectedShardRegionState)
+          },
+          max = autoStartTimeout,
+        )
       }
       enterBarrier("All Raft actors are running.")
     }

--- a/src/multi-jvm/scala/lerna/akka/entityreplication/typed/ClusterReplicationMultiNodeSpec.scala
+++ b/src/multi-jvm/scala/lerna/akka/entityreplication/typed/ClusterReplicationMultiNodeSpec.scala
@@ -5,7 +5,7 @@ import akka.actor.typed.ActorRef
 import akka.cluster.sharding.{ ClusterSharding, ShardRegion }
 import akka.remote.testconductor.RoleName
 import akka.remote.testkit.{ MultiNodeConfig, MultiNodeSpec }
-import com.typesafe.config.{ Config, ConfigFactory, ConfigValueFactory }
+import com.typesafe.config.{ ConfigFactory, ConfigValueFactory }
 import lerna.akka.entityreplication.raft.routing.MemberIndex
 import lerna.akka.entityreplication.{ ReplicationRegion, STMultiNodeSerializable, STMultiNodeSpec }
 
@@ -52,7 +52,6 @@ abstract class ClusterReplicationMultiNodeSpec
 
   import ClusterReplicationMultiNodeSpec._
   import ClusterReplicationMultiNodeSpecConfig._
-
   import akka.actor.typed.scaladsl.adapter._
 
   private val settings                 = ClusterReplicationSettings(system.toTyped)

--- a/src/multi-jvm/scala/lerna/akka/entityreplication/typed/ClusterReplicationMultiNodeSpec.scala
+++ b/src/multi-jvm/scala/lerna/akka/entityreplication/typed/ClusterReplicationMultiNodeSpec.scala
@@ -23,22 +23,12 @@ object ClusterReplicationMultiNodeSpecConfig extends MultiNodeConfig {
     node3 -> MemberIndex("member-3"),
   )
 
-  private val testConfig: Config =
-    ConfigFactory.parseString(
-      """
-        |# Overwrite to speed up tests.
-        |lerna.akka.entityreplication.raft.number-of-shards = 50
-        |lerna.akka.entityreplication.raft.raft-actor-auto-start.number-of-actors = 20
-        |lerna.akka.entityreplication.raft.raft-actor-auto-start.frequency = 100ms
-        |""".stripMargin,
-    )
-
   commonConfig(
     debugConfig(false)
       .withValue(
         "lerna.akka.entityreplication.raft.multi-raft-roles",
         ConfigValueFactory.fromIterable(memberIndexes.values.map(_.role).toSet.asJava),
-      ).withFallback(testConfig)
+      )
       .withFallback(ConfigFactory.parseResources("multi-jvm-testing.conf")),
   )
   nodeConfig(node1)(ConfigFactory.parseString(s"""

--- a/src/multi-jvm/scala/lerna/akka/entityreplication/typed/EventSourcingAutoStartMultiNodeSpec.scala
+++ b/src/multi-jvm/scala/lerna/akka/entityreplication/typed/EventSourcingAutoStartMultiNodeSpec.scala
@@ -1,0 +1,284 @@
+package lerna.akka.entityreplication.typed
+
+import akka.actor.ExtendedActorSystem
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.adapter.ClassicActorSystemOps
+import akka.actor.typed.{ ActorRef, ActorSystem }
+import akka.event.Logging
+import akka.persistence.journal.{ Tagged, WriteEventAdapter }
+import akka.persistence.query.scaladsl.CurrentEventsByTagQuery
+import akka.persistence.query.{ EventEnvelope, Offset, PersistenceQuery }
+import akka.remote.testconductor.RoleName
+import akka.remote.testkit.{ MultiNodeConfig, MultiNodeSpec }
+import com.typesafe.config.{ Config, ConfigFactory }
+import lerna.akka.entityreplication.util.AtLeastOnceComplete
+import lerna.akka.entityreplication.{ STMultiNodeSerializable, STMultiNodeSpec }
+
+import scala.concurrent.duration.{ DurationInt, FiniteDuration }
+
+object EventSourcingAutoStartMultiNodeSpecConfig extends MultiNodeConfig {
+  // node1~3 form the first cluster.
+  val node1: RoleName = role("node1")
+  val node2: RoleName = role("node2")
+  val node3: RoleName = role("node3")
+
+  // node4~6 form the second cluster after the first cluster stops.
+  val node4: RoleName = role("node4")
+  val node5: RoleName = role("node5")
+  val node6: RoleName = role("node6")
+
+  /** ClusterReplication should persist events eventually within this timeout. */
+  val propagationTimeout: FiniteDuration = 10.seconds
+
+  private val testConfig: Config =
+    ConfigFactory.parseString(s"""
+        |lerna.akka.entityreplication.raft.multi-raft-roles = ["member-1", "member-2", "member-3"]
+        |lerna.akka.entityreplication.recovery-entity-timeout = 1s
+        |
+        |# Overwrite to speed up tests.
+        |# All Raft actors will start immediately after a cluster startup.
+        |lerna.akka.entityreplication {
+        |  raft {
+        |    number-of-shards = 3
+        |    raft-actor-auto-start {
+        |      number-of-actors = 3
+        |    }
+        |  }
+        |}
+        |
+        |inmemory-journal {
+        |  event-adapters {
+        |    catalog-tagging = "lerna.akka.entityreplication.typed.EventSourcingAutoStartMultiNodeSpec$$CatalogEventAdapter"
+        |  }
+        |  event-adapter-bindings {
+        |    "lerna.akka.entityreplication.typed.EventSourcingAutoStartMultiNodeSpec$$Catalog$$Event" = catalog-tagging
+        |  }
+        |}
+        |""".stripMargin)
+
+  commonConfig(
+    debugConfig(false)
+      .withFallback(testConfig)
+      .withFallback(ConfigFactory.parseResources("multi-jvm-testing.conf")),
+  )
+
+  // Use invalid plugins to emulate journal failures.
+  private val invalidEventSourcedPersistenceConfig =
+    ConfigFactory.parseString("""
+        |lerna.akka.entityreplication.raft.eventsourced.persistence {
+        |  journal.plugin = invalid
+        |  snapshot-store.plugin = invalid
+        |}
+        |""".stripMargin)
+
+  // node1~3 fail to persist events on the read side.
+  nodeConfig(node1)(
+    ConfigFactory
+      .parseString(s"""akka.cluster.roles = ["member-1"]""")
+      .withFallback(invalidEventSourcedPersistenceConfig),
+  )
+  nodeConfig(node2)(
+    ConfigFactory
+      .parseString(s"""akka.cluster.roles = ["member-2"]""")
+      .withFallback(invalidEventSourcedPersistenceConfig),
+  )
+  nodeConfig(node3)(
+    ConfigFactory
+      .parseString(s"""akka.cluster.roles = ["member-3"]""")
+      .withFallback(invalidEventSourcedPersistenceConfig),
+  )
+
+  // node4~6 succeed to persist events on the read side.
+  nodeConfig(node4)(
+    ConfigFactory
+      .parseString(s"""akka.cluster.roles = ["member-1"]"""),
+  )
+  nodeConfig(node5)(
+    ConfigFactory
+      .parseString(s"""akka.cluster.roles = ["member-2"]"""),
+  )
+  nodeConfig(node6)(
+    ConfigFactory
+      .parseString(s"""akka.cluster.roles = ["member-3"]"""),
+  )
+
+}
+
+final class EventSourcingAutoStartMultiNodeSpecMultiJvmNode1 extends EventSourcingAutoStartMultiNodeSpec
+final class EventSourcingAutoStartMultiNodeSpecMultiJvmNode2 extends EventSourcingAutoStartMultiNodeSpec
+final class EventSourcingAutoStartMultiNodeSpecMultiJvmNode3 extends EventSourcingAutoStartMultiNodeSpec
+
+final class EventSourcingAutoStartMultiNodeSpecMultiJvmNode4 extends EventSourcingAutoStartMultiNodeSpec
+final class EventSourcingAutoStartMultiNodeSpecMultiJvmNode5 extends EventSourcingAutoStartMultiNodeSpec
+final class EventSourcingAutoStartMultiNodeSpecMultiJvmNode6 extends EventSourcingAutoStartMultiNodeSpec
+
+class EventSourcingAutoStartMultiNodeSpec
+    extends MultiNodeSpec(EventSourcingAutoStartMultiNodeSpecConfig)
+    with STMultiNodeSpec {
+
+  import EventSourcingAutoStartMultiNodeSpec._
+  import EventSourcingAutoStartMultiNodeSpecConfig._
+
+  override def initialParticipants: Int = 3
+
+  private implicit val typedSystem: ActorSystem[Nothing] = system.toTyped
+  private val clusterReplication: ClusterReplication     = ClusterReplication(typedSystem)
+  private val readJournal: CurrentEventsByTagQuery =
+    PersistenceQuery(system).readJournalFor[CurrentEventsByTagQuery](
+      readJournalPluginId = "lerna.akka.entityreplication.util.persistence.query.proxy",
+    )
+
+  "Cluster Replication Event Sourcing" should {
+
+    "start a new cluster ([node1,node2,node3])" in {
+      joinCluster(node1, node2, node3)
+    }
+
+    "initialize ClusterReplication on [node1,node2,node3]" in {
+      runOn(node1, node2, node3) {
+        clusterReplication.init(Catalog(typedSystem))
+      }
+      enterBarrier("Done ClusterReplication initialization")
+    }
+
+    "persist events via node1" in {
+      runOn(node1) {
+        val entityRef = clusterReplication.entityRefFor(Catalog.typeKey, "example-1")
+        val reply1    = AtLeastOnceComplete.askTo(entityRef, Catalog.Add("1", _), retryInterval = 100.millis).await
+        reply1 shouldBe Catalog.AddReply(Set("1"))
+        val reply2 = AtLeastOnceComplete.askTo(entityRef, Catalog.Add("2", _), retryInterval = 100.millis).await
+        reply2 shouldBe Catalog.AddReply(Set("2", "1"))
+      }
+      enterBarrier("Done event persists")
+    }
+
+    "not read persisted events using PersistenceQuery on [node1,node2,nod3]" in {
+      // Events is not available since `lerna.akka.entityreplication.raft.eventsourced.persistence` is invalid.
+      runOn(node1, node2, node3) {
+        assertForDuration(
+          {
+            val source = readJournal
+              .currentEventsByTag(CatalogEventAdapter.tag, Offset.noOffset)
+            val events = source.runFold(Seq.empty[EventEnvelope])(_ :+ _).await.collect {
+              case EventEnvelope(_, _, _, event: Catalog.Event) => event
+            }
+            events shouldBe Seq.empty
+          },
+          propagationTimeout,
+          100.millis,
+        )
+      }
+      enterBarrier("Done persisted-event reads on [node1,node2,node3]")
+    }
+
+    // NOTE: Starting a new cluster is crucial for this test.
+    //       This test verifies Event Sourcing will automatically start without any interaction from users.
+    "stop the cluster ([node1,node2,node3]) and then " in {
+      leaveCluster(node1, node2, node3)
+    }
+    "start a new cluster ([node4,node5,node6])" in {
+      newCluster(node4, node5, node6)
+    }
+
+    "initialize ClusterReplication on [node4,node5,node6]" in {
+      runOn(node4, node5, node6) {
+        clusterReplication.init(Catalog(typedSystem))
+      }
+      enterBarrier("Done ClusterReplication initialization")
+    }
+
+    "read persisted events using PersistenceQuery on [node4,node5,node6]" in {
+      runOn(node4, node5, node6) {
+        awaitAssert(
+          {
+            val source = readJournal
+              .currentEventsByTag(CatalogEventAdapter.tag, Offset.noOffset)
+            val events = source.runFold(Seq.empty[EventEnvelope])(_ :+ _).await.collect {
+              case EventEnvelope(_, _, _, event: Catalog.Event) => event
+            }
+            events shouldBe Seq(
+              Catalog.Added("1"),
+              Catalog.Added("2"),
+            )
+          },
+          propagationTimeout,
+          100.millis,
+        )
+      }
+      enterBarrier("Done persisted-event reads on [node4,node5,node6]")
+    }
+
+  }
+
+}
+
+object EventSourcingAutoStartMultiNodeSpec {
+
+  /** Holds a set of string values */
+  object Catalog {
+    val typeKey: ReplicatedEntityTypeKey[Command] = ReplicatedEntityTypeKey(s"catalog")
+
+    sealed trait Command                                             extends STMultiNodeSerializable
+    final case class Add(value: String, replyTo: ActorRef[AddReply]) extends Command
+    final case class AddReply(values: Set[String])                   extends STMultiNodeSerializable
+
+    sealed trait Event                    extends STMultiNodeSerializable
+    final case class Added(value: String) extends Event
+
+    final case class State(values: Set[String]) extends STMultiNodeSerializable
+
+    def apply(
+        system: ActorSystem[_],
+    ): ReplicatedEntity[Command, ReplicationEnvelope[Command]] = {
+      val settings = ClusterReplicationSettings(system)
+      ReplicatedEntity(typeKey)(entityContext =>
+        Behaviors.setup { context =>
+          context.setLoggerName(Catalog.getClass)
+          ReplicatedEntityBehavior[Command, Event, State](
+            entityContext = entityContext,
+            emptyState = State(Set.empty),
+            commandHandler = commandHandler,
+            eventHandler = eventHandler,
+          )
+        },
+      ).withSettings(settings)
+    }
+
+    // NOTE: Command Handler should be idempotent.
+    def commandHandler(state: State, command: Command): Effect[Event, State] =
+      command match {
+        case Add(value, replyTo) =>
+          if (state.values.contains(value)) {
+            Effect.none.thenReply(replyTo) { _: State => AddReply(state.values) }
+          } else {
+            Effect
+              .replicate(Added(value))
+              .thenReply(replyTo)(newState => AddReply(newState.values))
+          }
+      }
+
+    def eventHandler(state: State, event: Event): State =
+      event match {
+        case Added(value) =>
+          state.copy(state.values + value)
+      }
+
+  }
+
+  object CatalogEventAdapter {
+    val tag = "catalog"
+  }
+  final class CatalogEventAdapter(system: ExtendedActorSystem) extends WriteEventAdapter {
+    private val log                           = Logging(system, getClass)
+    override def manifest(event: Any): String = ""
+    override def toJournal(event: Any): Any =
+      event match {
+        case event: Catalog.Event =>
+          Tagged(event, tags = Set(CatalogEventAdapter.tag))
+        case _ =>
+          log.warning("Got unexpected event [{}]", event)
+          event
+      }
+  }
+
+}

--- a/src/multi-jvm/scala/lerna/akka/entityreplication/typed/MultiDataStoreSpec.scala
+++ b/src/multi-jvm/scala/lerna/akka/entityreplication/typed/MultiDataStoreSpec.scala
@@ -102,11 +102,6 @@ class MultiDataStoreSpec extends MultiNodeSpec(MultiDataStoreSpecConfig) with ST
       joinCluster(node1, node2, node3)
     }
 
-    "initialize ClusterReplication" in {
-      clusterReplication.init(PingPongEntity(defaultDataStoreTypeKey, typedSystem))
-      clusterReplication.init(PingPongEntity(storageExtensionDataStoreTypeKey, typedSystem))
-    }
-
     /*
      * Rearranging the order of test cases will cause to fail the test:
      * https://github.com/lerna-stack/akka-entity-replication/pull/88#discussion_r661128422
@@ -114,12 +109,14 @@ class MultiDataStoreSpec extends MultiNodeSpec(MultiDataStoreSpecConfig) with ST
 
     "not persist data to StorageExtension when use default data store which is defined in configuration" in {
 
+      clusterReplication.init(PingPongEntity(defaultDataStoreTypeKey, typedSystem))
+
       runOn(node1) {
         val entityRef = clusterReplication.entityRefFor(defaultDataStoreTypeKey, entityId = "test")
 
-        val reply1 = AtLeastOnceComplete.askTo(entityRef, PingPongEntity.Ping(_), retryInterval = 100.millis)
+        val reply1 = AtLeastOnceComplete.askTo(entityRef, PingPongEntity.Ping(_), retryInterval = 200.millis)
         reply1.await shouldBe a[PingPongEntity.Pong]
-        val reply2 = AtLeastOnceComplete.askTo(entityRef, PingPongEntity.Ping(_), retryInterval = 100.millis)
+        val reply2 = AtLeastOnceComplete.askTo(entityRef, PingPongEntity.Ping(_), retryInterval = 200.millis)
         reply2.await shouldBe a[PingPongEntity.Pong]
 
         fetchAllJournalEntriesFromSecondaryStorage() should be(empty)
@@ -129,12 +126,14 @@ class MultiDataStoreSpec extends MultiNodeSpec(MultiDataStoreSpecConfig) with ST
 
     "persist data to StorageExtension when set persistent plugins to ClusterReplicationSettings" in {
 
+      clusterReplication.init(PingPongEntity(storageExtensionDataStoreTypeKey, typedSystem))
+
       runOn(node1) {
         val entityRef = clusterReplication.entityRefFor(storageExtensionDataStoreTypeKey, entityId = "test")
 
-        val reply1 = AtLeastOnceComplete.askTo(entityRef, PingPongEntity.Ping(_), retryInterval = 100.millis)
+        val reply1 = AtLeastOnceComplete.askTo(entityRef, PingPongEntity.Ping(_), retryInterval = 200.millis)
         reply1.await shouldBe a[PingPongEntity.Pong]
-        val reply2 = AtLeastOnceComplete.askTo(entityRef, PingPongEntity.Ping(_), retryInterval = 100.millis)
+        val reply2 = AtLeastOnceComplete.askTo(entityRef, PingPongEntity.Ping(_), retryInterval = 200.millis)
         reply2.await shouldBe a[PingPongEntity.Pong]
 
         fetchAllJournalEntriesFromSecondaryStorage() should not be empty

--- a/src/test/scala/lerna/akka/entityreplication/ReplicationRegionRaftActorStarterSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/ReplicationRegionRaftActorStarterSpec.scala
@@ -124,6 +124,7 @@ final class ReplicationRegionRaftActorStarterSpec
       val startedRaftActorIdsOnFirstTry = (1 to 5).map { _ =>
         expectStartEntityAndThenAck(shardRegionProbe)
       }.toSet
+      startedRaftActorIdsOnFirstTry.size shouldBe 5
 
       // Advance the clock by `frequency`.
       // The starter will trigger starts on the second round.
@@ -134,6 +135,7 @@ final class ReplicationRegionRaftActorStarterSpec
       val startedRaftActorIdsOnSecondTry = (1 to 5).map { _ =>
         expectStartEntityAndThenAck(shardRegionProbe)
       }.toSet
+      startedRaftActorIdsOnSecondTry.size shouldBe 5
 
       // Advance the clock by `frequency`.
       // The starter will trigger starts on the third round.
@@ -144,6 +146,7 @@ final class ReplicationRegionRaftActorStarterSpec
       val startedRaftActorIdsOnThirdTry = (1 to 2).map { _ =>
         expectStartEntityAndThenAck(shardRegionProbe)
       }.toSet
+      startedRaftActorIdsOnThirdTry.size shouldBe 2
 
       val startedRaftActorIds =
         startedRaftActorIdsOnFirstTry

--- a/src/test/scala/lerna/akka/entityreplication/ReplicationRegionRaftActorStarterSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/ReplicationRegionRaftActorStarterSpec.scala
@@ -1,0 +1,161 @@
+package lerna.akka.entityreplication
+
+import akka.actor.testkit.typed.scaladsl.ManualTime
+import akka.actor.typed.scaladsl.adapter.{ ClassicActorSystemOps, TypedActorRefOps }
+import akka.actor.{ ActorRef, ActorSystem }
+import akka.cluster.sharding.ShardRegion
+import akka.testkit.{ TestKit, TestProbe }
+import com.typesafe.config.{ Config, ConfigFactory }
+import lerna.akka.entityreplication.raft.{ ActorSpec, RaftSettings }
+
+import scala.concurrent.duration.DurationInt
+
+object ReplicationRegionRaftActorStarterSpec {
+  private val config: Config = {
+    ManualTime.config.withFallback(ConfigFactory.load())
+  }
+}
+
+final class ReplicationRegionRaftActorStarterSpec
+    extends TestKit(ActorSystem("ReplicationRegionRaftActorStarterSpec", ReplicationRegionRaftActorStarterSpec.config))
+    with ActorSpec {
+
+  private val manualTime = ManualTime()(system.toTyped)
+
+  private def spawnRaftActorStarter(
+      shardRegion: ActorRef,
+      ids: Set[ShardRegion.EntityId],
+      settings: RaftSettings,
+  ): ActorRef = {
+    val starter =
+      system.spawnAnonymous[Nothing](ReplicationRegionRaftActorStarter(shardRegion, ids, settings)).toClassic
+    planAutoKill(starter)
+  }
+
+  private def expectStartEntityAndThenAck(shardRegionProbe: TestProbe): ShardRegion.EntityId = {
+    val startMessage = shardRegionProbe.expectMsgType[ShardRegion.StartEntity]
+    shardRegionProbe.reply(ShardRegion.StartEntityAck(startMessage.entityId, "unused"))
+    startMessage.entityId
+  }
+
+  private def expectStartEntityAndThenNoAck(shardRegionProbe: TestProbe): ShardRegion.EntityId = {
+    val startMessage = shardRegionProbe.expectMsgType[ShardRegion.StartEntity]
+    startMessage.entityId
+  }
+
+  "ReplicationRegionRaftActorStarter" should {
+
+    "trigger all actor starts" in {
+      val shardRegionProbe = TestProbe()
+
+      val defaultSettings = RaftSettings(system.settings.config)
+      val raftActorStarter =
+        spawnRaftActorStarter(shardRegionProbe.ref, Set("1", "2", "3"), defaultSettings)
+
+      assume(defaultSettings.raftActorAutoStartNumberOfActors >= 3)
+
+      // The starter will stop at the end of this test.
+      watch(raftActorStarter)
+
+      // The starter should trigger all actor starts.
+      val startedRaftActorIds = (1 to 3).map { _ =>
+        expectStartEntityAndThenAck(shardRegionProbe)
+      }.toSet
+      startedRaftActorIds shouldBe Set("1", "2", "3")
+
+      // The starter should stop itself.
+      expectTerminated(raftActorStarter)
+
+    }
+
+    "retry all actor starts with no ACK" in {
+
+      val shardRegionProbe = TestProbe()
+
+      val defaultSettings = RaftSettings(system.settings.config)
+      val raftActorStarter =
+        spawnRaftActorStarter(shardRegionProbe.ref, Set("1", "2", "3"), defaultSettings)
+
+      assume(defaultSettings.raftActorAutoStartNumberOfActors >= 3)
+
+      // The starter will stop at the end of this test.
+      watch(raftActorStarter)
+
+      // First round (all starts will fail)
+      // The shard region should not reply ACK
+      // since this test verifies that the starter should retry such starts.
+      (1 to 3).map { _ =>
+        expectStartEntityAndThenNoAck(shardRegionProbe)
+      }.toSet
+
+      // Advance the clock by `retry-interval`.
+      // Then the starter will try again.
+      manualTime.expectNoMessageFor(defaultSettings.raftActorAutoStartRetryInterval - 1.milli)
+      manualTime.timePasses(1.milli)
+
+      // Second round (all starts will succeed)
+      val startedRaftActorIdsOnSecondTry = (1 to 3).map { _ =>
+        expectStartEntityAndThenAck(shardRegionProbe)
+      }.toSet
+      startedRaftActorIdsOnSecondTry shouldBe Set("1", "2", "3")
+
+      // The starter should stop itself.
+      expectTerminated(raftActorStarter)
+
+    }
+
+    "trigger all actor starts in multiple rounds" in {
+      val shardRegionProbe = TestProbe()
+
+      val defaultSettings = RaftSettings(system.settings.config)
+      val raftActorStarter =
+        spawnRaftActorStarter(
+          shardRegionProbe.ref,
+          Set("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"),
+          defaultSettings,
+        )
+
+      assume(defaultSettings.raftActorAutoStartNumberOfActors == 5)
+
+      // The starter will stop at the end of this test.
+      watch(raftActorStarter)
+
+      // First round
+      val startedRaftActorIdsOnFirstTry = (1 to 5).map { _ =>
+        expectStartEntityAndThenAck(shardRegionProbe)
+      }.toSet
+
+      // Advance the clock by `frequency`.
+      // The starter will trigger starts on the second round.
+      manualTime.expectNoMessageFor(defaultSettings.raftActorAutoStartFrequency - 1.milli)
+      manualTime.timePasses(1.milli)
+
+      // Second round
+      val startedRaftActorIdsOnSecondTry = (1 to 5).map { _ =>
+        expectStartEntityAndThenAck(shardRegionProbe)
+      }.toSet
+
+      // Advance the clock by `frequency`.
+      // The starter will trigger starts on the third round.
+      manualTime.expectNoMessageFor(defaultSettings.raftActorAutoStartFrequency - 1.milli)
+      manualTime.timePasses(1.milli)
+
+      // Third round
+      val startedRaftActorIdsOnThirdTry = (1 to 2).map { _ =>
+        expectStartEntityAndThenAck(shardRegionProbe)
+      }.toSet
+
+      val startedRaftActorIds =
+        startedRaftActorIdsOnFirstTry
+          .union(startedRaftActorIdsOnSecondTry)
+          .union(startedRaftActorIdsOnThirdTry)
+      startedRaftActorIds shouldBe Set("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12")
+
+      // The starter should stop itself.
+      expectTerminated(raftActorStarter)
+
+    }
+
+  }
+
+}

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftSettingsSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftSettingsSpec.scala
@@ -34,6 +34,9 @@ final class RaftSettingsSpec extends TestKit(ActorSystem("RaftSettingsSpec")) wi
       settings.snapshotSyncCopyingParallelism shouldBe 10
       settings.snapshotSyncPersistenceOperationTimeout shouldBe 10.seconds
       settings.clusterShardingConfig shouldBe defaultConfig.getConfig("lerna.akka.entityreplication.raft.sharding")
+      settings.raftActorAutoStartFrequency shouldBe 200.millis
+      settings.raftActorAutoStartNumberOfActors shouldBe 5
+      settings.raftActorAutoStartRetryInterval shouldBe 100.millis
       settings.journalPluginId shouldBe ""
       settings.snapshotStorePluginId shouldBe ""
       settings.queryPluginId shouldBe ""
@@ -52,6 +55,39 @@ final class RaftSettingsSpec extends TestKit(ActorSystem("RaftSettingsSpec")) wi
       settings.journalPluginAdditionalConfig.getConfig("my-journal-plugin-id") shouldBe defaultConfig.getConfig(
         "lerna.akka.entityreplication.raft.persistence.journal-plugin-additional",
       )
+    }
+
+    "throw an IllegalArgumentException if the given raft-actor-auto-start.frequency is 0 milli" in {
+      val config = ConfigFactory
+        .parseString("""
+                       |lerna.akka.entityreplication.raft.raft-actor-auto-start.frequency = 0ms
+                       |""".stripMargin)
+        .withFallback(defaultConfig)
+      a[IllegalArgumentException] shouldBe thrownBy {
+        RaftSettings(config)
+      }
+    }
+
+    "throw an IllegalArgumentException if the given raft-actor-auto-start.number-of-actors is 0" in {
+      val config = ConfigFactory
+        .parseString("""
+                       |lerna.akka.entityreplication.raft.raft-actor-auto-start.number-of-actors = 0
+                       |""".stripMargin)
+        .withFallback(defaultConfig)
+      a[IllegalArgumentException] shouldBe thrownBy {
+        RaftSettings(config)
+      }
+    }
+
+    "throw an IllegalArgumentException if the given raft-actor-auto-start.retry-interval is 0 milli" in {
+      val config = ConfigFactory
+        .parseString("""
+                       |lerna.akka.entityreplication.raft.raft-actor-auto-start.retry-interval = 0ms
+                       |""".stripMargin)
+        .withFallback(defaultConfig)
+      a[IllegalArgumentException] shouldBe thrownBy {
+        RaftSettings(config)
+      }
     }
 
     "throw an IllegalArgumentException if the given snapshot-every is out of range" in {

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftSettingsSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftSettingsSpec.scala
@@ -57,17 +57,6 @@ final class RaftSettingsSpec extends TestKit(ActorSystem("RaftSettingsSpec")) wi
       )
     }
 
-    "throw an IllegalArgumentException if the given `raft.sharding.remember-entities-store` is not `ddata`" in {
-      val config = ConfigFactory
-        .parseString("""
-                       |lerna.akka.entityreplication.raft.sharding.remember-entities-store = "eventsourced"
-                       |""".stripMargin)
-        .withFallback(defaultConfig)
-      a[IllegalArgumentException] shouldBe thrownBy {
-        RaftSettings(config)
-      }
-    }
-
     "throw an IllegalArgumentException if the given raft-actor-auto-start.frequency is 0 milli" in {
       val config = ConfigFactory
         .parseString("""

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftSettingsSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftSettingsSpec.scala
@@ -57,6 +57,17 @@ final class RaftSettingsSpec extends TestKit(ActorSystem("RaftSettingsSpec")) wi
       )
     }
 
+    "throw an IllegalArgumentException if the given `raft.sharding.remember-entities-store` is not `ddata`" in {
+      val config = ConfigFactory
+        .parseString("""
+                       |lerna.akka.entityreplication.raft.sharding.remember-entities-store = "eventsourced"
+                       |""".stripMargin)
+        .withFallback(defaultConfig)
+      a[IllegalArgumentException] shouldBe thrownBy {
+        RaftSettings(config)
+      }
+    }
+
     "throw an IllegalArgumentException if the given raft-actor-auto-start.frequency is 0 milli" in {
       val config = ConfigFactory
         .parseString("""

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftSettingsSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftSettingsSpec.scala
@@ -34,9 +34,9 @@ final class RaftSettingsSpec extends TestKit(ActorSystem("RaftSettingsSpec")) wi
       settings.snapshotSyncCopyingParallelism shouldBe 10
       settings.snapshotSyncPersistenceOperationTimeout shouldBe 10.seconds
       settings.clusterShardingConfig shouldBe defaultConfig.getConfig("lerna.akka.entityreplication.raft.sharding")
-      settings.raftActorAutoStartFrequency shouldBe 200.millis
+      settings.raftActorAutoStartFrequency shouldBe 3.seconds
       settings.raftActorAutoStartNumberOfActors shouldBe 5
-      settings.raftActorAutoStartRetryInterval shouldBe 100.millis
+      settings.raftActorAutoStartRetryInterval shouldBe 5.seconds
       settings.journalPluginId shouldBe ""
       settings.snapshotStorePluginId shouldBe ""
       settings.queryPluginId shouldBe ""


### PR DESCRIPTION
Closes #118 

Raft actors start automatically after `ClusterReplication.init`. To achieve this feature, a `ReplictionRegion` actor spawns a `ReplicationRegionRaftActorStarter` actor that triggers all Raft actor starts. After all starts triggered, `ReplicationRegionRaftActorStarter` will stop itself. This mechanism requires us to give all possible Raft actor IDs to `ReplicationRegionRaftActorStarter`. This feature is enabled only if we use typed APIs since it would be hard to know such IDs on using classic `ClusterReplication`.