### PR TITLE
Test receiving RequestVoteResponse

### DIFF
--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorCandidateSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorCandidateSpec.scala
@@ -192,6 +192,7 @@ class RaftActorCandidateSpec extends TestKit(ActorSystem()) with RaftActorSpecBa
       val state = getState(candidate)
       state.stateName should be(Follower)
       state.stateData.currentTerm should be(newerTerm)
+      state.stateData.leaderMember should be(None)
     }
 
     "AppendEntries が古い Term を持っているときは拒否" in {


### PR DESCRIPTION
* Revise some tests that verify a candidate's behavior on receiving `RequestVoteResponse`
  * This change will verify the candidate's state after receiving `RequestVoteResponse`
* Add a test verifying that the candidate doesn't become the leader by duplicated votes from the same follower