### PR TITLE
Ignore `LogReplicationDuringSnapshotSyncSpec` due to unstable

### DIFF
--- a/src/multi-jvm/scala/lerna/akka/entityreplication/typed/LogReplicationDuringSnapshotSyncSpec.scala
+++ b/src/multi-jvm/scala/lerna/akka/entityreplication/typed/LogReplicationDuringSnapshotSyncSpec.scala
@@ -14,6 +14,7 @@ import akka.util.Timeout
 import com.typesafe.config.{ Config, ConfigFactory }
 import lerna.akka.entityreplication.util.AtLeastOnceComplete
 import lerna.akka.entityreplication.{ STMultiNodeSerializable, STMultiNodeSpec }
+import org.scalatest.Ignore
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -132,12 +133,20 @@ object LogReplicationDuringSnapshotSyncSpecConfig extends MultiNodeConfig {
   })
 }
 
-class LogReplicationDuringSnapshotSyncSpecMultiJvmController extends LogReplicationDuringSnapshotSyncSpec
-class LogReplicationDuringSnapshotSyncSpecMultiJvmNode1      extends LogReplicationDuringSnapshotSyncSpec
-class LogReplicationDuringSnapshotSyncSpecMultiJvmNode2      extends LogReplicationDuringSnapshotSyncSpec
-class LogReplicationDuringSnapshotSyncSpecMultiJvmNode3      extends LogReplicationDuringSnapshotSyncSpec
-class LogReplicationDuringSnapshotSyncSpecMultiJvmNode4      extends LogReplicationDuringSnapshotSyncSpec
+// This test is ignored due to that stabilizing this test in a CI environment is difficult.
+// To enable this test, remove all @Ignore below:
+@Ignore class LogReplicationDuringSnapshotSyncSpecMultiJvmController extends LogReplicationDuringSnapshotSyncSpec
+@Ignore class LogReplicationDuringSnapshotSyncSpecMultiJvmNode1      extends LogReplicationDuringSnapshotSyncSpec
+@Ignore class LogReplicationDuringSnapshotSyncSpecMultiJvmNode2      extends LogReplicationDuringSnapshotSyncSpec
+@Ignore class LogReplicationDuringSnapshotSyncSpecMultiJvmNode3      extends LogReplicationDuringSnapshotSyncSpec
+@Ignore class LogReplicationDuringSnapshotSyncSpecMultiJvmNode4      extends LogReplicationDuringSnapshotSyncSpec
 
+/**
+  * This test doesn't verify specific features but reproduces a specific fault.
+  *
+  * This test verifies that the committed events don't disappear even if new events are produced by entities
+  * while only the leader and the member synchronizing the snapshot exist.
+  */
 class LogReplicationDuringSnapshotSyncSpec
     extends MultiNodeSpec(LogReplicationDuringSnapshotSyncSpecConfig)
     with STMultiNodeSpec {

--- a/src/multi-jvm/scala/lerna/akka/entityreplication/typed/LogReplicationDuringSnapshotSyncSpec.scala
+++ b/src/multi-jvm/scala/lerna/akka/entityreplication/typed/LogReplicationDuringSnapshotSyncSpec.scala
@@ -30,7 +30,9 @@ object LogReplicationDuringSnapshotSyncSpecConfig extends MultiNodeConfig {
 
   testTransport(true)
 
-  private implicit val testKitSettings: TestKitSettings = TestKitSettings(ConfigFactory.load())
+  private implicit val testKitSettings: TestKitSettings = TestKitSettings(
+    ConfigFactory.load().getConfig("akka.actor.testkit.typed"),
+  )
 
   private val testConfig: Config =
     ConfigFactory.parseString {


### PR DESCRIPTION
`LogReplicationDuringSnapshotSyncSpec` throws the following exception:
```
[JVM-4] *** RUN ABORTED ***
[JVM-4]   java.lang.ExceptionInInitializerError:
[JVM-4]   at lerna.akka.entityreplication.typed.LogReplicationDuringSnapshotSyncSpec.<init>(LogReplicationDuringSnapshotSyncSpec.scala:136)
[JVM-4]   at lerna.akka.entityreplication.typed.LogReplicationDuringSnapshotSyncSpecMultiJvmNode3.<init>(LogReplicationDuringSnapshotSyncSpec.scala:132)
[JVM-4]   at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
[JVM-4]   at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
[JVM-4]   at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
[JVM-4]   at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
[JVM-4]   at java.lang.Class.newInstance(Class.java:442)
[JVM-4]   at org.scalatest.tools.Runner$.genSuiteConfig(Runner.scala:1431)
[JVM-4]   at org.scalatest.tools.Runner$.$anonfun$doRunRunRunDaDoRunRun$8(Runner.scala:1239)
[JVM-4]   at scala.collection.immutable.List.map(List.scala:246)
[JVM-4]   ...
[JVM-4]   Cause: com.typesafe.config.ConfigException$Missing: merge of system properties,application.conf @ ...: 1: No configuration setting found for key 'timefactor'
[JVM-4]   at com.typesafe.config.impl.SimpleConfig.findKeyOrNull(SimpleConfig.java:156)
[JVM-4]   at com.typesafe.config.impl.SimpleConfig.findOrNull(SimpleConfig.java:174)
[JVM-4]   at com.typesafe.config.impl.SimpleConfig.find(SimpleConfig.java:188)
[JVM-4]   at com.typesafe.config.impl.SimpleConfig.find(SimpleConfig.java:193)
[JVM-4]   at com.typesafe.config.impl.SimpleConfig.getConfigNumber(SimpleConfig.java:223)
[JVM-4]   at com.typesafe.config.impl.SimpleConfig.getNumber(SimpleConfig.java:229)
[JVM-4]   at com.typesafe.config.impl.SimpleConfig.getDouble(SimpleConfig.java:245)
[JVM-4]   at akka.actor.testkit.typed.TestKitSettings.<init>(TestKitSettings.scala:60)
[JVM-4]   at akka.actor.testkit.typed.TestKitSettings$.apply(TestKitSettings.scala:30)
[JVM-2]   at lerna.akka.entityreplication.typed.LogReplicationDuringSnapshotSyncSpec.<init>(LogReplicationDuringSnapshotSyncSpec.scala:136)
[JVM-4]   at lerna.akka.entityreplication.typed.LogReplicationDuringSnapshotSyncSpecConfig$.<clinit>(LogReplicationDuringSnapshotSyncSpec.scala:33)
[JVM-4]   ...
```

To reproduce, `sbt "multi-jvm:testOnly lerna.akka.entityreplication.typed.LogReplicationDuringSnapshotSyncSpec"`.

`akka.actor.testkit.typed.TestKitSettings$.apply` have to take a config that is the same layout as the `akka.actor.testkit.typed` section ([Akka 2\.6\.17 \- akka\.actor\.testkit\.typed\.TestKitSettings](https://doc.akka.io/api/akka/2.6.17/akka/actor/testkit/typed/TestKitSettings$.html#apply(config:com.typesafe.config.Config):akka.actor.testkit.typed.TestKitSettings)).

Furthermore, `LogReplicationDuringSnapshotSyncSpec` will be ignored due to unstable.