### PR TITLE
Fix/new event during event committing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Starting a follower member later than leader completes a compaction may break ReplicatedLog of the follower [#105](https://github.com/lerna-stack/akka-entity-replication/issues/105)
 - The Raft leader uses the same previous `LogEntryIndex` and `Term` to all batched `AppendEntries` messages [#123](https://github.com/lerna-stack/akka-entity-replication/issues/123)
 - Raft Actors doesn't accept a `RequestVote(lastLogIndex < log.lastLogIndex, lastLogTerm > log.lastLogTerm)` message [#125](https://github.com/lerna-stack/akka-entity-replication/issues/125)
+- A new event is created even though all past events have not been applied [#130](https://github.com/lerna-stack/akka-entity-replication/issues/130)
 
 ## [v2.0.0] - 2021-07-16
 [v2.0.0]: https://github.com/lerna-stack/akka-entity-replication/compare/v1.0.0...v2.0.0

--- a/src/main/scala/lerna/akka/entityreplication/ReplicationActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/ReplicationActor.scala
@@ -144,6 +144,9 @@ trait ReplicationActor[StateData] extends Actor with Stash with akka.lerna.Stash
             innerApplyEvent(logEntry.event.event, logEntry.index)
             changeState(ready)
             internalStash.unstashAll()
+          case ReplicationFailed =>
+            changeState(ready)
+            internalStash.unstashAll()
           case ReplicationSucceeded(_, logEntryIndex, responseInstanceId) if responseInstanceId.contains(instanceId) =>
             changeState(ready)
             internalStash.unstashAll()

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftMemberData.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftMemberData.scala
@@ -323,6 +323,12 @@ private[entityreplication] trait RaftMemberData
     replicatedLog.sliceEntries(from, to).filter(_.event.entityId.contains(entityId))
   }
 
+  def hasUncommittedLogEntryOf(entityId: NormalizedEntityId): Boolean = {
+    replicatedLog
+      .dropEntries(to = commitIndex) // uncommitted entries
+      .exists(_.event.entityId.contains(entityId))
+  }
+
   def alreadyVotedOthers(candidate: MemberIndex): Boolean = votedFor.exists(candidate != _)
 
   def hasMatchLogEntry(prevLogIndex: LogEntryIndex, prevLogTerm: Term): Boolean = {

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftMemberData.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftMemberData.scala
@@ -325,7 +325,7 @@ private[entityreplication] trait RaftMemberData
 
   def hasUncommittedLogEntryOf(entityId: NormalizedEntityId): Boolean = {
     replicatedLog
-      .dropEntries(to = commitIndex) // uncommitted entries
+      .entriesAfter(index = commitIndex) // uncommitted entries
       .exists(_.event.entityId.contains(entityId))
   }
 

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftProtocol.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftProtocol.scala
@@ -52,6 +52,7 @@ private[entityreplication] object RaftProtocol {
   final case class Replica(logEntry: LogEntry)                                            extends EntityCommand
   final case class TakeSnapshot(metadata: EntitySnapshotMetadata, replyTo: ActorRef)      extends EntityCommand
   final case object RecoveryTimeout                                                       extends EntityCommand
+  final case object ReplicationFailed                                                     extends EntityCommand
 
   sealed trait ReplicationResponse
 

--- a/src/main/scala/lerna/akka/entityreplication/raft/model/ReplicatedLog.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/model/ReplicatedLog.scala
@@ -36,8 +36,8 @@ private[entityreplication] final case class ReplicatedLog private[model] (
     entries.slice(toSeqIndex(from), until = toSeqIndex(to.next()))
   }
 
-  def dropEntries(to: LogEntryIndex): Iterator[LogEntry] =
-    entries.iterator.drop(n = toSeqIndex(to) + 1)
+  def entriesAfter(index: LogEntryIndex): Iterator[LogEntry] =
+    entries.iterator.drop(n = toSeqIndex(index) + 1)
 
   def nonEmpty: Boolean = entries.nonEmpty
 

--- a/src/main/scala/lerna/akka/entityreplication/raft/model/ReplicatedLog.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/model/ReplicatedLog.scala
@@ -36,6 +36,9 @@ private[entityreplication] final case class ReplicatedLog private[model] (
     entries.slice(toSeqIndex(from), until = toSeqIndex(to.next()))
   }
 
+  def dropEntries(to: LogEntryIndex): Iterator[LogEntry] =
+    entries.iterator.drop(n = toSeqIndex(to) + 1)
+
   def nonEmpty: Boolean = entries.nonEmpty
 
   def append(event: EntityEvent, term: Term): ReplicatedLog = {

--- a/src/main/scala/lerna/akka/entityreplication/typed/internal/behavior/Inactive.scala
+++ b/src/main/scala/lerna/akka/entityreplication/typed/internal/behavior/Inactive.scala
@@ -37,6 +37,7 @@ private[entityreplication] class Inactive[Command, Event, State](
         case _: RaftProtocol.RecoveryState        => Behaviors.unhandled
         case _: RaftProtocol.ReplicationSucceeded => Behaviors.unhandled
         case RaftProtocol.RecoveryTimeout         => Behaviors.unhandled
+        case RaftProtocol.ReplicationFailed       => Behaviors.unhandled
       }.receiveSignal(setup.onSignal(setup.emptyState))
 
   def receiveActivate(command: RaftProtocol.Activate): Behavior[EntityCommand] = {

--- a/src/main/scala/lerna/akka/entityreplication/typed/internal/behavior/Ready.scala
+++ b/src/main/scala/lerna/akka/entityreplication/typed/internal/behavior/Ready.scala
@@ -76,6 +76,7 @@ private[entityreplication] class Ready[Command, Event, State](
         case _: RaftProtocol.RecoveryState        => Behaviors.unhandled
         case _: RaftProtocol.ReplicationSucceeded => Behaviors.unhandled
         case RaftProtocol.RecoveryTimeout         => Behaviors.unhandled
+        case RaftProtocol.ReplicationFailed       => Behaviors.unhandled
       }.receiveSignal(setup.onSignal(readyState.entityState))
 
   def receiveProcessCommand(command: RaftProtocol.ProcessCommand, state: BehaviorState): Behavior[EntityCommand] = {

--- a/src/main/scala/lerna/akka/entityreplication/typed/internal/behavior/Recovering.scala
+++ b/src/main/scala/lerna/akka/entityreplication/typed/internal/behavior/Recovering.scala
@@ -92,6 +92,7 @@ private[entityreplication] class Recovering[Command, Event, State](
               Behaviors.same
             case _: RaftProtocol.Activate             => Behaviors.unhandled
             case _: RaftProtocol.ReplicationSucceeded => Behaviors.unhandled
+            case RaftProtocol.ReplicationFailed       => Behaviors.unhandled
           }.receiveSignal(setup.onSignal(setup.emptyState))
       }
     }

--- a/src/main/scala/lerna/akka/entityreplication/typed/internal/behavior/WaitForReplication.scala
+++ b/src/main/scala/lerna/akka/entityreplication/typed/internal/behavior/WaitForReplication.scala
@@ -39,6 +39,7 @@ private[entityreplication] class WaitForReplication[Command, Event, State](
       .receiveMessage[EntityCommand] {
         case command: RaftProtocol.Replica              => receiveReplica(command, state)
         case command: RaftProtocol.ReplicationSucceeded => receiveReplicationSucceeded(command, state)
+        case RaftProtocol.ReplicationFailed             => Behaviors.unhandled
         case command: RaftProtocol.TakeSnapshot         => receiveTakeSnapshot(command, state.entityState)
         case command: RaftProtocol.ProcessCommand =>
           setup.stashBuffer.stash(command)

--- a/src/main/scala/lerna/akka/entityreplication/typed/internal/behavior/WaitForReplication.scala
+++ b/src/main/scala/lerna/akka/entityreplication/typed/internal/behavior/WaitForReplication.scala
@@ -39,7 +39,7 @@ private[entityreplication] class WaitForReplication[Command, Event, State](
       .receiveMessage[EntityCommand] {
         case command: RaftProtocol.Replica              => receiveReplica(command, state)
         case command: RaftProtocol.ReplicationSucceeded => receiveReplicationSucceeded(command, state)
-        case RaftProtocol.ReplicationFailed             => Behaviors.unhandled
+        case RaftProtocol.ReplicationFailed             => Ready.behavior(setup, transformReadyState(state)) // Discard side effects
         case command: RaftProtocol.TakeSnapshot         => receiveTakeSnapshot(command, state.entityState)
         case command: RaftProtocol.ProcessCommand =>
           setup.stashBuffer.stash(command)

--- a/src/multi-jvm/scala/lerna/akka/entityreplication/raft/RaftActorMultiNodeSpec.scala
+++ b/src/multi-jvm/scala/lerna/akka/entityreplication/raft/RaftActorMultiNodeSpec.scala
@@ -315,6 +315,7 @@ class RaftActorMultiNodeSpec extends MultiNodeSpec(RaftActorSpecConfig) with STM
 
       var leaderMember: RaftTestFSMRef   = null
       var followerMember: RaftTestFSMRef = null
+
       runOn(node1) {
         leaderMember = createRaftActor(
           shardId,
@@ -328,9 +329,9 @@ class RaftActorMultiNodeSpec extends MultiNodeSpec(RaftActorSpecConfig) with STM
         val leaderData = getState(leaderMember).stateData
         val log = leaderData.replicatedLog.merge(
           Seq(
-            LogEntry(LogEntryIndex(1), EntityEvent(Option(entityId), "correct1"), Term(2)),
-            LogEntry(LogEntryIndex(2), EntityEvent(Option(entityId), "correct2"), Term(2)),
-            LogEntry(LogEntryIndex(3), EntityEvent(Option(entityId), "correct3"), Term(2)),
+            LogEntry(LogEntryIndex(1), EntityEvent(Option(entityId), "correct1"), Term(1)),
+            LogEntry(LogEntryIndex(2), EntityEvent(Option(entityId), "correct2"), Term(1)),
+            LogEntry(LogEntryIndex(3), EntityEvent(Option(entityId), "correct3"), Term(1)),
           ),
           LogEntryIndex.initial(),
         )
@@ -362,13 +363,14 @@ class RaftActorMultiNodeSpec extends MultiNodeSpec(RaftActorSpecConfig) with STM
       val dummyEvent = "dummyEvent"
 
       val expectedLog = Seq(
-        LogEntry(LogEntryIndex(1), EntityEvent(Option(entityId), "correct1"), Term(2)),
-        LogEntry(LogEntryIndex(2), EntityEvent(Option(entityId), "correct2"), Term(2)),
-        LogEntry(LogEntryIndex(3), EntityEvent(Option(entityId), "correct3"), Term(2)),
+        LogEntry(LogEntryIndex(1), EntityEvent(Option(entityId), "correct1"), Term(1)),
+        LogEntry(LogEntryIndex(2), EntityEvent(Option(entityId), "correct2"), Term(1)),
+        LogEntry(LogEntryIndex(3), EntityEvent(Option(entityId), "correct3"), Term(1)),
         LogEntry(LogEntryIndex(4), EntityEvent(Option(entityId), dummyEvent), Term(1)),
       )
 
       runOn(node1) {
+        awaitCond(getState(leaderMember).stateData.commitIndex == LogEntryIndex(3)) // event = "correct3"
         val instanceId = EntityInstanceId(1)
         leaderMember ! Replicate(dummyEvent, testActor, entityId, instanceId, ActorRef.noSender)
         inside(expectMsgType[ReplicationSucceeded]) {

--- a/src/test/scala/lerna/akka/entityreplication/ReplicationActorSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/ReplicationActorSpec.scala
@@ -111,6 +111,22 @@ class ReplicationActorSpec extends TestKit(ActorSystem("ReplicationActorSpec", c
       raftActorProbe.expectMsgType[Replicate]
     }
 
+    "transition to `ready` state and processes the next command without executing any side effect if ReplicationActor receives ReplicationFailed in `waitForReplicationResponse` state" in {
+      val client           = TestProbe()
+      val raftActorProbe   = TestProbe()
+      val replicationActor = createReplicationActor(raftActorProbe)
+
+      client.send(replicationActor, Count())
+      raftActorProbe.expectMsgType[Replicate]
+
+      client.send(replicationActor, Count())
+      raftActorProbe.expectNoMessage() // the command is stashed
+
+      replicationActor ! ReplicationFailed // from raftActor
+      client.expectNoMessage()
+      raftActorProbe.expectMsgType[Replicate]
+    }
+
     "replace instanceId when it restarted" in {
       val watchProbe       = TestProbe()
       val raftActorProbe   = TestProbe()

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorLeaderSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorLeaderSpec.scala
@@ -6,7 +6,7 @@ import akka.testkit.{ TestKit, TestProbe }
 import com.typesafe.config.ConfigFactory
 import lerna.akka.entityreplication.{ ClusterReplicationSettings, ReplicationRegion }
 import lerna.akka.entityreplication.model.{ EntityInstanceId, NormalizedEntityId, NormalizedShardId, TypeName }
-import lerna.akka.entityreplication.raft.RaftProtocol.Replicate
+import lerna.akka.entityreplication.raft.RaftProtocol.{ Replicate, ReplicationFailed }
 import lerna.akka.entityreplication.raft.model._
 import lerna.akka.entityreplication.raft.protocol.RaftCommands._
 import lerna.akka.entityreplication.testkit.CustomTestProbe._
@@ -628,6 +628,47 @@ class RaftActorLeaderSpec extends TestKit(ActorSystem()) with RaftActorSpecBase 
           leader ! InstallSnapshotSucceeded(shardId, term, cmd.srcLatestSnapshotLastLogLogIndex, follower2Index)
           msg.index
       } should contain theSameElementsAs (Set(follower1Index, follower2Index))
+    }
+
+    "reply ReplicationFailed to replicationActor if replication is in progress" in {
+      val replicationActor1 = TestProbe()
+      val replicationActor2 = TestProbe()
+      val entityId1         = NormalizedEntityId("test-1")
+      val entityId2         = NormalizedEntityId("test-2")
+      val entityInstanceId  = EntityInstanceId(1)
+
+      val leader     = createRaftActor()
+      val term       = Term(1)
+      val leaderData = createLeaderData(term)
+      setState(leader, Candidate, leaderData)
+      setState(leader, Leader, leaderData)
+
+      leader ! Replicate(
+        event = "a",
+        replyTo = replicationActor1.ref,
+        entityId1,
+        entityInstanceId,
+        originSender = system.deadLetters,
+      )
+      replicationActor1.expectNoMessage()
+
+      leader ! Replicate(
+        event = "b",
+        replicationActor2.ref,
+        entityId2,
+        entityInstanceId,
+        originSender = system.deadLetters,
+      )
+      replicationActor2.expectNoMessage()
+
+      leader ! Replicate(
+        event = "c",
+        replicationActor1.ref,
+        entityId1,
+        entityInstanceId,
+        originSender = system.deadLetters,
+      )
+      replicationActor1.expectMsg(ReplicationFailed)
     }
   }
 

--- a/src/test/scala/lerna/akka/entityreplication/raft/model/ReplicatedLogSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/model/ReplicatedLogSpec.scala
@@ -428,7 +428,7 @@ class ReplicatedLogSpec extends WordSpecLike with Matchers {
 
   }
 
-  "ReplicatedLog.dropEntries" should {
+  "ReplicatedLog.entriesAfter" should {
 
     "returns entries with deleted up to the specified LogEntryIndex" in {
       val logEntries = Seq(
@@ -439,11 +439,11 @@ class ReplicatedLogSpec extends WordSpecLike with Matchers {
 
       val log = new ReplicatedLog(logEntries)
 
-      log.dropEntries(to = LogEntryIndex.initial()).map(_.event.event).toList shouldBe List("a", "b", "c")
-      log.dropEntries(to = LogEntryIndex(1)).map(_.event.event).toList shouldBe List("b", "c")
-      log.dropEntries(to = LogEntryIndex(2)).map(_.event.event).toList shouldBe List("c")
-      log.dropEntries(to = LogEntryIndex(3)).map(_.event.event).toList shouldBe List()
-      log.dropEntries(to = LogEntryIndex(4)).map(_.event.event).toList shouldBe List()
+      log.entriesAfter(index = LogEntryIndex.initial()).map(_.event.event).toList shouldBe List("a", "b", "c")
+      log.entriesAfter(index = LogEntryIndex(1)).map(_.event.event).toList shouldBe List("b", "c")
+      log.entriesAfter(index = LogEntryIndex(2)).map(_.event.event).toList shouldBe List("c")
+      log.entriesAfter(index = LogEntryIndex(3)).map(_.event.event).toList shouldBe List()
+      log.entriesAfter(index = LogEntryIndex(4)).map(_.event.event).toList shouldBe List()
     }
 
     "returns entries with deleted up to the specified LogEntryIndex when the log is compressed" in {
@@ -459,13 +459,13 @@ class ReplicatedLogSpec extends WordSpecLike with Matchers {
       require(log.entries.map(_.index.underlying) == List(3, 4, 5))
       require(log.entries.map(_.event.event) == List("c", "d", "e"))
 
-      log.dropEntries(to = LogEntryIndex.initial()).map(_.event.event).toList shouldBe List("c", "d", "e")
-      log.dropEntries(to = LogEntryIndex(1)).map(_.event.event).toList shouldBe List("c", "d", "e")
-      log.dropEntries(to = LogEntryIndex(2)).map(_.event.event).toList shouldBe List("c", "d", "e")
-      log.dropEntries(to = LogEntryIndex(3)).map(_.event.event).toList shouldBe List("d", "e")
-      log.dropEntries(to = LogEntryIndex(4)).map(_.event.event).toList shouldBe List("e")
-      log.dropEntries(to = LogEntryIndex(5)).map(_.event.event).toList shouldBe List()
-      log.dropEntries(to = LogEntryIndex(6)).map(_.event.event).toList shouldBe List()
+      log.entriesAfter(index = LogEntryIndex.initial()).map(_.event.event).toList shouldBe List("c", "d", "e")
+      log.entriesAfter(index = LogEntryIndex(1)).map(_.event.event).toList shouldBe List("c", "d", "e")
+      log.entriesAfter(index = LogEntryIndex(2)).map(_.event.event).toList shouldBe List("c", "d", "e")
+      log.entriesAfter(index = LogEntryIndex(3)).map(_.event.event).toList shouldBe List("d", "e")
+      log.entriesAfter(index = LogEntryIndex(4)).map(_.event.event).toList shouldBe List("e")
+      log.entriesAfter(index = LogEntryIndex(5)).map(_.event.event).toList shouldBe List()
+      log.entriesAfter(index = LogEntryIndex(6)).map(_.event.event).toList shouldBe List()
     }
 
   }

--- a/src/test/scala/lerna/akka/entityreplication/raft/model/ReplicatedLogSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/model/ReplicatedLogSpec.scala
@@ -428,4 +428,46 @@ class ReplicatedLogSpec extends WordSpecLike with Matchers {
 
   }
 
+  "ReplicatedLog.dropEntries" should {
+
+    "returns entries with deleted up to the specified LogEntryIndex" in {
+      val logEntries = Seq(
+        LogEntry(LogEntryIndex(1), EntityEvent(None, "a"), Term(1)),
+        LogEntry(LogEntryIndex(2), EntityEvent(None, "b"), Term(1)),
+        LogEntry(LogEntryIndex(3), EntityEvent(None, "c"), Term(1)),
+      )
+
+      val log = new ReplicatedLog(logEntries)
+
+      log.dropEntries(to = LogEntryIndex.initial()).map(_.event.event).toList shouldBe List("a", "b", "c")
+      log.dropEntries(to = LogEntryIndex(1)).map(_.event.event).toList shouldBe List("b", "c")
+      log.dropEntries(to = LogEntryIndex(2)).map(_.event.event).toList shouldBe List("c")
+      log.dropEntries(to = LogEntryIndex(3)).map(_.event.event).toList shouldBe List()
+      log.dropEntries(to = LogEntryIndex(4)).map(_.event.event).toList shouldBe List()
+    }
+
+    "returns entries with deleted up to the specified LogEntryIndex when the log is compressed" in {
+      val logEntries = Seq(
+        LogEntry(LogEntryIndex(1), EntityEvent(None, "a"), Term(1)),
+        LogEntry(LogEntryIndex(2), EntityEvent(None, "b"), Term(1)),
+        LogEntry(LogEntryIndex(3), EntityEvent(None, "c"), Term(1)),
+        LogEntry(LogEntryIndex(4), EntityEvent(None, "d"), Term(1)),
+        LogEntry(LogEntryIndex(5), EntityEvent(None, "e"), Term(1)),
+      )
+
+      val log = new ReplicatedLog(logEntries).deleteOldEntries(to = LogEntryIndex(2), preserveLogSize = 3)
+      require(log.entries.map(_.index.underlying) == List(3, 4, 5))
+      require(log.entries.map(_.event.event) == List("c", "d", "e"))
+
+      log.dropEntries(to = LogEntryIndex.initial()).map(_.event.event).toList shouldBe List("c", "d", "e")
+      log.dropEntries(to = LogEntryIndex(1)).map(_.event.event).toList shouldBe List("c", "d", "e")
+      log.dropEntries(to = LogEntryIndex(2)).map(_.event.event).toList shouldBe List("c", "d", "e")
+      log.dropEntries(to = LogEntryIndex(3)).map(_.event.event).toList shouldBe List("d", "e")
+      log.dropEntries(to = LogEntryIndex(4)).map(_.event.event).toList shouldBe List("e")
+      log.dropEntries(to = LogEntryIndex(5)).map(_.event.event).toList shouldBe List()
+      log.dropEntries(to = LogEntryIndex(6)).map(_.event.event).toList shouldBe List()
+    }
+
+  }
+
 }


### PR DESCRIPTION
Fix: https://github.com/lerna-stack/akka-entity-replication/issues/130 ``A new event is created even though all past events have not been applied · Issue #130 · lerna-stack/akka-entity-replication``