### PR TITLE
Compaction continues as possible and warns if it might not delete enough entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   This feature is enabled only by using `typed.ClusterReplication`.
   It is highly recommended that you switch using the typed API since the classic API was deprecated.
 
-- Raft actors track the progress of the event sourcing [#136](https://github.com/lerna-stack/akka-entity-replication/issues/136).
+- Raft actors track the progress of the event sourcing
+  [#136](https://github.com/lerna-stack/akka-entity-replication/issues/136),
+  [PR#137](https://github.com/lerna-stack/akka-entity-replication/pull/137),
+  [PR#142](https://github.com/lerna-stack/akka-entity-replication/pull/142).
 
   This feature ensures that
   - Event Sourcing won't halt even if the event-sourcing store is unavailable for a long period.
@@ -36,8 +39,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   It requires that
   `lerna.akka.entityreplication.raft.compaction.preserve-log-size` is less than
-  `lerna.akka.entityreplication.raft.compaction.log-size-threshold`. 
+  `lerna.akka.entityreplication.raft.compaction.log-size-threshold`.
 
+- Compaction warns if it might not delete enough entries [PR#142](https://github.com/lerna-stack/akka-entity-replication/pull/142)
 
 ### Changed
 - Bump up Akka version to 2.6.17 [PR#98](https://github.com/lerna-stack/akka-entity-replication/pull/98)

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
@@ -467,25 +467,28 @@ private[raft] class RaftActor(
 
     if (
       currentData.replicatedLog.entries.size >= settings.compactionLogSizeThreshold
-      && currentData.hasLogEntriesThatCanBeCompacted
+      // This value might be false if Log Replication stops or there is no leader (e.g. split-vote) until SnapshotTick expires.
+      && currentData.hasAppliedLogEntries
     ) {
       val estimatedCompactedLogSize: Int =
         currentData.estimatedReplicatedLogSizeAfterCompaction(settings.compactionPreserveLogSize)
       if (estimatedCompactedLogSize >= settings.compactionLogSizeThreshold) {
+        // This warning might also happen if there is already enough applied entries (>= compactionLogSizeThreshold) when the first SnapshotTick expires.
         if (log.isWarningEnabled) {
           log.warning(
-            "[{}] Skipping compaction since compaction might not delete enough entries " +
-            "(even if this compaction continues, the remaining entries will trigger new compaction at the next tick). " +
+            "[{}] Compaction might not delete enough entries, but will continue to reduce log size as possible " +
+            "(even if this compaction continues, the remaining entries might trigger new compaction at the next tick). " +
             s"Estimated compacted log size is [{}] entries (lastApplied [{}], eventSourcingIndex [{}], preserveLogSize [${settings.compactionPreserveLogSize}]), " +
             s"however compaction.log-size-threshold is [${settings.compactionLogSizeThreshold}] entries. " +
-            "This warning happens if event sourcing is too slow or compaction is too fast.",
+            "This warning might happen if event sourcing is too slow or compaction is too fast (or too slow).",
             currentState,
             estimatedCompactedLogSize,
             currentData.lastApplied,
             currentData.eventSourcingIndex,
           )
         }
-      } else if (snapshotSynchronizationIsInProgress) {
+      }
+      if (snapshotSynchronizationIsInProgress) {
         // Snapshot updates during synchronizing snapshot will break consistency
         if (log.isInfoEnabled)
           log.info("Skipping compaction because snapshot synchronization is in progress")

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftMemberData.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftMemberData.scala
@@ -397,7 +397,8 @@ private[entityreplication] trait RaftMemberData
     prevLogIndex == lastSnapshotStatus.targetSnapshotLastLogIndex
   }
 
-  def hasLogEntriesThatCanBeCompacted: Boolean = {
+  /** Returns true if [[replicatedLog]] has entries that have been already applied */
+  def hasAppliedLogEntries: Boolean = {
     replicatedLog.sliceEntriesFromHead(lastApplied).nonEmpty
   }
 

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorSpec.scala
@@ -75,7 +75,6 @@ class RaftActorSpec extends TestKit(ActorSystem()) with RaftActorSpecBase {
     "ログが追加された後にログの長さがしきい値を超えている場合はスナップショットがとられる" in {
       val snapshotStore       = TestProbe()
       val replicationActor    = TestProbe()
-      val commitLogStore      = TestProbe()
       val shardId             = createUniqueShardId()
       val followerMemberIndex = createUniqueMemberIndex()
       val follower = createRaftActor(
@@ -84,7 +83,6 @@ class RaftActorSpec extends TestKit(ActorSystem()) with RaftActorSpecBase {
         shardSnapshotStore = snapshotStore.ref,
         replicationActor = replicationActor.ref,
         settings = RaftSettings(raftConfig),
-        commitLogStore = commitLogStore.ref,
       )
 
       val leaderMemberIndex = createUniqueMemberIndex()
@@ -371,7 +369,6 @@ class RaftActorSpec extends TestKit(ActorSystem()) with RaftActorSpecBase {
     "prevent to start snapshot synchronization during compaction" in {
       val snapshotStore       = TestProbe()
       val replicationActor    = TestProbe()
-      val commitLogStore      = TestProbe()
       val shardId             = createUniqueShardId()
       val followerMemberIndex = createUniqueMemberIndex()
       val follower = createRaftActor(
@@ -380,7 +377,6 @@ class RaftActorSpec extends TestKit(ActorSystem()) with RaftActorSpecBase {
         shardSnapshotStore = snapshotStore.ref,
         replicationActor = replicationActor.ref,
         settings = RaftSettings(raftConfig),
-        commitLogStore = commitLogStore.ref,
       )
 
       val leaderMemberIndex = createUniqueMemberIndex()
@@ -432,7 +428,6 @@ class RaftActorSpec extends TestKit(ActorSystem()) with RaftActorSpecBase {
     "not persist snapshots that have already been persisted in the next compaction" in {
       val snapshotStore       = TestProbe()
       val replicationActor    = TestProbe()
-      val commitLogStore      = TestProbe()
       val shardId             = createUniqueShardId()
       val followerMemberIndex = createUniqueMemberIndex()
       val follower = createRaftActor(
@@ -441,7 +436,6 @@ class RaftActorSpec extends TestKit(ActorSystem()) with RaftActorSpecBase {
         shardSnapshotStore = snapshotStore.ref,
         replicationActor = replicationActor.ref,
         settings = RaftSettings(raftConfig),
-        commitLogStore = commitLogStore.ref,
       )
 
       val leaderMemberIndex = createUniqueMemberIndex()
@@ -486,10 +480,6 @@ class RaftActorSpec extends TestKit(ActorSystem()) with RaftActorSpecBase {
         ),
         leaderCommit = LogEntryIndex(7),
       )
-
-      // To ensure compaction starts, CommitLogStore should handle AppendCommittedEntries.
-      commitLogStore.expectMsg(CommitLogStoreActor.AppendCommittedEntries(shardId, Seq.empty))
-      commitLogStore.reply(CommitLogStoreActor.AppendCommittedEntriesResponse(LogEntryIndex(7)))
 
       // the snapshot should be only for entity2
       replicationActor.fishForSpecificMessage() {

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorSpec.scala
@@ -530,7 +530,8 @@ class RaftActorSpec extends TestKit(ActorSystem()) with RaftActorSpecBase {
           "(even if this compaction continues, the remaining entries might trigger new compaction at the next tick). " +
           "Estimated compacted log size is [3] entries (lastApplied [3], eventSourcingIndex [Some(0)], preserveLogSize [1]), " +
           "however compaction.log-size-threshold is [3] entries. " +
-          "This warning might happen if event sourcing is too slow or compaction is too fast (or too slow).",
+          "This warning might happen if event sourcing is too slow or compaction is too fast (or too slow). " +
+          "If this warning continues, please consult settings related to event sourcing and compaction.",
         ).expect {
           val leaderMemberIndex = createUniqueMemberIndex()
           val entityId          = NormalizedEntityId.from("entity1")


### PR DESCRIPTION
This PR addresses the following (if compaction might not delete enough entries):
1. compaction will continue
2. compaction warns as possible

Compaction calculates estimated compacted log size using (the old `eventSourcingIndex`, which is fetched on the previous `SnapshotTick`). In this nature, if the log continues to grow much faster, the estimated compacted log size might be always greater than or equal to `compaction.log-size-threshold`. In this case, compaction won't happen and the log continues to grow, which consumes much memory. However, if compaction continues in such cases, it sends many snapshots to the snapshot-store every `SnapshotTick`, which might overwhelm the snapshot-store. It might be a trade-off at the time of writing. We might be able to choose either one, this PR chooses the reducing memory (we can choose the other one).

Either way, it is great to warn such cases. This PR attempt to warn as possible (not complete). This warning might be false-positive on the first `SnapshotTick`, which might be acceptable. If the warning continues, we should consult settings related to compaction and event sourcing.