### PR TITLE
Raft leader should set appropriate previous values (`prevLogIndex` and `prevLogTerm`) to batched `AppendEntries`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TestKit throws "Shard received unexpected message" exception after the entity passivated [PR#100](https://github.com/lerna-stack/akka-entity-replication/pull/100)
 - `ReplicatedEntity` can produce illegal snapshot if compaction and receiving new event occur same time [#111](https://github.com/lerna-stack/akka-entity-replication/issues/111)
 - Starting a follower member later than leader completes a compaction may break ReplicatedLog of the follower [#105](https://github.com/lerna-stack/akka-entity-replication/issues/105)
+- The Raft leader uses the same previous `LogEntryIndex` and `Term` to all batched `AppendEntries` messages [#123](https://github.com/lerna-stack/akka-entity-replication/issues/123)
 
 ## [v2.0.0] - 2021-07-16
 [v2.0.0]: https://github.com/lerna-stack/akka-entity-replication/compare/v1.0.0...v2.0.0

--- a/src/test/scala/lerna/akka/entityreplication/raft/model/ReplicatedLogSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/model/ReplicatedLogSpec.scala
@@ -42,6 +42,23 @@ class ReplicatedLogSpec extends WordSpecLike with Matchers {
       log.getFrom(target, maxEntryCount = 10, maxBatchCount = 1) should be(expected)
     }
 
+    "return only one part of entries by getFrom(..., maxBatchCount=1) even if it has more succeeding entries" in {
+
+      val logEntries = Seq(
+        LogEntry(LogEntryIndex(1), EntityEvent(None, "a"), Term(1)),
+        LogEntry(LogEntryIndex(2), EntityEvent(None, "b"), Term(1)),
+        LogEntry(LogEntryIndex(3), EntityEvent(None, "c"), Term(1)),
+        LogEntry(LogEntryIndex(4), EntityEvent(None, "d"), Term(1)),
+        LogEntry(LogEntryIndex(5), EntityEvent(None, "e"), Term(1)),
+        LogEntry(LogEntryIndex(6), EntityEvent(None, "f"), Term(1)),
+      )
+      val log = new ReplicatedLog(logEntries)
+
+      val expectedParts = Seq(Seq(logEntries(2), logEntries(3)))
+      log.getFrom(LogEntryIndex(3), maxEntryCount = 2, maxBatchCount = 1) shouldBe expectedParts
+
+    }
+
     "return part of logEntries by getFrom(LogEntryIndex, maxEntryCount, maxBatchCount) when (maxEntryCount * maxBatchCount) is lower value than count of logEntries" in {
       val logEntries = Seq(
         LogEntry(LogEntryIndex(1), EntityEvent(None, "a"), Term(1)),


### PR DESCRIPTION
Closes #123 