### PR TITLE
Refactor `Replicate` message

### DIFF
--- a/src/main/mima-filters/2.1.0.backwards.excludes/pr-159-refactor-replicate-message.excludes
+++ b/src/main/mima-filters/2.1.0.backwards.excludes/pr-159-refactor-replicate-message.excludes
@@ -1,0 +1,4 @@
+# It's safe to exclude the following since RaftProtocol is package-private.
+ProblemFilters.exclude[IncompatibleTemplateDefProblem]("lerna.akka.entityreplication.raft.RaftProtocol$Replicate")
+ProblemFilters.exclude[MissingTypesProblem]("lerna.akka.entityreplication.raft.RaftProtocol$Replicate$")
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.akka.entityreplication.raft.RaftProtocol#Replicate.apply")

--- a/src/main/scala/lerna/akka/entityreplication/raft/Leader.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/Leader.scala
@@ -194,12 +194,12 @@ private[raft] trait Leader { this: RaftActor =>
     }
 
   private[this] def replicate(replicate: Replicate): Unit = {
-    replicate.entityId match {
-      case Some(normalizedEntityId) // from entity(ReplicationActor)
-          if currentData.hasUncommittedLogEntryOf(normalizedEntityId) =>
+    replicate match {
+      case replicateForEntity: Replicate.ReplicateForEntity
+          if currentData.hasUncommittedLogEntryOf(replicateForEntity._entityId) =>
         if (log.isWarningEnabled)
           log.warning(
-            s"Failed to replicate the event (${replicate.event.getClass.getName}) since an uncommitted event exists for the entity (entityId: ${normalizedEntityId.raw}). Replicating new events is allowed after the event is committed",
+            s"Failed to replicate the event (${replicate.event.getClass.getName}) since an uncommitted event exists for the entity (entityId: ${replicateForEntity._entityId.raw}). Replicating new events is allowed after the event is committed",
           )
         replicate.replyTo ! ReplicationFailed
 

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftProtocolReplicateSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftProtocolReplicateSpec.scala
@@ -1,0 +1,118 @@
+package lerna.akka.entityreplication.raft
+
+import akka.actor.ActorSystem
+import akka.testkit.{ TestKit, TestProbe }
+import lerna.akka.entityreplication.model.{ EntityInstanceId, NormalizedEntityId }
+import lerna.akka.entityreplication.raft.RaftProtocol.Replicate
+import org.scalatest.Inside
+
+final class RaftProtocolReplicateSpec
+    extends TestKit(ActorSystem("RaftProtocolReplicateSpec"))
+    with ActorSpec
+    with Inside {
+
+  "ReplicateForInternal.entityId should be None" in {
+    val replicateForInternal = Replicate.ReplicateForInternal("event-1", TestProbe().ref)
+    replicateForInternal.entityId should be(None)
+  }
+
+  "ReplicateForInternal.instanceId should be None" in {
+    val replicateForInternal = Replicate.ReplicateForInternal("event-1", TestProbe().ref)
+    replicateForInternal.instanceId should be(None)
+  }
+
+  "ReplicateForInternal.originSender should be None" in {
+    val replicateForInternal = Replicate.ReplicateForInternal("event-1", TestProbe().ref)
+    replicateForInternal.originSender should be(None)
+  }
+
+  "ReplicateForEntity.entityId should be an Option containing the given entityId" in {
+    val replicateForInternal = Replicate.ReplicateForEntity(
+      "event-1",
+      TestProbe().ref,
+      NormalizedEntityId("entity-1"),
+      EntityInstanceId(1),
+      TestProbe().ref,
+    )
+    replicateForInternal.entityId should be(Option(NormalizedEntityId("entity-1")))
+  }
+
+  "ReplicateForEntity.instanceId should be an Option containing the given instanceId" in {
+    val replicateForInternal = Replicate.ReplicateForEntity(
+      "event-1",
+      TestProbe().ref,
+      NormalizedEntityId("entity-1"),
+      EntityInstanceId(1),
+      TestProbe().ref,
+    )
+    replicateForInternal.instanceId should be(Option(EntityInstanceId(1)))
+  }
+
+  "ReplicateForEntity.originSender should be an Option containing the given originSender" in {
+    val originSender = TestProbe().ref
+    val replicateForInternal = Replicate.ReplicateForEntity(
+      "event-1",
+      TestProbe().ref,
+      NormalizedEntityId("entity-1"),
+      EntityInstanceId(1),
+      originSender,
+    )
+    replicateForInternal.originSender should be(Option(originSender))
+  }
+
+  "Replicate.apply should create a ReplicateForEntity instance with the given parameters" in {
+
+    val replyTo      = TestProbe().ref
+    val originSender = TestProbe().ref
+    val replicate    = Replicate("event-1", replyTo, NormalizedEntityId("entity-1"), EntityInstanceId(1), originSender)
+    replicate should be(
+      Replicate.ReplicateForEntity(
+        "event-1",
+        replyTo,
+        NormalizedEntityId("entity-1"),
+        EntityInstanceId(1),
+        originSender,
+      ),
+    )
+
+  }
+
+  "Replicate.internal should create a ReplicateForInternal instance with the given parameters" in {
+    val replyTo   = TestProbe().ref
+    val replicate = Replicate.internal("event-1", replyTo)
+    replicate should be(
+      Replicate.ReplicateForInternal("event-1", replyTo),
+    )
+  }
+
+  "Replicate.unapply should extract values from a ReplicateForInternal instance" in {
+    val replicate = Replicate.ReplicateForInternal("event-1", TestProbe().ref)
+    inside(replicate) {
+      case Replicate(event, replyTo, entityId, instanceId, originSender) =>
+        event should be(replicate.event)
+        replyTo should be(replicate.replyTo)
+        entityId should be(replicate.entityId)
+        instanceId should be(replicate.instanceId)
+        originSender should be(replicate.originSender)
+    }
+  }
+
+  "Replicate.unapply should extract values from a ReplicateForEntity instance" in {
+    val replicate = Replicate.ReplicateForEntity(
+      "event-1",
+      TestProbe().ref,
+      NormalizedEntityId("entity-1"),
+      EntityInstanceId(1),
+      TestProbe().ref,
+    )
+    inside(replicate) {
+      case Replicate(event, replyTo, entityId, instanceId, originSender) =>
+        event should be(replicate.event)
+        replyTo should be(replicate.replyTo)
+        entityId should be(replicate.entityId)
+        instanceId should be(replicate.instanceId)
+        originSender should be(replicate.originSender)
+    }
+  }
+
+}


### PR DESCRIPTION
`RaftActor` can relatively easily recognize whether the given `Replicate` message is for internal use or an entity.

Changes:
* Change `Replicate` to sealed trait
* An instance of `Replicate` is one of the following:
  * `ReplicateForInternal`: Used for internal use (`RaftActor` sends this message to itself)
  * `ReplicateForEntity`: Used for an entity (An entity sends this message to its `RaftActor`)

Considerations:
* This change doesn't affect serialization since `Replicate` is not a remote message.
* This change doesn't require rewriting the existing code.

Since we have a plan to change Leader's `Replicate` message handling, this PR is a preparation for future change.