### PR TITLE
RaftActor shouldn't delete committed or non-conflict entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 [Unreleased]: https://github.com/lerna-stack/akka-entity-replication/compare/v2.1.0...master
 
+### Fixed
+- RaftActor might delete committed entries [#152](https://github.com/lerna-stack/akka-entity-replication/issues/152)  
+  ⚠️ This fix adds a new persistent event type. It doesn't allow downgrading after being updated.
+
 
 ## [v2.1.0] - 2022-03-24
 [v2.1.0]: https://github.com/lerna-stack/akka-entity-replication/compare/v2.0.0...v2.1.0

--- a/src/main/mima-filters/2.1.0.backwards.excludes/pr-151-fix-append-entries-handling.excludes
+++ b/src/main/mima-filters/2.1.0.backwards.excludes/pr-151-fix-append-entries-handling.excludes
@@ -1,0 +1,22 @@
+# It's OK to exclude the following since protobuf.msg.AppendedEntries is not intend to use by users.
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.akka.entityreplication.protobuf.msg.AppendedEntries.<init>$default$4")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("lerna.akka.entityreplication.protobuf.msg.AppendedEntries.unapply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.akka.entityreplication.protobuf.msg.AppendedEntries.apply$default$4")
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.akka.entityreplication.protobuf.msg.AppendedEntries.apply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.akka.entityreplication.protobuf.msg.AppendedEntries.of")
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.akka.entityreplication.protobuf.msg.AppendedEntries.PREV_LOG_INDEX_FIELD_NUMBER")
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.akka.entityreplication.protobuf.msg.AppendedEntries.prevLogIndex")
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.akka.entityreplication.protobuf.msg.AppendedEntries.withPrevLogIndex")
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.akka.entityreplication.protobuf.msg.AppendedEntries.copy")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("lerna.akka.entityreplication.protobuf.msg.AppendedEntries.copy$default$3")
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.akka.entityreplication.protobuf.msg.AppendedEntries.copy$default$4")
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.akka.entityreplication.protobuf.msg.AppendedEntries.this")
+
+# It's safe to exclude the following since RaftActor#AppendedEntries is package-private.
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.akka.entityreplication.raft.RaftActor#AppendedEntries.prevLogIndex")
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.akka.entityreplication.raft.RaftActor#AppendedEntries.copy")
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.akka.entityreplication.raft.RaftActor#AppendedEntries.copy$default$3")
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.akka.entityreplication.raft.RaftActor#AppendedEntries.this")
+ProblemFilters.exclude[MissingTypesProblem]("lerna.akka.entityreplication.raft.RaftActor$AppendedEntries$")
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.akka.entityreplication.raft.RaftActor#AppendedEntries.apply")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("lerna.akka.entityreplication.raft.RaftActor#AppendedEntries.unapply")

--- a/src/main/protobuf/cluster_replication.proto
+++ b/src/main/protobuf/cluster_replication.proto
@@ -30,6 +30,11 @@ message DetectedNewTerm {
 message AppendedEntries {
   required Term term = 1;
   repeated LogEntry log_entries = 2;
+}
+
+message AppendedEntries_V2_1_0 {
+  required Term term = 1;
+  repeated LogEntry log_entries = 2;
   required LogEntryIndex prev_log_index = 3;
 }
 

--- a/src/main/protobuf/cluster_replication.proto
+++ b/src/main/protobuf/cluster_replication.proto
@@ -32,6 +32,8 @@ message AppendedEntries {
   repeated LogEntry log_entries = 2;
 }
 
+// AppendedEntries_V2_1_0 is for backward compatibility (Don't remove).
+// akka-entity-replication v2.1.0 or below persisted events in this format.
 message AppendedEntries_V2_1_0 {
   required Term term = 1;
   repeated LogEntry log_entries = 2;

--- a/src/main/scala/lerna/akka/entityreplication/raft/Follower.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/Follower.scala
@@ -107,16 +107,16 @@ private[raft] trait Follower { this: RaftActor =>
               become(Follower)
             }
           } else {
-            applyDomainEvent(AppendedEntries(appendEntries.term, appendEntries.entries, appendEntries.prevLogIndex)) {
-              domainEvent =>
-                applyDomainEvent(FollowedLeaderCommit(appendEntries.leader, appendEntries.leaderCommit)) { _ =>
-                  sender() ! AppendEntriesSucceeded(
-                    domainEvent.term,
-                    currentData.replicatedLog.lastLogIndex,
-                    selfMemberIndex,
-                  )
-                  become(Follower)
-                }
+            val newEntries = currentData.resolveNewLogEntries(appendEntries.entries)
+            applyDomainEvent(AppendedEntries(appendEntries.term, newEntries)) { domainEvent =>
+              applyDomainEvent(FollowedLeaderCommit(appendEntries.leader, appendEntries.leaderCommit)) { _ =>
+                sender() ! AppendEntriesSucceeded(
+                  domainEvent.term,
+                  currentData.replicatedLog.lastLogIndex,
+                  selfMemberIndex,
+                )
+                become(Follower)
+              }
             }
           }
         } else { // prevLogIndex と prevLogTerm がマッチするエントリが無かった

--- a/src/main/scala/lerna/akka/entityreplication/raft/Leader.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/Leader.scala
@@ -96,16 +96,16 @@ private[raft] trait Leader { this: RaftActor =>
         if (currentData.hasMatchLogEntry(appendEntries.prevLogIndex, appendEntries.prevLogTerm)) {
           cancelHeartbeatTimeoutTimer()
           if (log.isDebugEnabled) log.debug("=== [Leader] append {} ===", appendEntries)
-          applyDomainEvent(AppendedEntries(appendEntries.term, appendEntries.entries, appendEntries.prevLogIndex)) {
-            domainEvent =>
-              applyDomainEvent(FollowedLeaderCommit(appendEntries.leader, appendEntries.leaderCommit)) { _ =>
-                sender() ! AppendEntriesSucceeded(
-                  domainEvent.term,
-                  currentData.replicatedLog.lastLogIndex,
-                  selfMemberIndex,
-                )
-                become(Follower)
-              }
+          val newEntries = currentData.resolveNewLogEntries(appendEntries.entries)
+          applyDomainEvent(AppendedEntries(appendEntries.term, newEntries)) { domainEvent =>
+            applyDomainEvent(FollowedLeaderCommit(appendEntries.leader, appendEntries.leaderCommit)) { _ =>
+              sender() ! AppendEntriesSucceeded(
+                domainEvent.term,
+                currentData.replicatedLog.lastLogIndex,
+                selfMemberIndex,
+              )
+              become(Follower)
+            }
           }
         } else { // prevLogIndex と prevLogTerm がマッチするエントリが無かった
           if (log.isDebugEnabled) log.debug("=== [Leader] could not append {} ===", appendEntries)

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
@@ -84,10 +84,10 @@ private[entityreplication] object RaftActor {
 
   /** AppendedEntries event contains a term (possibly a new term) and log entries
     *
-    * The log entries include no existing entries on this RaftActor's raft log. RaftActor should truncate
-    * its log entries if the entries conflict with its log, and then append the entries.
+    * The log entries include no existing entries.
+    * RaftActor should truncate its log if the entries conflict with its log,and then append the entries.
     *
-    * Note that the index of the entries MUST be continuously increasing (not checked at instantiating an instance of this class)
+    * @note The index of the entries MUST be continuously increasing (not checked at instantiating an instance of this class)
     */
   final case class AppendedEntries(term: Term, logEntries: Seq[LogEntry])
       extends PersistEvent

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
@@ -18,6 +18,8 @@ import lerna.akka.entityreplication.raft.snapshot.sync.SnapshotSyncManager
 import lerna.akka.entityreplication.util.ActorIds
 import lerna.akka.entityreplication.{ ClusterReplicationSerializable, ReplicationActorContext, ReplicationRegion }
 
+import scala.annotation.nowarn
+
 private[entityreplication] object RaftActor {
 
   def props(
@@ -79,9 +81,24 @@ private[entityreplication] object RaftActor {
   final case class BegunNewTerm(term: Term)                  extends PersistEvent with ClusterReplicationSerializable
   final case class Voted(term: Term, candidate: MemberIndex) extends PersistEvent with ClusterReplicationSerializable
   final case class DetectedNewTerm(term: Term)               extends PersistEvent with ClusterReplicationSerializable
-  final case class AppendedEntries(term: Term, logEntries: Seq[LogEntry], prevLogIndex: LogEntryIndex)
+
+  /** AppendedEntries event contains a term (possibly a new term) and log entries
+    *
+    * The log entries include no existing entries on this RaftActor's raft log. RaftActor should truncate
+    * its log entries if the entries conflict with its log, and then append the entries.
+    *
+    * Note that the index of the entries MUST be continuously increasing (not checked at instantiating an instance of this class)
+    */
+  final case class AppendedEntries(term: Term, logEntries: Seq[LogEntry])
       extends PersistEvent
       with ClusterReplicationSerializable
+
+  @deprecated("Use RaftActor.AppendedEntries instead.", "2.1.1")
+  /** This class is for backward compatibility */
+  final case class AppendedEntries_V2_1_0(term: Term, logEntries: Seq[LogEntry], prevLogIndex: LogEntryIndex)
+      extends PersistEvent
+      with ClusterReplicationSerializable
+
   final case class AppendedEvent(event: EntityEvent) extends PersistEvent with ClusterReplicationSerializable
   final case class CompactionCompleted(
       memberIndex: MemberIndex,
@@ -199,6 +216,7 @@ private[raft] class RaftActor(
 
   val numberOfMembers: Int = settings.replicationFactor
 
+  @nowarn("msg=Use RaftMemberData.truncateAndAppendEntries instead.")
   protected def updateState(domainEvent: DomainEvent): RaftMemberData =
     domainEvent match {
       case BegunNewTerm(term) =>
@@ -207,7 +225,11 @@ private[raft] class RaftActor(
         currentData.vote(candidate, term)
       case DetectedNewTerm(term) =>
         currentData.syncTerm(term)
-      case AppendedEntries(term, logEntries, prevLogIndex) =>
+      case AppendedEntries(term, logEntries) =>
+        currentData
+          .syncTerm(term)
+          .truncateAndAppendEntries(logEntries)
+      case AppendedEntries_V2_1_0(term, logEntries, prevLogIndex) =>
         currentData
           .syncTerm(term)
           .appendEntries(logEntries, prevLogIndex)

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftMemberData.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftMemberData.scala
@@ -146,14 +146,6 @@ private[entityreplication] trait FollowerData { self: RaftMemberData =>
           conflictIndex > commitIndex,
           s"The entry with index [$conflictIndex] should not conflict with the committed entry (commitIndex [$commitIndex])",
         )
-        assert(
-          conflictIndex > replicatedLog.ancestorLastIndex,
-          s"The entry with index [$conflictIndex] should not conflict with the compacted entry (ancestorLastIndex [${replicatedLog.ancestorLastIndex}])",
-        )
-        assert(
-          conflictIndex <= replicatedLog.lastLogIndex,
-          s"The entry with index [$conflictIndex] should conflict with an exising entry, but didn't (lastLogIndex [${replicatedLog.lastLogIndex}])",
-        )
         val newEntries = logEntries
           .dropWhile(_.index < conflictIndex)
         assert(

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftMemberData.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftMemberData.scala
@@ -5,6 +5,7 @@ import lerna.akka.entityreplication.model.NormalizedEntityId
 import lerna.akka.entityreplication.raft.model._
 import lerna.akka.entityreplication.raft.routing.MemberIndex
 import lerna.akka.entityreplication.raft.snapshot.SnapshotProtocol.EntitySnapshotMetadata
+import org.slf4j.{ Logger, LoggerFactory }
 
 private[entityreplication] object PersistentStateData {
 
@@ -104,9 +105,75 @@ private[entityreplication] trait FollowerData { self: RaftMemberData =>
     updatePersistentState(currentTerm = term, votedFor = Some(candidate))
   }
 
+  /** Returns new entries that contain no existing entries
+    *
+    * While the given entries could conflict with the existing entries, this method finds such a conflict and returns entries
+    * beginning with the conflicting. [[ReplicatedLog.findConflict]] describes what conflicting means.
+    *
+    * The given entries should start with an index less than or equal to the last index of exising entries plus one.
+    * If this requirement breaks, this method throws an [[IllegalArgumentException]] since it will miss some entries.
+    *
+    * Note that the index of the given entries MUST be continuously increasing (not checked on this method)
+    *
+    * @see [[ReplicatedLog.findConflict]]
+    */
+  def resolveNewLogEntries(logEntries: Seq[LogEntry]): Seq[LogEntry] = {
+    import ReplicatedLog.FindConflictResult
+    require(
+      logEntries.isEmpty || logEntries.head.index <= replicatedLog.lastLogIndex.plus(1),
+      s"The given non-empty log entries (indices: [${logEntries.head.index}..${logEntries.last.index}]) should start with an index " +
+      s"less than or equal to lastLogIndex[${replicatedLog.lastLogIndex}] + 1. " +
+      "If this requirement breaks, the raft log will miss some entries.",
+    )
+    replicatedLog.findConflict(logEntries) match {
+      case FindConflictResult.NoConflict =>
+        logEntries
+          .dropWhile(_.index <= replicatedLog.lastLogIndex)
+          .ensuring(
+            _.headOption.forall(_.index == replicatedLog.lastLogIndex.plus(1)),
+            s"The new entries (not-empty) should start with lastLogIndex ${replicatedLog.lastLogIndex} + 1.",
+          )
+      case FindConflictResult.ConflictFound(conflictIndex, conflictTerm) =>
+        if (log.isInfoEnabled) {
+          log.info(
+            "found conflict at index [{}] (existing term: [{}], conflicting term: [{}]).",
+            conflictIndex,
+            replicatedLog.termAt(conflictIndex),
+            conflictTerm,
+          )
+        }
+        assert(
+          conflictIndex > commitIndex,
+          s"The entry with index [$conflictIndex] should not conflict with the committed entry (commitIndex [$commitIndex])",
+        )
+        assert(
+          conflictIndex > replicatedLog.ancestorLastIndex,
+          s"The entry with index [$conflictIndex] should not conflict with the compacted entry (ancestorLastIndex [${replicatedLog.ancestorLastIndex}])",
+        )
+        assert(
+          conflictIndex <= replicatedLog.lastLogIndex,
+          s"The entry with index [$conflictIndex] should conflict with an exising entry, but didn't (lastLogIndex [${replicatedLog.lastLogIndex}])",
+        )
+        val newEntries = logEntries
+          .dropWhile(_.index < conflictIndex)
+        assert(
+          newEntries.nonEmpty && newEntries.head.index == conflictIndex,
+          s"The new entries (containing conflicts, size=[${newEntries.size}]) should always be non-empty and start with the conflict Index [$conflictIndex]",
+        )
+        newEntries
+    }
+  }
+
+  @deprecated("Use RaftMemberData.truncateAndAppendEntries instead.", "2.1.1")
   def appendEntries(logEntries: Seq[LogEntry], prevLogIndex: LogEntryIndex): RaftMemberData = {
     updatePersistentState(
       replicatedLog = replicatedLog.merge(logEntries, prevLogIndex),
+    )
+  }
+
+  def truncateAndAppendEntries(logEntries: Seq[LogEntry]): RaftMemberData = {
+    updatePersistentState(
+      replicatedLog = replicatedLog.truncateAndAppend(logEntries),
     )
   }
 
@@ -351,6 +418,8 @@ private[entityreplication] trait RaftMemberData
     with CandidateData
     with LeaderData
     with ShardData {
+
+  protected val log: Logger = LoggerFactory.getLogger(getClass)
 
   protected def selectApplicableLogEntries: Seq[LogEntry] =
     if (commitIndex > lastApplied) {

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftMemberData.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftMemberData.scala
@@ -113,8 +113,7 @@ private[entityreplication] trait FollowerData { self: RaftMemberData =>
     * The given entries should start with an index less than or equal to the last index of exising entries plus one.
     * If this requirement breaks, this method throws an [[IllegalArgumentException]] since it will miss some entries.
     *
-    * Note that the index of the given entries MUST be continuously increasing (not checked on this method)
-    *
+    * @note The index of the given entries MUST be continuously increasing (not checked on this method)
     * @see [[ReplicatedLog.findConflict]]
     */
   def resolveNewLogEntries(logEntries: Seq[LogEntry]): Seq[LogEntry] = {

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftMemberData.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftMemberData.scala
@@ -142,7 +142,7 @@ private[entityreplication] trait FollowerData { self: RaftMemberData =>
             conflictTerm,
           )
         }
-        assert(
+        require(
           conflictIndex > commitIndex,
           s"The entry with index [$conflictIndex] should not conflict with the committed entry (commitIndex [$commitIndex])",
         )

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftMemberData.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftMemberData.scala
@@ -136,7 +136,8 @@ private[entityreplication] trait FollowerData { self: RaftMemberData =>
       case FindConflictResult.ConflictFound(conflictIndex, conflictTerm) =>
         if (log.isInfoEnabled) {
           log.info(
-            "found conflict at index [{}] (existing term: [{}], conflicting term: [{}]).",
+            "Found conflict at index [{}] (existing term: [{}], conflicting term: [{}]). " +
+            "Raft Protocol is resolving this conflict safely. No action is required.",
             conflictIndex,
             replicatedLog.termAt(conflictIndex),
             conflictTerm,

--- a/src/main/scala/lerna/akka/entityreplication/raft/model/ReplicatedLog.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/model/ReplicatedLog.scala
@@ -178,7 +178,7 @@ private[entityreplication] final case class ReplicatedLog private[model] (
         s" The head index [$headIndex] of the given entries with indices [${thatEntries.head.index}..${thatEntries.last.index}]" +
         s" should be between ancestorLastIndex([$ancestorLastIndex])+1 and lastLogIndex([$lastLogIndex])+1.",
       )
-      val truncatedEntries = this.entries.takeWhile(_.index < headIndex)
+      val truncatedEntries = sliceEntriesFromHead(headIndex.prev())
       val newEntries       = truncatedEntries ++ thatEntries
       copy(newEntries)
     }

--- a/src/main/scala/lerna/akka/entityreplication/raft/model/ReplicatedLog.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/model/ReplicatedLog.scala
@@ -130,14 +130,14 @@ private[entityreplication] final case class ReplicatedLog private[model] (
     } else {
       require(
         thatEntries.head.index >= ancestorLastIndex,
-        s"Could not find conflict with already compacted entries excluding the last one " +
+        s"The given entries shouldn't contain compacted entries, excluding the last one " +
         s"(ancestorLastIndex: [$ancestorLastIndex], ancestorLastTerm: [${ancestorLastTerm.term}]), " +
         s"but got entries (indices: [${thatEntries.head.index}..${thatEntries.last.index}]).",
       )
       require(
         thatEntries.head.index != ancestorLastIndex || thatEntries.head.term == ancestorLastTerm,
-        s"The last compacted entry (ancestorLastIndex: [$ancestorLastIndex], ancestorLastTerm: [${ancestorLastTerm.term}]) " +
-        s"should not conflict with the given first entry (index: [${thatEntries.head.index}], term: [${thatEntries.head.term.term}]).",
+        s"The given first entry (index: [${thatEntries.head.index}], term: [${thatEntries.head.term.term}]) " +
+        s"shouldn't conflict with the last compacted entry (ancestorLastIndex: [$ancestorLastIndex], ancestorLastTerm: [${ancestorLastTerm.term}]).",
       )
       val conflictEntryOption = thatEntries.find(entry => {
         termAt(entry.index).exists(_ != entry.term)

--- a/src/main/scala/lerna/akka/entityreplication/raft/model/ReplicatedLog.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/model/ReplicatedLog.scala
@@ -176,7 +176,7 @@ private[entityreplication] final case class ReplicatedLog private[model] (
         headIndex >= ancestorLastIndex.plus(1) && headIndex <= lastLogIndex.plus(1),
         "Replicated log should not contain a missing entry." +
         s" The head index [$headIndex] of the given entries with indices [${thatEntries.head.index}..${thatEntries.last.index}]" +
-        s" should be between ($ancestorLastIndex + 1) and ($lastLogIndex + 1).",
+        s" should be between ancestorLastIndex([$ancestorLastIndex])+1 and lastLogIndex([$lastLogIndex])+1.",
       )
       val truncatedEntries = this.entries.takeWhile(_.index < headIndex)
       val newEntries       = truncatedEntries ++ thatEntries

--- a/src/main/scala/lerna/akka/entityreplication/raft/model/ReplicatedLog.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/model/ReplicatedLog.scala
@@ -100,7 +100,7 @@ private[entityreplication] final case class ReplicatedLog private[model] (
 
   /** Finds the index of the conflict
     *
-    * This returns the first index of conflicting entries between existing entries and the given entries.
+    * This method returns the first index of conflicting entries between existing entries and the given entries.
     * If there is no conflict, this returns [[FindConflictResult.NoConflict]].
     * An entry is considered to be conflicting if it has the same index but a different term.
     *
@@ -111,7 +111,8 @@ private[entityreplication] final case class ReplicatedLog private[model] (
     *  conflict: index=3 and term =2
     * </pre>
     *
-    * If there is no overlapping between exising entries and the given entries, this returns [[FindConflictResult.NoConflict]].
+    * If there is no overlapping index between exising entries and the given entries,
+    * this method returns [[FindConflictResult.NoConflict]].
     *
     * @throws IllegalArgumentException
     *   - if the given entries contains the already compacted entries, excluding the last one.
@@ -160,12 +161,12 @@ private[entityreplication] final case class ReplicatedLog private[model] (
   /** Truncates the exising entries and appends the given entries
     *
     * This method truncates the existing entries with an index greater than or equal to the first index of the given entries.
-    * If the given entries are empty, this method doesn't truncate any entries.
+    * If the given entries are empty, this method truncates no entry.
     *
     * The given entries should start with an index less than or equal to the last index of exising entries plus one.
     * If this requirement breaks, this method throws an [[IllegalArgumentException]] since it will miss some entries.
     *
-    * Note that the index of the given entries MUST be continuously increasing (not checked on this method).
+    * @note The index of the given entries MUST be continuously increasing (not checked on this method).
     */
   def truncateAndAppend(thatEntries: Seq[LogEntry]): ReplicatedLog = {
     if (thatEntries.isEmpty) {

--- a/src/multi-jvm/scala/lerna/akka/entityreplication/raft/RaftActorMultiNodeSpec.scala
+++ b/src/multi-jvm/scala/lerna/akka/entityreplication/raft/RaftActorMultiNodeSpec.scala
@@ -327,13 +327,12 @@ class RaftActorMultiNodeSpec extends MultiNodeSpec(RaftActorSpecConfig) with STM
         )
         awaitCond(getState(leaderMember).stateName == Leader)
         val leaderData = getState(leaderMember).stateData
-        val log = leaderData.replicatedLog.merge(
+        val log = leaderData.replicatedLog.truncateAndAppend(
           Seq(
             LogEntry(LogEntryIndex(1), EntityEvent(Option(entityId), "correct1"), Term(1)),
             LogEntry(LogEntryIndex(2), EntityEvent(Option(entityId), "correct2"), Term(1)),
             LogEntry(LogEntryIndex(3), EntityEvent(Option(entityId), "correct3"), Term(1)),
           ),
-          LogEntryIndex.initial(),
         )
         setState(leaderMember, Leader, leaderData.asInstanceOf[RaftMemberDataImpl].copy(replicatedLog = log))
       }
@@ -341,12 +340,11 @@ class RaftActorMultiNodeSpec extends MultiNodeSpec(RaftActorSpecConfig) with STM
         followerMember = createRaftActor(shardId)
         awaitCond(getState(followerMember).stateName == Follower)
         val followerData = getState(followerMember).stateData
-        val conflictLog = followerData.replicatedLog.merge(
+        val conflictLog = followerData.replicatedLog.truncateAndAppend(
           Seq(
             LogEntry(LogEntryIndex(1), EntityEvent(Option(entityId), "conflict1"), Term(1)),
             LogEntry(LogEntryIndex(2), EntityEvent(Option(entityId), "conflict2"), Term(1)),
           ),
-          LogEntryIndex.initial(),
         )
         setState(
           followerMember,

--- a/src/test/scala/lerna/akka/entityreplication/protobuf/ClusterReplicationSerializerSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/protobuf/ClusterReplicationSerializerSpec.scala
@@ -61,6 +61,7 @@ object ClusterReplicationSerializerSpec {
   object MyStopMessage                                  extends KryoSerializable
 }
 
+@nowarn("msg=Use RaftActor.AppendedEntries instead.")
 @nowarn("msg=Use CommitLogStoreActor.AppendCommittedEntries instead.")
 final class ClusterReplicationSerializerSpec
     extends SerializerSpecBase(ActorSystem("ClusterReplicationSerializerSpec")) {
@@ -80,17 +81,34 @@ final class ClusterReplicationSerializerSpec
     checkSerialization(DetectedNewTerm(Term(8417)))
     checkSerialization(
       AppendedEntries(
-        Term(12851),
+        Term(2),
         Seq(
           LogEntry(
             LogEntryIndex(2),
             EntityEvent(None, MyEvent(2141, "message&hello")),
-            Term(9841),
+            Term(1),
           ),
           LogEntry(
-            LogEntryIndex(2),
+            LogEntryIndex(3),
             EntityEvent(Some(NormalizedEntityId.from("shard:1248")), MyEvent(5891, "message?world")),
-            Term(9841),
+            Term(2),
+          ),
+        ),
+      ),
+    )
+    checkSerialization(
+      AppendedEntries_V2_1_0(
+        Term(2),
+        Seq(
+          LogEntry(
+            LogEntryIndex(2),
+            EntityEvent(None, MyEvent(2141, "message&hello")),
+            Term(1),
+          ),
+          LogEntry(
+            LogEntryIndex(3),
+            EntityEvent(Some(NormalizedEntityId.from("shard:1248")), MyEvent(5891, "message?world")),
+            Term(2),
           ),
         ),
         LogEntryIndex(1),

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorCandidateEventSourcingSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorCandidateEventSourcingSpec.scala
@@ -175,7 +175,7 @@ object RaftActorCandidateEventSourcingSpec {
   ): ReplicatedLog = {
     ReplicatedLog()
       .reset(Term(0), LogEntryIndex(0))
-      .merge(entries, LogEntryIndex(0))
+      .truncateAndAppend(entries)
   }
 
 }

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorCandidateReceivingRequestVoteSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorCandidateReceivingRequestVoteSpec.scala
@@ -324,7 +324,7 @@ object RaftActorCandidateReceivingRequestVoteSpec {
   ) = {
     ReplicatedLog()
       .reset(Term(0), LogEntryIndex(0))
-      .merge(entries, LogEntryIndex(0))
+      .truncateAndAppend(entries)
   }
 
 }

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorCandidateSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorCandidateSpec.scala
@@ -72,7 +72,7 @@ class RaftActorCandidateSpec extends TestKit(ActorSystem()) with RaftActorSpecBa
           LogEntry(LogEntryIndex(2), EntityEvent(Option(entityId), "b"), Term(1)),
           LogEntry(LogEntryIndex(3), EntityEvent(Option(entityId), "c"), Term(2)),
         )
-        ReplicatedLog().merge(candidateLogEntries, LogEntryIndex.initial())
+        ReplicatedLog().truncateAndAppend(candidateLogEntries)
       }
       val candidateData = createCandidateData(currentTerm, replicatedLog)
       setState(candidate, Candidate, candidateData)
@@ -163,7 +163,7 @@ class RaftActorCandidateSpec extends TestKit(ActorSystem()) with RaftActorSpecBa
         )
         val replicatedLog = ReplicatedLog()
           .reset(ancestorLastTerm, ancestorLastIndex)
-          .merge(candidateLogEntries, LogEntryIndex(0))
+          .truncateAndAppend(candidateLogEntries)
         createCandidateData(currentTerm, replicatedLog)
       }
       setState(candidate, Candidate, candidateData)
@@ -406,7 +406,7 @@ class RaftActorCandidateSpec extends TestKit(ActorSystem()) with RaftActorSpecBa
         LogEntry(index1, EntityEvent(Option(entityId), "a"), term1),
         LogEntry(index2, EntityEvent(Option(entityId), "b"), term1),
       )
-      val log           = ReplicatedLog().merge(logEntries, LogEntryIndex.initial())
+      val log           = ReplicatedLog().truncateAndAppend(logEntries)
       val candidateData = createCandidateData(term1, log, index2)
 
       // send appendEntries
@@ -439,7 +439,7 @@ class RaftActorCandidateSpec extends TestKit(ActorSystem()) with RaftActorSpecBa
         LogEntry(index2, EntityEvent(Option(entityId), SomeEvent2), term1),
       )
 
-      val log           = ReplicatedLog().merge(logEntries, LogEntryIndex.initial())
+      val log           = ReplicatedLog().truncateAndAppend(logEntries)
       val candidateData = createCandidateData(term1, log, index2)
 
       setState(candidate, Candidate, candidateData)
@@ -470,7 +470,7 @@ class RaftActorCandidateSpec extends TestKit(ActorSystem()) with RaftActorSpecBa
       val leaderLogEntries = Seq(
         LogEntry(index4, EntityEvent(Option(entityId), "e"), term.next()),
       )
-      val log = ReplicatedLog().merge(followerLogEntries, LogEntryIndex.initial())
+      val log = ReplicatedLog().truncateAndAppend(followerLogEntries)
       setState(candidate, Candidate, createCandidateData(term, log))
 
       candidate ! createAppendEntries(shardId, term, leaderMemberIndex, index3, term.next(), leaderLogEntries)
@@ -497,7 +497,7 @@ class RaftActorCandidateSpec extends TestKit(ActorSystem()) with RaftActorSpecBa
       val appendLogEntries = Seq(
         LogEntry(index4, EntityEvent(Option(entityId), "e"), leaderTerm),
       )
-      val log = ReplicatedLog().merge(candidateLogEntries, LogEntryIndex.initial())
+      val log = ReplicatedLog().truncateAndAppend(candidateLogEntries)
       setState(candidate, Candidate, createCandidateData(selfTerm, log))
 
       candidate ! createAppendEntries(shardId, leaderTerm, leaderMemberIndex, index3, leaderTerm, appendLogEntries)
@@ -525,7 +525,7 @@ class RaftActorCandidateSpec extends TestKit(ActorSystem()) with RaftActorSpecBa
         LogEntry(index1, EntityEvent(Option(entityId), "a"), term1),
         LogEntry(index2, EntityEvent(Option(entityId), "b"), term1),
       )
-      val log           = ReplicatedLog().merge(logEntries1, LogEntryIndex.initial())
+      val log           = ReplicatedLog().truncateAndAppend(logEntries1)
       val candidateData = createCandidateData(term1, log, index2)
 
       val logEntries2 = Seq(

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorCandidateSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorCandidateSpec.scala
@@ -1,6 +1,7 @@
 package lerna.akka.entityreplication.raft
 
 import akka.actor.ActorSystem
+import akka.persistence.testkit.scaladsl.PersistenceTestKit
 import akka.testkit.{ TestKit, TestProbe }
 import lerna.akka.entityreplication.ReplicationRegion
 import lerna.akka.entityreplication.model.{ NormalizedEntityId, NormalizedShardId }
@@ -10,12 +11,22 @@ import lerna.akka.entityreplication.raft.protocol.RaftCommands._
 import lerna.akka.entityreplication.raft.routing.MemberIndex
 import org.scalatest.Inside
 
-class RaftActorCandidateSpec extends TestKit(ActorSystem()) with RaftActorSpecBase with Inside {
+class RaftActorCandidateSpec
+    extends TestKit(ActorSystem("RaftActorCandidateSpec", RaftActorSpecBase.configWithPersistenceTestKits))
+    with RaftActorSpecBase
+    with Inside {
 
   import RaftActor._
 
   private[this] val shardId  = NormalizedShardId.from("test-shard")
   private[this] val entityId = NormalizedEntityId.from("test-entity")
+
+  private val persistenceTestKit = PersistenceTestKit(system)
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    persistenceTestKit.clearAll()
+  }
 
   "Candidate" should {
 
@@ -536,6 +547,245 @@ class RaftActorCandidateSpec extends TestKit(ActorSystem()) with RaftActorSpecBa
       expectMsg(AppendEntriesSucceeded(term1, leaderCommit, candidateMemberIndex))
 
       getState(candidate).stateData.commitIndex should be(leaderCommit)
+    }
+
+    "persist the whole new entries starting with the lastLogIndex + 1 " +
+    "if the received AppendEntries message contains no existing entries" in {
+      val shardId              = createUniqueShardId()
+      val candidateMemberIndex = createUniqueMemberIndex()
+      val candidate = createRaftActor(
+        shardId = shardId,
+        selfMemberIndex = candidateMemberIndex,
+      )
+      val candidatePersistenceId = raftActorPersistenceId(shardId = shardId, selfMemberIndex = candidateMemberIndex)
+      val replicatedLog = {
+        val logEntries = Seq(
+          LogEntry(LogEntryIndex(1), EntityEvent(None, NoOp), Term(1)),
+          LogEntry(LogEntryIndex(2), EntityEvent(Some(entityId), "event-1"), Term(1)),
+          LogEntry(LogEntryIndex(3), EntityEvent(None, NoOp), Term(2)),
+        )
+        ReplicatedLog().truncateAndAppend(logEntries)
+      }
+      setState(candidate, Candidate, createCandidateData(Term(3), replicatedLog))
+
+      val leaderMemberIndex = createUniqueMemberIndex()
+      candidate ! createAppendEntries(
+        shardId,
+        Term(3),
+        leaderMemberIndex,
+        prevLogIndex = LogEntryIndex(3),
+        prevLogTerm = Term(2),
+        entries = Seq(
+          LogEntry(LogEntryIndex(4), EntityEvent(None, NoOp), Term(3)),
+          LogEntry(LogEntryIndex(5), EntityEvent(Some(entityId), "event-2"), Term(3)),
+        ),
+      )
+
+      expectMsg(AppendEntriesSucceeded(Term(3), LogEntryIndex(5), candidateMemberIndex))
+      inside(persistenceTestKit.expectNextPersistedType[AppendedEntries](candidatePersistenceId)) {
+        case appendedEntries =>
+          appendedEntries.term should be(Term(3))
+          val expectedEntries = Seq(
+            LogEntry(LogEntryIndex(4), EntityEvent(None, NoOp), Term(3)),
+            LogEntry(LogEntryIndex(5), EntityEvent(Some(entityId), "event-2"), Term(3)),
+          )
+          appendedEntries.logEntries should contain theSameElementsInOrderAs expectedEntries
+          appendedEntries.logEntries.map(_.event) should contain theSameElementsInOrderAs expectedEntries.map(_.event)
+      }
+      inside(getState(candidate)) { candidateState =>
+        candidateState.stateName should be(Follower)
+        inside(candidateState.stateData.replicatedLog.entries) {
+          case logEntries =>
+            val expectedEntries = Seq(
+              LogEntry(LogEntryIndex(1), EntityEvent(None, NoOp), Term(1)),
+              LogEntry(LogEntryIndex(2), EntityEvent(Some(entityId), "event-1"), Term(1)),
+              LogEntry(LogEntryIndex(3), EntityEvent(None, NoOp), Term(2)),
+              LogEntry(LogEntryIndex(4), EntityEvent(None, NoOp), Term(3)),
+              LogEntry(LogEntryIndex(5), EntityEvent(Some(entityId), "event-2"), Term(3)),
+            )
+            logEntries should contain theSameElementsInOrderAs expectedEntries
+            logEntries.map(_.event) should contain theSameElementsInOrderAs expectedEntries.map(_.event)
+        }
+      }
+    }
+
+    "persist only new entries starting with the lastLogIndex + 1 " +
+    "if the received AppendEntries message contains some existing entries" in {
+      val shardId              = createUniqueShardId()
+      val candidateMemberIndex = createUniqueMemberIndex()
+      val candidate = createRaftActor(
+        shardId = shardId,
+        selfMemberIndex = candidateMemberIndex,
+      )
+      val candidatePersistenceId = raftActorPersistenceId(shardId = shardId, selfMemberIndex = candidateMemberIndex)
+      val replicatedLog = {
+        val logEntries = Seq(
+          LogEntry(LogEntryIndex(1), EntityEvent(None, NoOp), Term(1)),
+          LogEntry(LogEntryIndex(2), EntityEvent(Some(entityId), "event-1"), Term(1)),
+          LogEntry(LogEntryIndex(3), EntityEvent(None, NoOp), Term(2)),
+        )
+        ReplicatedLog().truncateAndAppend(logEntries)
+      }
+      setState(candidate, Candidate, createCandidateData(Term(3), replicatedLog))
+
+      val leaderMemberIndex = createUniqueMemberIndex()
+      candidate ! createAppendEntries(
+        shardId,
+        Term(3),
+        leaderMemberIndex,
+        prevLogIndex = LogEntryIndex(2),
+        prevLogTerm = Term(1),
+        entries = Seq(
+          LogEntry(LogEntryIndex(3), EntityEvent(None, NoOp), Term(2)),
+          LogEntry(LogEntryIndex(4), EntityEvent(None, NoOp), Term(3)),
+          LogEntry(LogEntryIndex(5), EntityEvent(Some(entityId), "event-2"), Term(3)),
+        ),
+      )
+
+      expectMsg(AppendEntriesSucceeded(Term(3), LogEntryIndex(5), candidateMemberIndex))
+      inside(persistenceTestKit.expectNextPersistedType[AppendedEntries](candidatePersistenceId)) {
+        case appendedEntries =>
+          appendedEntries.term should be(Term(3))
+          val expectedEntries = Seq(
+            LogEntry(LogEntryIndex(4), EntityEvent(None, NoOp), Term(3)),
+            LogEntry(LogEntryIndex(5), EntityEvent(Some(entityId), "event-2"), Term(3)),
+          )
+          appendedEntries.logEntries should contain theSameElementsInOrderAs expectedEntries
+          appendedEntries.logEntries.map(_.event) should contain theSameElementsInOrderAs expectedEntries.map(_.event)
+      }
+      inside(getState(candidate)) { candidateState =>
+        candidateState.stateName should be(Follower)
+        inside(candidateState.stateData.replicatedLog.entries) {
+          case logEntries =>
+            val expectedEntries = Seq(
+              LogEntry(LogEntryIndex(1), EntityEvent(None, NoOp), Term(1)),
+              LogEntry(LogEntryIndex(2), EntityEvent(Some(entityId), "event-1"), Term(1)),
+              LogEntry(LogEntryIndex(3), EntityEvent(None, NoOp), Term(2)),
+              LogEntry(LogEntryIndex(4), EntityEvent(None, NoOp), Term(3)),
+              LogEntry(LogEntryIndex(5), EntityEvent(Some(entityId), "event-2"), Term(3)),
+            )
+            logEntries should contain theSameElementsInOrderAs expectedEntries
+            logEntries.map(_.event) should contain theSameElementsInOrderAs expectedEntries.map(_.event)
+        }
+      }
+    }
+
+    "persist only new entries (beginning with the first conflict) " +
+    "if the received AppendEntries message contains conflict entries" in {
+      val shardId              = createUniqueShardId()
+      val candidateMemberIndex = createUniqueMemberIndex()
+      val candidate = createRaftActor(
+        shardId = shardId,
+        selfMemberIndex = candidateMemberIndex,
+      )
+      val candidatePersistenceId = raftActorPersistenceId(shardId = shardId, selfMemberIndex = candidateMemberIndex)
+      val replicatedLog = {
+        val logEntries = Seq(
+          LogEntry(LogEntryIndex(1), EntityEvent(None, NoOp), Term(1)),
+          LogEntry(LogEntryIndex(2), EntityEvent(Some(entityId), "event-1"), Term(1)),
+          LogEntry(LogEntryIndex(3), EntityEvent(None, NoOp), Term(4)),
+        )
+        ReplicatedLog().truncateAndAppend(logEntries)
+      }
+      setState(candidate, Candidate, createCandidateData(Term(5), replicatedLog, commitIndex = LogEntryIndex(2)))
+
+      val leaderMemberIndex = createUniqueMemberIndex()
+      candidate ! createAppendEntries(
+        shardId,
+        Term(5),
+        leaderMemberIndex,
+        prevLogIndex = LogEntryIndex(2),
+        prevLogTerm = Term(1),
+        entries = Seq(
+          LogEntry(LogEntryIndex(3), EntityEvent(None, NoOp), Term(3)),
+          LogEntry(LogEntryIndex(4), EntityEvent(None, NoOp), Term(5)),
+          LogEntry(LogEntryIndex(5), EntityEvent(Some(entityId), "event-2"), Term(5)),
+        ),
+      )
+
+      expectMsg(AppendEntriesSucceeded(Term(5), LogEntryIndex(5), candidateMemberIndex))
+      inside(persistenceTestKit.expectNextPersistedType[AppendedEntries](candidatePersistenceId)) {
+        case appendedEntries =>
+          appendedEntries.term should be(Term(5))
+          val expectedEntries = Seq(
+            LogEntry(LogEntryIndex(3), EntityEvent(None, NoOp), Term(3)),
+            LogEntry(LogEntryIndex(4), EntityEvent(None, NoOp), Term(5)),
+            LogEntry(LogEntryIndex(5), EntityEvent(Some(entityId), "event-2"), Term(5)),
+          )
+          appendedEntries.logEntries should contain theSameElementsInOrderAs expectedEntries
+          appendedEntries.logEntries.map(_.event) should contain theSameElementsInOrderAs expectedEntries.map(_.event)
+      }
+      inside(getState(candidate)) { candidateState =>
+        candidateState.stateName should be(Follower)
+        inside(candidateState.stateData.replicatedLog.entries) {
+          case logEntries =>
+            val expectedEntries = Seq(
+              LogEntry(LogEntryIndex(1), EntityEvent(None, NoOp), Term(1)),
+              LogEntry(LogEntryIndex(2), EntityEvent(Some(entityId), "event-1"), Term(1)),
+              LogEntry(LogEntryIndex(3), EntityEvent(None, NoOp), Term(3)),
+              LogEntry(LogEntryIndex(4), EntityEvent(None, NoOp), Term(5)),
+              LogEntry(LogEntryIndex(5), EntityEvent(Some(entityId), "event-2"), Term(5)),
+            )
+            logEntries should contain theSameElementsInOrderAs expectedEntries
+            logEntries.map(_.event) should contain theSameElementsInOrderAs expectedEntries.map(_.event)
+        }
+      }
+    }
+
+    "truncate no entries even if the received AppendEntries message contains all existing entries (not including the last entry)" in {
+      val shardId              = createUniqueShardId()
+      val candidateMemberIndex = createUniqueMemberIndex()
+      val candidate = createRaftActor(
+        shardId = shardId,
+        selfMemberIndex = candidateMemberIndex,
+      )
+      val candidatePersistenceId = raftActorPersistenceId(shardId = shardId, selfMemberIndex = candidateMemberIndex)
+      val replicatedLog = {
+        val logEntries = Seq(
+          LogEntry(LogEntryIndex(1), EntityEvent(None, NoOp), Term(1)),
+          LogEntry(LogEntryIndex(2), EntityEvent(Some(entityId), "event-1"), Term(1)),
+          LogEntry(LogEntryIndex(3), EntityEvent(None, NoOp), Term(2)),
+          LogEntry(LogEntryIndex(4), EntityEvent(Some(entityId), "event-2"), Term(2)),
+        )
+        ReplicatedLog().truncateAndAppend(logEntries)
+      }
+      setState(candidate, Candidate, createCandidateData(Term(3), replicatedLog))
+
+      val leaderMemberIndex = createUniqueMemberIndex()
+      candidate ! createAppendEntries(
+        shardId,
+        Term(3),
+        leaderMemberIndex,
+        prevLogIndex = LogEntryIndex(2),
+        prevLogTerm = Term(1),
+        entries = Seq(
+          LogEntry(LogEntryIndex(3), EntityEvent(None, NoOp), Term(2)),
+          // The following entries will be sent in another AppendEntries batch.
+          // LogEntry(LogEntryIndex(4), EntityEvent(Some(entityId), "event-2"), Term(2)),
+          // LogEntry(LogEntryIndex(5), EntityEvent(None, NoOp), Term(3)),
+        ),
+      )
+
+      expectMsg(AppendEntriesSucceeded(Term(3), LogEntryIndex(4), candidateMemberIndex))
+      inside(persistenceTestKit.expectNextPersistedType[AppendedEntries](candidatePersistenceId)) {
+        case appendedEntries =>
+          appendedEntries.term should be(Term(3))
+          appendedEntries.logEntries should be(empty)
+      }
+      inside(getState(candidate)) { candidateState =>
+        candidateState.stateName should be(Follower)
+        inside(candidateState.stateData.replicatedLog.entries) {
+          case logEntries =>
+            val expectedEntries = Seq(
+              LogEntry(LogEntryIndex(1), EntityEvent(None, NoOp), Term(1)),
+              LogEntry(LogEntryIndex(2), EntityEvent(Some(entityId), "event-1"), Term(1)),
+              LogEntry(LogEntryIndex(3), EntityEvent(None, NoOp), Term(2)),
+              LogEntry(LogEntryIndex(4), EntityEvent(Some(entityId), "event-2"), Term(2)),
+            )
+            logEntries should contain theSameElementsInOrderAs expectedEntries
+            logEntries.map(_.event) should contain theSameElementsInOrderAs expectedEntries.map(_.event)
+        }
+      }
     }
 
   }

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorFollowerEventSourcingSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorFollowerEventSourcingSpec.scala
@@ -171,7 +171,7 @@ object RaftActorFollowerEventSourcingSpec {
   ): ReplicatedLog = {
     ReplicatedLog()
       .reset(Term(0), LogEntryIndex(0))
-      .merge(entries, LogEntryIndex(0))
+      .truncateAndAppend(entries)
   }
 
 }

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorFollowerReceivingRequestVoteSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorFollowerReceivingRequestVoteSpec.scala
@@ -845,7 +845,7 @@ object RaftActorFollowerReceivingRequestVoteSpec {
   ) = {
     ReplicatedLog()
       .reset(ancestorLastTerm = Term(0), ancestorLastIndex = LogEntryIndex(0))
-      .merge(entries, LogEntryIndex(0))
+      .truncateAndAppend(entries)
   }
 
 }

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorLeaderEventSourcingSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorLeaderEventSourcingSpec.scala
@@ -512,7 +512,7 @@ object RaftActorLeaderEventSourcingSpec {
       require(firstIndex == ancestorLastIndex.next())
       ReplicatedLog()
         .reset(ancestorLastTerm, ancestorLastIndex)
-        .merge(entries, firstIndex.prev())
+        .truncateAndAppend(entries)
     }
   }
 

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorLeaderReceivingRequestVoteSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorLeaderReceivingRequestVoteSpec.scala
@@ -304,7 +304,7 @@ object RaftActorLeaderReceivingRequestVoteSpec {
   ) = {
     ReplicatedLog()
       .reset(Term(0), LogEntryIndex(0))
-      .merge(entries, LogEntryIndex(0))
+      .truncateAndAppend(entries)
   }
 
 }

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorSpec.scala
@@ -42,7 +42,7 @@ class RaftActorSpec extends TestKit(ActorSystem()) with RaftActorSpecBase {
         LogEntry(LogEntryIndex(4), EntityEvent(Option(entityId), "c"), term),
       )
       val data = RaftMemberData(
-        replicatedLog = ReplicatedLog().merge(logEntries, LogEntryIndex.initial()),
+        replicatedLog = ReplicatedLog().truncateAndAppend(logEntries),
         lastApplied = LogEntryIndex(3),
       )
       setState(follower, Follower, data)

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorSpec.scala
@@ -3,10 +3,11 @@ package lerna.akka.entityreplication.raft
 import akka.actor.testkit.typed.scaladsl.LoggingTestKit
 import akka.actor.typed.scaladsl.adapter._
 import akka.actor.{ typed, ActorSystem }
+import akka.persistence.testkit.scaladsl.PersistenceTestKit
 import akka.testkit.{ TestKit, TestProbe }
 import com.typesafe.config.ConfigFactory
 import lerna.akka.entityreplication.model.NormalizedEntityId
-import lerna.akka.entityreplication.raft.RaftActor.Follower
+import lerna.akka.entityreplication.raft.RaftActor.{ AppendedEntries_V2_1_0, Follower }
 import lerna.akka.entityreplication.raft.RaftProtocol._
 import lerna.akka.entityreplication.raft.eventsourced.CommitLogStoreActor
 import lerna.akka.entityreplication.raft.model._
@@ -14,14 +15,24 @@ import lerna.akka.entityreplication.raft.protocol.RaftCommands.InstallSnapshot
 import lerna.akka.entityreplication.raft.protocol.{ FetchEntityEvents, FetchEntityEventsResponse }
 import lerna.akka.entityreplication.raft.snapshot.SnapshotProtocol._
 
+import scala.annotation.nowarn
+
 object RaftActorSpec {
   final case object DummyEntityState
 }
 
-class RaftActorSpec extends TestKit(ActorSystem()) with RaftActorSpecBase {
+class RaftActorSpec
+    extends TestKit(ActorSystem("RaftActorSpec", RaftActorSpecBase.configWithPersistenceTestKits))
+    with RaftActorSpecBase {
   import RaftActorSpec._
 
   private implicit val typedSystem: typed.ActorSystem[Nothing] = system.toTyped
+  private val persistenceTestKit                               = PersistenceTestKit(system)
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    persistenceTestKit.clearAll()
+  }
 
   "RaftActor receiving FetchEntityEvents" should {
     "reply FetchEntityEventsResponse" in {
@@ -546,4 +557,66 @@ class RaftActorSpec extends TestKit(ActorSystem()) with RaftActorSpecBase {
     }
 
   }
+
+  "RaftActor" should {
+
+    "recover by reading AppendedEntries_V2_1_0 for backward compatibility" in {
+      val shardId             = createUniqueShardId()
+      val followerMemberIndex = createUniqueMemberIndex()
+
+      val followerPersistenceId = raftActorPersistenceId(shardId = shardId, selfMemberIndex = followerMemberIndex)
+      persistenceTestKit.persistForRecovery(
+        followerPersistenceId,
+        Seq(
+          AppendedEntries_V2_1_0(
+            Term(1),
+            Seq(
+              LogEntry(LogEntryIndex(1), EntityEvent(None, NoOp), Term(1)),
+              LogEntry(LogEntryIndex(2), EntityEvent(Some(NormalizedEntityId.from("1")), "event-1"), Term(1)),
+            ),
+            LogEntryIndex(0),
+          ): @nowarn,
+          AppendedEntries_V2_1_0(
+            Term(1),
+            Seq(
+              LogEntry(LogEntryIndex(3), EntityEvent(Some(NormalizedEntityId.from("1")), "event-2"), Term(1)),
+            ),
+            LogEntryIndex(2),
+          ): @nowarn,
+          AppendedEntries_V2_1_0(
+            Term(2),
+            Seq(
+              LogEntry(LogEntryIndex(3), EntityEvent(None, NoOp), Term(2)),
+              LogEntry(LogEntryIndex(4), EntityEvent(Some(NormalizedEntityId.from("2")), "event-1"), Term(2)),
+              LogEntry(LogEntryIndex(5), EntityEvent(Some(NormalizedEntityId.from("2")), "event-2"), Term(2)),
+            ),
+            LogEntryIndex(2),
+          ): @nowarn,
+          AppendedEntries_V2_1_0(
+            Term(2),
+            Seq(
+              LogEntry(LogEntryIndex(4), EntityEvent(Some(NormalizedEntityId.from("2")), "event-1"), Term(2)),
+            ),
+            LogEntryIndex(3),
+          ): @nowarn,
+        ),
+      )
+      val expectedEntriesAfterRecover = Seq(
+        LogEntry(LogEntryIndex(1), EntityEvent(None, NoOp), Term(1)),
+        LogEntry(LogEntryIndex(2), EntityEvent(Some(NormalizedEntityId.from("1")), "event-1"), Term(1)),
+        LogEntry(LogEntryIndex(3), EntityEvent(None, NoOp), Term(2)),
+        LogEntry(LogEntryIndex(4), EntityEvent(Some(NormalizedEntityId.from("2")), "event-1"), Term(2)),
+      )
+
+      val follower = createRaftActor(
+        shardId = shardId,
+        selfMemberIndex = followerMemberIndex,
+      )
+      val recoveredLogEntries = getState(follower).stateData.replicatedLog.entries
+      recoveredLogEntries should contain theSameElementsInOrderAs expectedEntriesAfterRecover
+      recoveredLogEntries.map(_.event) should contain theSameElementsInOrderAs expectedEntriesAfterRecover.map(_.event)
+    }
+
+  }
+
 }

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftMemberDataSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftMemberDataSpec.scala
@@ -24,7 +24,7 @@ final class RaftMemberDataSpec extends FlatSpec with Matchers with Inside {
       LogEntry(LogEntryIndex(7), EntityEvent(Option(entityId2), "f"), term),
     )
     val data = RaftMemberData(
-      replicatedLog = ReplicatedLog().merge(logEntries, prevLogIndex = LogEntryIndex.initial()),
+      replicatedLog = ReplicatedLog().truncateAndAppend(logEntries),
       lastApplied = LogEntryIndex(5),
     )
     val selectedForEntity1 =
@@ -45,7 +45,7 @@ final class RaftMemberDataSpec extends FlatSpec with Matchers with Inside {
       LogEntry(LogEntryIndex(1), EntityEvent(None, NoOp), term),
     )
     val data = RaftMemberData(
-      replicatedLog = ReplicatedLog().merge(logEntries, prevLogIndex = LogEntryIndex.initial()),
+      replicatedLog = ReplicatedLog().truncateAndAppend(logEntries),
       lastApplied = LogEntryIndex(1),
     )
     val selected =
@@ -68,7 +68,7 @@ final class RaftMemberDataSpec extends FlatSpec with Matchers with Inside {
       LogEntry(LogEntryIndex(7), EntityEvent(Option(entityId2), "f"), term),
     )
     val data = RaftMemberData(
-      replicatedLog = ReplicatedLog().merge(logEntries, prevLogIndex = LogEntryIndex.initial()),
+      replicatedLog = ReplicatedLog().truncateAndAppend(logEntries),
       lastApplied = LogEntryIndex(5),
     )
 
@@ -160,14 +160,13 @@ final class RaftMemberDataSpec extends FlatSpec with Matchers with Inside {
   it should "return estimated compacted log size when lastApplied is greater than eventSourcingIndex" in {
     val entityId = NormalizedEntityId("entity1")
     val replicatedLog = {
-      ReplicatedLog().merge(
+      ReplicatedLog().truncateAndAppend(
         Seq(
           LogEntry(LogEntryIndex(1), EntityEvent(None, NoOp), Term(1)),
           LogEntry(LogEntryIndex(2), EntityEvent(Some(entityId), "event1"), Term(1)),
           LogEntry(LogEntryIndex(3), EntityEvent(None, NoOp), Term(2)),
           LogEntry(LogEntryIndex(4), EntityEvent(Some(entityId), "event2"), Term(2)),
         ),
-        LogEntryIndex(0),
       )
     }
     val data = RaftMemberData(
@@ -182,7 +181,7 @@ final class RaftMemberDataSpec extends FlatSpec with Matchers with Inside {
   it should "return estimated compacted log size when lastApplied is less than eventSourcingIndex" in {
     val entityId = NormalizedEntityId("entity1")
     val replicatedLog = {
-      ReplicatedLog().merge(
+      ReplicatedLog().truncateAndAppend(
         Seq(
           LogEntry(LogEntryIndex(1), EntityEvent(None, NoOp), Term(1)),
           LogEntry(LogEntryIndex(2), EntityEvent(Some(entityId), "event1"), Term(1)),
@@ -190,7 +189,6 @@ final class RaftMemberDataSpec extends FlatSpec with Matchers with Inside {
           LogEntry(LogEntryIndex(4), EntityEvent(Some(entityId), "event2"), Term(2)),
           LogEntry(LogEntryIndex(5), EntityEvent(Some(entityId), "event3"), Term(2)),
         ),
-        LogEntryIndex(0),
       )
     }
     val data = RaftMemberData(
@@ -205,12 +203,11 @@ final class RaftMemberDataSpec extends FlatSpec with Matchers with Inside {
   it should "return estimated compacted log size when eventSourcingIndex is unknown" in {
     val entityId = NormalizedEntityId("entity1")
     val replicatedLog = {
-      ReplicatedLog().merge(
+      ReplicatedLog().truncateAndAppend(
         Seq(
           LogEntry(LogEntryIndex(1), EntityEvent(None, NoOp), Term(1)),
           LogEntry(LogEntryIndex(2), EntityEvent(Some(entityId), "event1"), Term(1)),
         ),
-        LogEntryIndex(0),
       )
     }
     val data = RaftMemberData(
@@ -225,13 +222,12 @@ final class RaftMemberDataSpec extends FlatSpec with Matchers with Inside {
   it should "return estimated compacted log size (preserveLogSize floors this size)" in {
     val entityId = NormalizedEntityId("entity1")
     val replicatedLog = {
-      ReplicatedLog().merge(
+      ReplicatedLog().truncateAndAppend(
         Seq(
           LogEntry(LogEntryIndex(1), EntityEvent(None, NoOp), Term(1)),
           LogEntry(LogEntryIndex(2), EntityEvent(Some(entityId), "event1"), Term(1)),
           LogEntry(LogEntryIndex(3), EntityEvent(Some(entityId), "event2"), Term(1)),
         ),
-        LogEntryIndex(0),
       )
     }
     val data = RaftMemberData(
@@ -249,7 +245,7 @@ final class RaftMemberDataSpec extends FlatSpec with Matchers with Inside {
   it should "throw an IllegalArgumentException if the given preserveLogSize is less than or equals to 0" in {
     val data = {
       val replicatedLog =
-        ReplicatedLog().merge(Seq(LogEntry(LogEntryIndex(1), EntityEvent(None, NoOp), Term(1))), LogEntryIndex(0))
+        ReplicatedLog().truncateAndAppend(Seq(LogEntry(LogEntryIndex(1), EntityEvent(None, NoOp), Term(1))))
       RaftMemberData(
         replicatedLog = replicatedLog,
         commitIndex = LogEntryIndex(1),
@@ -274,7 +270,7 @@ final class RaftMemberDataSpec extends FlatSpec with Matchers with Inside {
   it should "return new RaftMemberData with compacted entries. The number of compacted entries should be greater than or equal to preserveLogSize)" in {
     val entityId = NormalizedEntityId("entity1")
     val replicatedLog = {
-      ReplicatedLog().merge(
+      ReplicatedLog().truncateAndAppend(
         Seq(
           LogEntry(LogEntryIndex(1), EntityEvent(None, NoOp), Term(1)),
           LogEntry(LogEntryIndex(2), EntityEvent(Some(entityId), "event1"), Term(1)),
@@ -282,7 +278,6 @@ final class RaftMemberDataSpec extends FlatSpec with Matchers with Inside {
           LogEntry(LogEntryIndex(4), EntityEvent(Some(entityId), "event2"), Term(2)),
           LogEntry(LogEntryIndex(5), EntityEvent(Some(entityId), "event3"), Term(2)),
         ),
-        LogEntryIndex(0),
       )
     }
     val data = RaftMemberData(
@@ -344,7 +339,7 @@ final class RaftMemberDataSpec extends FlatSpec with Matchers with Inside {
   it should "return new RaftMemberData with compacted entries. The new data should also contain entries with indices between eventSourcingIndex+1 and lastApplied." in {
     val entityId = NormalizedEntityId("entity1")
     val replicatedLog = {
-      ReplicatedLog().merge(
+      ReplicatedLog().truncateAndAppend(
         Seq(
           LogEntry(LogEntryIndex(1), EntityEvent(None, NoOp), Term(1)),
           LogEntry(LogEntryIndex(2), EntityEvent(Some(entityId), "event1"), Term(1)),
@@ -352,7 +347,6 @@ final class RaftMemberDataSpec extends FlatSpec with Matchers with Inside {
           LogEntry(LogEntryIndex(4), EntityEvent(Some(entityId), "event2"), Term(2)),
           LogEntry(LogEntryIndex(5), EntityEvent(Some(entityId), "event3"), Term(2)),
         ),
-        LogEntryIndex(0),
       )
     }
     val data = RaftMemberData(
@@ -385,7 +379,7 @@ final class RaftMemberDataSpec extends FlatSpec with Matchers with Inside {
   it should "return new RaftMemberData with whole entries when eventSourcingIndex is unknown" in {
     val entityId = NormalizedEntityId("entity1")
     val replicatedLog = {
-      ReplicatedLog().merge(
+      ReplicatedLog().truncateAndAppend(
         Seq(
           LogEntry(LogEntryIndex(1), EntityEvent(None, NoOp), Term(1)),
           LogEntry(LogEntryIndex(2), EntityEvent(Some(entityId), "event1"), Term(1)),
@@ -393,7 +387,6 @@ final class RaftMemberDataSpec extends FlatSpec with Matchers with Inside {
           LogEntry(LogEntryIndex(4), EntityEvent(Some(entityId), "event2"), Term(2)),
           LogEntry(LogEntryIndex(5), EntityEvent(Some(entityId), "event3"), Term(2)),
         ),
-        LogEntryIndex(0),
       )
     }
     val data = RaftMemberData(
@@ -417,7 +410,7 @@ final class RaftMemberDataSpec extends FlatSpec with Matchers with Inside {
   it should "throw an IllegalArgumentException if the given preserveLogSize is less than or equals to 0" in {
     val data = {
       val replicatedLog =
-        ReplicatedLog().merge(Seq(LogEntry(LogEntryIndex(1), EntityEvent(None, NoOp), Term(1))), LogEntryIndex(0))
+        ReplicatedLog().truncateAndAppend(Seq(LogEntry(LogEntryIndex(1), EntityEvent(None, NoOp), Term(1))))
       RaftMemberData(
         replicatedLog = replicatedLog,
         commitIndex = LogEntryIndex(1),
@@ -448,13 +441,12 @@ final class RaftMemberDataSpec extends FlatSpec with Matchers with Inside {
   it should "return empty entries when eventSourcingIndex equals commitIndex" in {
     val replicatedLog = {
       val entityId = NormalizedEntityId("entity1")
-      ReplicatedLog().merge(
+      ReplicatedLog().truncateAndAppend(
         Seq(
           LogEntry(LogEntryIndex(1), EntityEvent(None, NoOp), Term(1)),
           LogEntry(LogEntryIndex(2), EntityEvent(Some(entityId), "event1"), Term(1)),
           LogEntry(LogEntryIndex(3), EntityEvent(Some(entityId), "event2"), Term(1)),
         ),
-        LogEntryIndex(0),
       )
     }
     val data = RaftMemberData(
@@ -468,13 +460,12 @@ final class RaftMemberDataSpec extends FlatSpec with Matchers with Inside {
   it should "return empty entries when eventSourcingIndex is larger than commitIndex" in {
     val replicatedLog = {
       val entityId = NormalizedEntityId("entity1")
-      ReplicatedLog().merge(
+      ReplicatedLog().truncateAndAppend(
         Seq(
           LogEntry(LogEntryIndex(1), EntityEvent(None, NoOp), Term(1)),
           LogEntry(LogEntryIndex(2), EntityEvent(Some(entityId), "event1"), Term(1)),
           LogEntry(LogEntryIndex(3), EntityEvent(Some(entityId), "event2"), Term(1)),
         ),
-        LogEntryIndex(0),
       )
     }
     val data = RaftMemberData(
@@ -491,13 +482,12 @@ final class RaftMemberDataSpec extends FlatSpec with Matchers with Inside {
       val entityId = NormalizedEntityId("entity1")
       ReplicatedLog()
         .reset(Term(1), LogEntryIndex(3))
-        .merge(
+        .truncateAndAppend(
           Seq(
             LogEntry(LogEntryIndex(4), EntityEvent(None, NoOp), Term(2)),
             LogEntry(LogEntryIndex(5), EntityEvent(Some(entityId), "event4"), Term(2)),
             LogEntry(LogEntryIndex(6), EntityEvent(Some(entityId), "event5"), Term(2)),
           ),
-          LogEntryIndex(3),
         )
     }
     val data = RaftMemberData(
@@ -516,13 +506,12 @@ final class RaftMemberDataSpec extends FlatSpec with Matchers with Inside {
       val entityId = NormalizedEntityId("entity1")
       ReplicatedLog()
         .reset(Term(1), LogEntryIndex(3))
-        .merge(
+        .truncateAndAppend(
           Seq(
             LogEntry(LogEntryIndex(4), EntityEvent(None, NoOp), Term(2)),
             LogEntry(LogEntryIndex(5), EntityEvent(Some(entityId), "event4"), Term(2)),
             LogEntry(LogEntryIndex(6), EntityEvent(Some(entityId), "event5"), Term(2)),
           ),
-          LogEntryIndex(3),
         )
     }
     val data = RaftMemberData(
@@ -540,13 +529,12 @@ final class RaftMemberDataSpec extends FlatSpec with Matchers with Inside {
     val replicatedLog =
       ReplicatedLog()
         .reset(Term(1), LogEntryIndex(3))
-        .merge(
+        .truncateAndAppend(
           Seq(
             LogEntry(LogEntryIndex(4), EntityEvent(None, NoOp), Term(2)),
             LogEntry(LogEntryIndex(5), EntityEvent(Some(entityId), "event4"), Term(2)),
             LogEntry(LogEntryIndex(6), EntityEvent(Some(entityId), "event5"), Term(2)),
           ),
-          LogEntryIndex(3),
         )
     val data = RaftMemberData(
       eventSourcingIndex = Some(LogEntryIndex(3)),

--- a/src/test/scala/lerna/akka/entityreplication/raft/model/ReplicatedLogSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/model/ReplicatedLogSpec.scala
@@ -570,7 +570,7 @@ class ReplicatedLogSpec extends WordSpecLike with Matchers {
         )
       }
       exception.getMessage should be(
-        "requirement failed: Could not find conflict with already compacted entries excluding the last one " +
+        "requirement failed: The given entries shouldn't contain compacted entries, excluding the last one " +
         "(ancestorLastIndex: [3], ancestorLastTerm: [1]), but got entries (indices: [1..2]).",
       )
     }
@@ -593,8 +593,7 @@ class ReplicatedLogSpec extends WordSpecLike with Matchers {
         )
       }
       exception.getMessage should be(
-        "requirement failed: The last compacted entry (ancestorLastIndex: [2], ancestorLastTerm: [1]) should not conflict " +
-        "with the given first entry (index: [2], term: [1000]).",
+        "requirement failed: The given first entry (index: [2], term: [1000]) shouldn't conflict with the last compacted entry (ancestorLastIndex: [2], ancestorLastTerm: [1]).",
       )
     }
 

--- a/src/test/scala/lerna/akka/entityreplication/raft/model/ReplicatedLogSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/model/ReplicatedLogSpec.scala
@@ -3,6 +3,8 @@ package lerna.akka.entityreplication.raft.model
 import lerna.akka.entityreplication.model.NormalizedEntityId
 import org.scalatest.{ Matchers, WordSpecLike }
 
+import scala.annotation.nowarn
+
 class ReplicatedLogSpec extends WordSpecLike with Matchers {
 
   "ReplicatedLog" should {
@@ -193,7 +195,7 @@ class ReplicatedLogSpec extends WordSpecLike with Matchers {
 
       val log = new ReplicatedLog(followerLog)
 
-      val updatedLog = log.merge(appendEntries, prevLogIndex = LogEntryIndex(2))
+      val updatedLog = log.merge(appendEntries, prevLogIndex = LogEntryIndex(2)): @nowarn
 
       updatedLog.entries should be(expectedLog)
       updatedLog.entries.map(_.event) should contain theSameElementsInOrderAs expectedLog.map(_.event)
@@ -220,7 +222,7 @@ class ReplicatedLogSpec extends WordSpecLike with Matchers {
 
       val log = new ReplicatedLog(followerLog)
 
-      val updatedLog = log.merge(appendEntries, prevLogIndex = LogEntryIndex(2))
+      val updatedLog = log.merge(appendEntries, prevLogIndex = LogEntryIndex(2)): @nowarn
 
       updatedLog.entries should be(expectedLog)
       updatedLog.entries.map(_.event) should contain theSameElementsInOrderAs expectedLog.map(_.event)
@@ -245,7 +247,7 @@ class ReplicatedLogSpec extends WordSpecLike with Matchers {
 
       val log = new ReplicatedLog(followerLog)
 
-      val updatedLog = log.merge(appendEntries, prevLogIndex = LogEntryIndex(0))
+      val updatedLog = log.merge(appendEntries, prevLogIndex = LogEntryIndex(0)): @nowarn
 
       updatedLog.entries should be(expectedLog)
       updatedLog.entries.map(_.event) should contain theSameElementsInOrderAs expectedLog.map(_.event)
@@ -275,7 +277,7 @@ class ReplicatedLogSpec extends WordSpecLike with Matchers {
 
       val log = new ReplicatedLog(followerLog)
 
-      val updatedLog = log.merge(appendEntries, prevLogIndex = LogEntryIndex(1))
+      val updatedLog = log.merge(appendEntries, prevLogIndex = LogEntryIndex(1)): @nowarn
 
       updatedLog.entries should be(expectedLog)
       updatedLog.entries.map(_.event) should contain theSameElementsInOrderAs expectedLog.map(_.event)
@@ -351,13 +353,12 @@ class ReplicatedLogSpec extends WordSpecLike with Matchers {
       assert(emptyWithAncestor.isGivenLogUpToDate(Term(4), LogEntryIndex(7))) // index = lastLogIndex
       assert(emptyWithAncestor.isGivenLogUpToDate(Term(4), LogEntryIndex(8))) // index > lastLogIndex
 
-      val nonEmpty = ReplicatedLog().merge(
+      val nonEmpty = ReplicatedLog().truncateAndAppend(
         Seq(
           LogEntry(LogEntryIndex(1), EntityEvent(None, NoOp), Term(1)),
           LogEntry(LogEntryIndex(2), EntityEvent(None, NoOp), Term(1)),
           LogEntry(LogEntryIndex(3), EntityEvent(None, NoOp), Term(2)),
         ),
-        LogEntryIndex(0),
       )
       assert(nonEmpty.isGivenLogUpToDate(Term(3), LogEntryIndex(2))) // index < lastLogIndex
       assert(nonEmpty.isGivenLogUpToDate(Term(3), LogEntryIndex(3))) // index = lastLogIndex
@@ -375,13 +376,12 @@ class ReplicatedLogSpec extends WordSpecLike with Matchers {
       assert(emptyWithAncestor.isGivenLogUpToDate(Term(3), LogEntryIndex(7))) // index = lastLogIndex
       assert(emptyWithAncestor.isGivenLogUpToDate(Term(3), LogEntryIndex(8))) // index > lastLogIndex
 
-      val nonEmpty = ReplicatedLog().merge(
+      val nonEmpty = ReplicatedLog().truncateAndAppend(
         Seq(
           LogEntry(LogEntryIndex(1), EntityEvent(None, NoOp), Term(1)),
           LogEntry(LogEntryIndex(2), EntityEvent(None, NoOp), Term(1)),
           LogEntry(LogEntryIndex(3), EntityEvent(None, NoOp), Term(2)),
         ),
-        LogEntryIndex(0),
       )
       assert(nonEmpty.isGivenLogUpToDate(Term(2), LogEntryIndex(3))) // index = lastLogIndex
       assert(nonEmpty.isGivenLogUpToDate(Term(2), LogEntryIndex(4))) // index > lastLogIndex
@@ -393,13 +393,12 @@ class ReplicatedLogSpec extends WordSpecLike with Matchers {
       val emptyWithAncestor = ReplicatedLog().reset(Term(3), LogEntryIndex(7))
       assert(!emptyWithAncestor.isGivenLogUpToDate(Term(3), LogEntryIndex(6))) // index < lastLogIndex
 
-      val nonEmpty = ReplicatedLog().merge(
+      val nonEmpty = ReplicatedLog().truncateAndAppend(
         Seq(
           LogEntry(LogEntryIndex(1), EntityEvent(None, NoOp), Term(1)),
           LogEntry(LogEntryIndex(2), EntityEvent(None, NoOp), Term(1)),
           LogEntry(LogEntryIndex(3), EntityEvent(None, NoOp), Term(2)),
         ),
-        LogEntryIndex(0),
       )
       assert(!nonEmpty.isGivenLogUpToDate(Term(2), LogEntryIndex(2))) // index < lastLogIndex
 
@@ -412,13 +411,12 @@ class ReplicatedLogSpec extends WordSpecLike with Matchers {
       assert(!emptyWithAncestor.isGivenLogUpToDate(Term(2), LogEntryIndex(7))) // index = lastLogIndex
       assert(!emptyWithAncestor.isGivenLogUpToDate(Term(2), LogEntryIndex(8))) // index > lastLogIndex
 
-      val nonEmpty = ReplicatedLog().merge(
+      val nonEmpty = ReplicatedLog().truncateAndAppend(
         Seq(
           LogEntry(LogEntryIndex(1), EntityEvent(None, NoOp), Term(1)),
           LogEntry(LogEntryIndex(2), EntityEvent(None, NoOp), Term(1)),
           LogEntry(LogEntryIndex(3), EntityEvent(None, NoOp), Term(2)),
         ),
-        LogEntryIndex(0),
       )
       assert(!nonEmpty.isGivenLogUpToDate(Term(1), LogEntryIndex(2))) // index < lastLogIndex
       assert(!nonEmpty.isGivenLogUpToDate(Term(1), LogEntryIndex(3))) // index = lastLogIndex


### PR DESCRIPTION
Closes https://github.com/lerna-stack/akka-entity-replication/issues/152

There might be two places to be able to fix this bug:
* `AppendedEntries` replay or
* `AppendEntries` handling

This PR changes `AppendEntries` handling to fix this bug.
pros:
* possible to maintain backward compatibility (changing event replay might break the existing Raft log)
* reduce required event storage space since RaftActor persists only new entries (including conflicts)

## TODO
* [x] Fix main code
* [x] Write unit tests
  * [x] `RaftMemberData.resolveNewLogEntries`
  * [x] `ReplicatedLog.findConflict`
  * [x] `ReplicatedLog.truncateAndAppend`
  * [x] receiving `AppendEntries`
  * [x] `RaftActor` can read old `AppenddedEntries` event
* [x] Run one AZ failure gatling scenario (not included in this project) for verifying this bug fixed
* [x] Write an issue describing this bug
* [x] Write CHANGELOG