### PR TITLE
Improve CI failure detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,15 +52,14 @@ jobs:
       run: sbt --batch mimaReportBinaryIssues
 
     - name: Run tests
-      continue-on-error: true # results are reported by action-junit-report
       run: sbt coverage test
 
     - name: Run integration tests
-      continue-on-error: true # results are reported by action-junit-report
       run: sh ./scripts/run-multijvm-test.sh 1
 
     - name: Publish test report
       uses: mikepenz/action-junit-report@v2
+      if: ${{ always() }}
       with:
         check_name: ScalaTest Report (Java ${{ matrix.java }})
         report_paths: 'target/**test-reports/TEST-*.xml'


### PR DESCRIPTION
Closes https://github.com/lerna-stack/akka-entity-replication/issues/145

Use `always` instead of `continue-on-error`.
CI will fail if the test runner fails due to initialization errors, etc...

[\[DONT MERGE\] CI will fail due to \`java\.lang\.ExceptionInInitializerError:\` by xirc · Pull Request \#148 · lerna\-stack/akka\-entity\-replication](https://github.com/lerna-stack/akka-entity-replication/pull/148) verifies that CI will fail if `ExceptionInInitializerError` happens.