### PR TITLE
🚨test: Increase retryInterval to prevent premature compaction

### DIFF
--- a/src/multi-jvm/scala/lerna/akka/entityreplication/typed/MultiSnapshotSyncSpec.scala
+++ b/src/multi-jvm/scala/lerna/akka/entityreplication/typed/MultiSnapshotSyncSpec.scala
@@ -242,14 +242,17 @@ class MultiSnapshotSyncSpec extends MultiNodeSpec(MultiSnapshotSyncSpecConfig) w
   }
 
   private def setValue(id: String, value: Int)(implicit timeout: Timeout): Int = {
+    // NOTE:
+    // Too short retryInterval (e.g.200ms) will cause premature compaction and make this test unstable
+    // because also read-only operations create new LogEntry(NoOp) to guarantee consistency
     val entityRef = clusterReplication.entityRefFor(Register.TypeKey, id)
-    val reply     = AtLeastOnceComplete.askTo(entityRef, Register.Set(value, _), retryInterval = 200.millis)
+    val reply     = AtLeastOnceComplete.askTo(entityRef, Register.Set(value, _), retryInterval = 2.seconds)
     reply.await.value
   }
 
   private def getValue(id: String)(implicit timeout: Timeout): Int = {
     val entityRef = clusterReplication.entityRefFor(Register.TypeKey, id)
-    val reply     = AtLeastOnceComplete.askTo(entityRef, Register.Get(_), retryInterval = 200.millis)
+    val reply     = AtLeastOnceComplete.askTo(entityRef, Register.Get(_), retryInterval = 2.seconds)
     reply.await.value
   }
 


### PR DESCRIPTION
`MultiSnapshotSyncSpec` requires compaction that occurs at the appropriate time.
However, the current `retryInterval` of `AtLeastOnceComplete.askTo` can upset it.
Too short `retryInterval` will cause premature compaction because also read-only operations create new LogEntry(NoOp) to guarantee consistency.

The following shows us that increasing `retryInterval` can reduce `NoOp`:
(I extracted and formatted `AppendEntries` sent by the leader to the follower from the debug log)

**retryInterval = 1s**
```
AppendEntries(
    NormalizedShardId(0),
    Term(2),
    member-1,
    0,
    Term(0),
    List(
        LogEntry(1, EntityEvent(None,NoOp), Term(2)),
        LogEntry(2, EntityEvent(Some(NormalizedEntityId(0)),NoOp), Term(2)),
        LogEntry(3, EntityEvent(Some(NormalizedEntityId(0)),NoOp), Term(2)), 
        LogEntry(4, EntityEvent(Some(NormalizedEntityId(0)),NoOp), Term(2)), 
        LogEntry(5, EntityEvent(Some(NormalizedEntityId(1)),SetEvent(1)), Term(2)), 
        LogEntry(6, EntityEvent(Some(NormalizedEntityId(0)),NoOp), Term(2)), 
        LogEntry(7, EntityEvent(Some(NormalizedEntityId(2)),SetEvent(2)), Term(2)), 
        LogEntry(8, EntityEvent(Some(NormalizedEntityId(3)),SetEvent(3)), Term(2)), 
        LogEntry(9, EntityEvent(Some(NormalizedEntityId(4)),SetEvent(4)), Term(2)), 
        LogEntry(10, EntityEvent(Some(NormalizedEntityId(5)),SetEvent(5)), Term(2)), 
        LogEntry(11, EntityEvent(Some(NormalizedEntityId(6)),SetEvent(6)), Term(2)), 
        LogEntry(12, EntityEvent(Some(NormalizedEntityId(7)),SetEvent(7)), Term(2)), 
        LogEntry(13, EntityEvent(Some(NormalizedEntityId(8)),SetEvent(8)), Term(2)), 
        LogEntry(14, EntityEvent(Some(NormalizedEntityId(9)),SetEvent(9)), Term(2)), 
        LogEntry(15, EntityEvent(Some(NormalizedEntityId(10)),SetEvent(10)), Term(2))
    ),
    15
)
```

**retryInterval = 2s** (reduces the number of `NoOp`)
```
AppendEntries(
    NormalizedShardId(0),
    Term(1),
    member-2,
    0,
    Term(0),
    List(
        LogEntry(1, EntityEvent(None,NoOp), Term(1)),
        LogEntry(2, EntityEvent(Some(NormalizedEntityId(0)),NoOp),Term(1)),
        LogEntry(3, EntityEvent(Some(NormalizedEntityId(0)),NoOp),Term(1)), 
        LogEntry(4, EntityEvent(Some(NormalizedEntityId(1)),SetEvent(1)),Term(1)), 
        LogEntry(5, EntityEvent(Some(NormalizedEntityId(2)),SetEvent(2)),Term(1)), 
        LogEntry(6, EntityEvent(Some(NormalizedEntityId(3)),SetEvent(3)), Term(1)), 
        LogEntry(7, EntityEvent(Some(NormalizedEntityId(4)),SetEvent(4)), Term(1)), 
        LogEntry(8, EntityEvent(Some(NormalizedEntityId(5)),SetEvent(5)), Term(1)), 
        LogEntry(9, EntityEvent(Some(NormalizedEntityId(6)),SetEvent(6)), Term(1)), 
        LogEntry(10, EntityEvent(Some(NormalizedEntityId(7)),SetEvent(7)), Term(1)), 
        LogEntry(11, EntityEvent(Some(NormalizedEntityId(8)),SetEvent(8)), Term(1)), 
        LogEntry(12, EntityEvent(Some(NormalizedEntityId(9)),SetEvent(9)), Term(1)), 
        LogEntry(13, EntityEvent(Some(NormalizedEntityId(10)),SetEvent(10)), Term(1))
    ),
    13
)
```
