### PR TITLE
Enhance leader's replication response handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 [Unreleased]: https://github.com/lerna-stack/akka-entity-replication/compare/v2.1.0...master
 
+### Changed
+- Enhance leader's replication response handling [PR#160](https://github.com/lerna-stack/akka-entity-replication/pull/160)
+
 ### Fixed
 - RaftActor might delete committed entries [#152](https://github.com/lerna-stack/akka-entity-replication/issues/152)  
   ⚠️ This fix adds a new persistent event type. It doesn't allow downgrading after being updated.

--- a/src/main/scala/lerna/akka/entityreplication/raft/Leader.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/Leader.scala
@@ -219,8 +219,8 @@ private[raft] trait Leader { this: RaftActor =>
 
   }
 
-  private[this] def receiveReplicationResponse(event: ReplicationResponse): Unit =
-    event match {
+  private[this] def receiveReplicationResponse(replicationResponse: ReplicationResponse): Unit =
+    replicationResponse match {
 
       case ReplicationSucceeded(NoOp, _, _) =>
       // ignore: no-op replication when become leader

--- a/src/main/scala/lerna/akka/entityreplication/raft/Leader.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/Leader.scala
@@ -227,6 +227,12 @@ private[raft] trait Leader { this: RaftActor =>
 
       case ReplicationSucceeded(unknownEvent, _, _) =>
         if (log.isWarningEnabled) log.warning("unknown event: {}", unknownEvent)
+
+      case ReplicationFailed =>
+        if (log.isWarningEnabled) {
+          log.warning("[Leader] received the unexpected ReplicationFailed message")
+        }
+
     }
 
   private[this] def startEntityPassivationProcess(entityPath: ActorPath, stopMessage: Any): Unit = {

--- a/src/main/scala/lerna/akka/entityreplication/raft/Leader.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/Leader.scala
@@ -225,8 +225,15 @@ private[raft] trait Leader { this: RaftActor =>
       case ReplicationSucceeded(NoOp, _, _) =>
       // ignore: no-op replication when become leader
 
-      case ReplicationSucceeded(unknownEvent, _, _) =>
-        if (log.isWarningEnabled) log.warning("unknown event: {}", unknownEvent)
+      case ReplicationSucceeded(unknownEvent, logEntryIndex, instanceId) =>
+        if (log.isWarningEnabled) {
+          log.warning(
+            "[Leader] received the unexpected ReplicationSucceeded message: event type=[{}], index=[{}], instanceId=[{}]",
+            unknownEvent.getClass.getName,
+            logEntryIndex,
+            instanceId.map(_.underlying),
+          )
+        }
 
       case ReplicationFailed =>
         if (log.isWarningEnabled) {

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftProtocol.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftProtocol.scala
@@ -52,13 +52,13 @@ private[entityreplication] object RaftProtocol {
   final case class Replica(logEntry: LogEntry)                                            extends EntityCommand
   final case class TakeSnapshot(metadata: EntitySnapshotMetadata, replyTo: ActorRef)      extends EntityCommand
   final case object RecoveryTimeout                                                       extends EntityCommand
-  final case object ReplicationFailed                                                     extends EntityCommand
 
   sealed trait ReplicationResponse
 
   final case class ReplicationSucceeded(event: Any, logEntryIndex: LogEntryIndex, instanceId: Option[EntityInstanceId])
       extends ReplicationResponse
       with EntityCommand
+  final case object ReplicationFailed extends ReplicationResponse with EntityCommand
 
   final case class EntityRecoveryTimeoutException(entityPath: ActorPath) extends RuntimeException
 }

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftProtocol.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftProtocol.scala
@@ -53,12 +53,10 @@ private[entityreplication] object RaftProtocol {
   final case class TakeSnapshot(metadata: EntitySnapshotMetadata, replyTo: ActorRef)      extends EntityCommand
   final case object RecoveryTimeout                                                       extends EntityCommand
 
-  sealed trait ReplicationResponse
-
+  sealed trait ReplicationResponse extends EntityCommand
   final case class ReplicationSucceeded(event: Any, logEntryIndex: LogEntryIndex, instanceId: Option[EntityInstanceId])
       extends ReplicationResponse
-      with EntityCommand
-  final case object ReplicationFailed extends ReplicationResponse with EntityCommand
+  final case object ReplicationFailed extends ReplicationResponse
 
   final case class EntityRecoveryTimeoutException(entityPath: ActorPath) extends RuntimeException
 }

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorLeaderSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorLeaderSpec.scala
@@ -1413,6 +1413,33 @@ class RaftActorLeaderSpec
           replicationActor1.expectMsg(ReplicationFailed)
         }
     }
+
+    "log a warning if it receives a ReplicationSucceeded message containing an event other than NoOp" in {
+      val leader     = createRaftActor()
+      val leaderData = createLeaderData(Term(1))
+      setState(leader, Leader, leaderData)
+
+      LoggingTestKit
+        .warn(
+          "[Leader] received the unexpected ReplicationSucceeded message: event type=[java.lang.String], index=[3], instanceId=[Some(1)]",
+        ).expect {
+          leader ! ReplicationSucceeded("event-1", LogEntryIndex(3), Option(EntityInstanceId(1)))
+        }
+    }
+
+    "log a warning if it receives a ReplicationFailed message" in {
+      val leader     = createRaftActor()
+      val leaderData = createLeaderData(Term(1))
+      setState(leader, Leader, leaderData)
+
+      LoggingTestKit
+        .warn(
+          "[Leader] received the unexpected ReplicationFailed message",
+        ).expect {
+          leader ! ReplicationFailed
+        }
+    }
+
   }
 
   private[this] def createLeaderData(


### PR DESCRIPTION
* `ReplicationFailed` extends `ReplicationResponse`
* `ReplicationResponse` extends `EntityCommand`
  * `ReplicationSucceeded` extends `EntityCommand` via `ReplicationResponse`
  * `ReplicationFaield` extends `EntityCommand` via `ReplicationResponse`
* Enhance `Leader.receiveReplicationResponse` method
  * This method logs a warning when the leader receives the unexpected `ReplicaitonFailed`
  * Add diagnostic information to a warning message about the unexpected `ReplicationSucceeded`
* Add tests for `Leader.receiveReplicationResponse`