### PR TITLE
Verify batched append entries settings

### DIFF
--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftSettingsImpl.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftSettingsImpl.scala
@@ -107,6 +107,10 @@ private[entityreplication] object RaftSettingsImpl {
     )
 
     val maxAppendEntriesBatchSize: Int = config.getInt("max-append-entries-batch-size")
+    require(
+      maxAppendEntriesBatchSize > 0,
+      s"max-append-entries-batch-size ($maxAppendEntriesBatchSize) should be greater than 0",
+    )
 
     val compactionSnapshotCacheTimeToLive: FiniteDuration =
       config.getDuration("compaction.snapshot-cache-time-to-live").toScala

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftSettingsImpl.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftSettingsImpl.scala
@@ -101,6 +101,10 @@ private[entityreplication] object RaftSettingsImpl {
     )
 
     val maxAppendEntriesSize: Int = config.getInt("max-append-entries-size")
+    require(
+      maxAppendEntriesSize > 0,
+      s"max-append-entries-size ($maxAppendEntriesSize) should be greater than 0",
+    )
 
     val maxAppendEntriesBatchSize: Int = config.getInt("max-append-entries-batch-size")
 

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftSettingsSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftSettingsSpec.scala
@@ -76,6 +76,28 @@ final class RaftSettingsSpec extends TestKit(ActorSystem("RaftSettingsSpec")) wi
       }
     }
 
+    "throw an IllegalArgumentException if the given max-append-entries-batch-size is 0" in {
+      val config = ConfigFactory
+        .parseString("""
+                       |lerna.akka.entityreplication.raft.max-append-entries-batch-size = 0
+                       |""".stripMargin)
+        .withFallback(defaultConfig)
+      a[IllegalArgumentException] shouldBe thrownBy {
+        RaftSettings(config)
+      }
+    }
+
+    "throw an IllegalArgumentException if the given max-append-entries-batch-size is -1" in {
+      val config = ConfigFactory
+        .parseString("""
+                       |lerna.akka.entityreplication.raft.max-append-entries-batch-size = -1
+                       |""".stripMargin)
+        .withFallback(defaultConfig)
+      a[IllegalArgumentException] shouldBe thrownBy {
+        RaftSettings(config)
+      }
+    }
+
     "throw an IllegalArgumentException if the given snapshot-every is out of range" in {
       val config = ConfigFactory
         .parseString("""

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftSettingsSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftSettingsSpec.scala
@@ -54,6 +54,28 @@ final class RaftSettingsSpec extends TestKit(ActorSystem("RaftSettingsSpec")) wi
       )
     }
 
+    "throw an IllegalArgumentException if the given max-append-entries-size is 0" in {
+      val config = ConfigFactory
+        .parseString("""
+                       |lerna.akka.entityreplication.raft.max-append-entries-size = 0
+                       |""".stripMargin)
+        .withFallback(defaultConfig)
+      a[IllegalArgumentException] shouldBe thrownBy {
+        RaftSettings(config)
+      }
+    }
+
+    "throw an IllegalArgumentException if the given max-append-entries-size is -1" in {
+      val config = ConfigFactory
+        .parseString("""
+                       |lerna.akka.entityreplication.raft.max-append-entries-size = -1
+                       |""".stripMargin)
+        .withFallback(defaultConfig)
+      a[IllegalArgumentException] shouldBe thrownBy {
+        RaftSettings(config)
+      }
+    }
+
     "throw an IllegalArgumentException if the given snapshot-every is out of range" in {
       val config = ConfigFactory
         .parseString("""


### PR DESCRIPTION
`RaftSettings`(Impl) throws an `IllegalArgumentException` if any of the following conditions don't meet.
* `lerna.akka.entityreplication.raft.max-append-entries-size > 0`
* `lerna.akka.entityreplication.raft.max-append-entries-batch-size > 0`