### PR TITLE
[DONT MERGE] CI will fail due to `java.lang.ExceptionInInitializerError:`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,15 +52,14 @@ jobs:
       run: sbt --batch mimaReportBinaryIssues
 
     - name: Run tests
-      continue-on-error: true # results are reported by action-junit-report
       run: sbt coverage test
 
     - name: Run integration tests
-      continue-on-error: true # results are reported by action-junit-report
       run: sh ./scripts/run-multijvm-test.sh 1
 
     - name: Publish test report
       uses: mikepenz/action-junit-report@v2
+      if: ${{ always() }}
       with:
         check_name: ScalaTest Report (Java ${{ matrix.java }})
         report_paths: 'target/**test-reports/TEST-*.xml'

--- a/src/multi-jvm/scala/lerna/akka/entityreplication/typed/LogReplicationDuringSnapshotSyncSpec.scala
+++ b/src/multi-jvm/scala/lerna/akka/entityreplication/typed/LogReplicationDuringSnapshotSyncSpec.scala
@@ -31,9 +31,7 @@ object LogReplicationDuringSnapshotSyncSpecConfig extends MultiNodeConfig {
 
   testTransport(true)
 
-  private implicit val testKitSettings: TestKitSettings = TestKitSettings(
-    ConfigFactory.load().getConfig("akka.actor.testkit.typed"),
-  )
+  private implicit val testKitSettings: TestKitSettings = TestKitSettings(ConfigFactory.load())
 
   private val testConfig: Config =
     ConfigFactory.parseString {


### PR DESCRIPTION
This PR won't be merged.
This verifies CI will fail if `java.lang.ExceptionInInitializerError:` happens.