### PR TITLE
fix: event omission due to loss of ReplicationSucceeded due to restart of Entity

### DIFF
--- a/src/main/scala/lerna/akka/entityreplication/ReplicationActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/ReplicationActor.scala
@@ -144,6 +144,9 @@ trait ReplicationActor[StateData] extends Actor with Stash with akka.lerna.Stash
             innerApplyEvent(logEntry.event.event, logEntry.index)
             changeState(ready)
             internalStash.unstashAll()
+          case ReplicationFailed =>
+            changeState(ready)
+            internalStash.unstashAll()
           case ReplicationSucceeded(_, logEntryIndex, responseInstanceId) if responseInstanceId.contains(instanceId) =>
             changeState(ready)
             internalStash.unstashAll()

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftProtocol.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftProtocol.scala
@@ -52,6 +52,7 @@ private[entityreplication] object RaftProtocol {
   final case class Replica(logEntry: LogEntry)                                            extends EntityCommand
   final case class TakeSnapshot(metadata: EntitySnapshotMetadata, replyTo: ActorRef)      extends EntityCommand
   final case object RecoveryTimeout                                                       extends EntityCommand
+  final case object ReplicationFailed                                                     extends EntityCommand
 
   sealed trait ReplicationResponse
 

--- a/src/main/scala/lerna/akka/entityreplication/raft/model/ReplicatedLog.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/model/ReplicatedLog.scala
@@ -36,6 +36,9 @@ private[entityreplication] final case class ReplicatedLog private[model] (
     entries.slice(toSeqIndex(from), until = toSeqIndex(to.next()))
   }
 
+  def dropEntries(to: LogEntryIndex): Iterator[LogEntry] =
+    entries.iterator.drop(n = toSeqIndex(to) + 1)
+
   def nonEmpty: Boolean = entries.nonEmpty
 
   def append(event: EntityEvent, term: Term): ReplicatedLog = {

--- a/src/main/scala/lerna/akka/entityreplication/typed/internal/behavior/Inactive.scala
+++ b/src/main/scala/lerna/akka/entityreplication/typed/internal/behavior/Inactive.scala
@@ -37,6 +37,7 @@ private[entityreplication] class Inactive[Command, Event, State](
         case _: RaftProtocol.RecoveryState        => Behaviors.unhandled
         case _: RaftProtocol.ReplicationSucceeded => Behaviors.unhandled
         case RaftProtocol.RecoveryTimeout         => Behaviors.unhandled
+        case RaftProtocol.ReplicationFailed       => Behaviors.unhandled
       }.receiveSignal(setup.onSignal(setup.emptyState))
 
   def receiveActivate(command: RaftProtocol.Activate): Behavior[EntityCommand] = {

--- a/src/main/scala/lerna/akka/entityreplication/typed/internal/behavior/Ready.scala
+++ b/src/main/scala/lerna/akka/entityreplication/typed/internal/behavior/Ready.scala
@@ -76,6 +76,7 @@ private[entityreplication] class Ready[Command, Event, State](
         case _: RaftProtocol.RecoveryState        => Behaviors.unhandled
         case _: RaftProtocol.ReplicationSucceeded => Behaviors.unhandled
         case RaftProtocol.RecoveryTimeout         => Behaviors.unhandled
+        case RaftProtocol.ReplicationFailed       => Behaviors.unhandled
       }.receiveSignal(setup.onSignal(readyState.entityState))
 
   def receiveProcessCommand(command: RaftProtocol.ProcessCommand, state: BehaviorState): Behavior[EntityCommand] = {

--- a/src/main/scala/lerna/akka/entityreplication/typed/internal/behavior/Recovering.scala
+++ b/src/main/scala/lerna/akka/entityreplication/typed/internal/behavior/Recovering.scala
@@ -92,6 +92,7 @@ private[entityreplication] class Recovering[Command, Event, State](
               Behaviors.same
             case _: RaftProtocol.Activate             => Behaviors.unhandled
             case _: RaftProtocol.ReplicationSucceeded => Behaviors.unhandled
+            case RaftProtocol.ReplicationFailed       => Behaviors.unhandled
           }.receiveSignal(setup.onSignal(setup.emptyState))
       }
     }

--- a/src/main/scala/lerna/akka/entityreplication/typed/internal/behavior/WaitForReplication.scala
+++ b/src/main/scala/lerna/akka/entityreplication/typed/internal/behavior/WaitForReplication.scala
@@ -39,6 +39,7 @@ private[entityreplication] class WaitForReplication[Command, Event, State](
       .receiveMessage[EntityCommand] {
         case command: RaftProtocol.Replica              => receiveReplica(command, state)
         case command: RaftProtocol.ReplicationSucceeded => receiveReplicationSucceeded(command, state)
+        case RaftProtocol.ReplicationFailed             => Behaviors.unhandled
         case command: RaftProtocol.TakeSnapshot         => receiveTakeSnapshot(command, state.entityState)
         case command: RaftProtocol.ProcessCommand =>
           setup.stashBuffer.stash(command)

--- a/src/main/scala/lerna/akka/entityreplication/typed/internal/behavior/WaitForReplication.scala
+++ b/src/main/scala/lerna/akka/entityreplication/typed/internal/behavior/WaitForReplication.scala
@@ -39,7 +39,7 @@ private[entityreplication] class WaitForReplication[Command, Event, State](
       .receiveMessage[EntityCommand] {
         case command: RaftProtocol.Replica              => receiveReplica(command, state)
         case command: RaftProtocol.ReplicationSucceeded => receiveReplicationSucceeded(command, state)
-        case RaftProtocol.ReplicationFailed             => Behaviors.unhandled
+        case RaftProtocol.ReplicationFailed             => Ready.behavior(setup, transformReadyState(state)) // Discard side effects
         case command: RaftProtocol.TakeSnapshot         => receiveTakeSnapshot(command, state.entityState)
         case command: RaftProtocol.ProcessCommand =>
           setup.stashBuffer.stash(command)

--- a/src/test/scala/lerna/akka/entityreplication/raft/model/ReplicatedLogSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/model/ReplicatedLogSpec.scala
@@ -428,4 +428,46 @@ class ReplicatedLogSpec extends WordSpecLike with Matchers {
 
   }
 
+  "ReplicatedLog.dropEntries" should {
+
+    "returns entries with deleted up to the specified LogEntryIndex" in {
+      val logEntries = Seq(
+        LogEntry(LogEntryIndex(1), EntityEvent(None, "a"), Term(1)),
+        LogEntry(LogEntryIndex(2), EntityEvent(None, "b"), Term(1)),
+        LogEntry(LogEntryIndex(3), EntityEvent(None, "c"), Term(1)),
+      )
+
+      val log = new ReplicatedLog(logEntries)
+
+      log.dropEntries(to = LogEntryIndex.initial()).map(_.event.event).toList shouldBe List("a", "b", "c")
+      log.dropEntries(to = LogEntryIndex(1)).map(_.event.event).toList shouldBe List("b", "c")
+      log.dropEntries(to = LogEntryIndex(2)).map(_.event.event).toList shouldBe List("c")
+      log.dropEntries(to = LogEntryIndex(3)).map(_.event.event).toList shouldBe List()
+      log.dropEntries(to = LogEntryIndex(4)).map(_.event.event).toList shouldBe List()
+    }
+
+    "returns entries with deleted up to the specified LogEntryIndex when the log is compressed" in {
+      val logEntries = Seq(
+        LogEntry(LogEntryIndex(1), EntityEvent(None, "a"), Term(1)),
+        LogEntry(LogEntryIndex(2), EntityEvent(None, "b"), Term(1)),
+        LogEntry(LogEntryIndex(3), EntityEvent(None, "c"), Term(1)),
+        LogEntry(LogEntryIndex(4), EntityEvent(None, "d"), Term(1)),
+        LogEntry(LogEntryIndex(5), EntityEvent(None, "e"), Term(1)),
+      )
+
+      val log = new ReplicatedLog(logEntries).deleteOldEntries(to = LogEntryIndex(2), preserveLogSize = 3)
+      require(log.entries.map(_.index.underlying) == List(3, 4, 5))
+      require(log.entries.map(_.event.event) == List("c", "d", "e"))
+
+      log.dropEntries(to = LogEntryIndex.initial()).map(_.event.event).toList shouldBe List("c", "d", "e")
+      log.dropEntries(to = LogEntryIndex(1)).map(_.event.event).toList shouldBe List("c", "d", "e")
+      log.dropEntries(to = LogEntryIndex(2)).map(_.event.event).toList shouldBe List("c", "d", "e")
+      log.dropEntries(to = LogEntryIndex(3)).map(_.event.event).toList shouldBe List("d", "e")
+      log.dropEntries(to = LogEntryIndex(4)).map(_.event.event).toList shouldBe List("e")
+      log.dropEntries(to = LogEntryIndex(5)).map(_.event.event).toList shouldBe List()
+      log.dropEntries(to = LogEntryIndex(6)).map(_.event.event).toList shouldBe List()
+    }
+
+  }
+
 }


### PR DESCRIPTION
Fix: https://github.com/lerna-stack/akka-entity-replication/issues/130 ``Entity processes the command in the presence of uncommitted events · Issue #130 · lerna-stack/akka-entity-replication``