### PR TITLE
Leader replies with ReplicationFailed based on entity's last applied index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - An entity on a follower could stick at `WaitForReplication` if the entity has a `ProcessCommand` in its mailbox
   [#157](https://github.com/lerna-stack/akka-entity-replication/issues/157),
   [PR#158](https://github.com/lerna-stack/akka-entity-replication/pull/158)
+- Leader cannot reply to an entity with a `ReplicationFailed` message in some cases
+  [#153](https://github.com/lerna-stack/akka-entity-replication/issues/153),
+  [PR#161](https://github.com/lerna-stack/akka-entity-replication/pull/161)
 
 ## [v2.1.0] - 2022-03-24
 [v2.1.0]: https://github.com/lerna-stack/akka-entity-replication/compare/v2.0.0...v2.1.0

--- a/src/main/mima-filters/2.1.0.backwards.excludes/pr-161-replication-failure-based-on-entitys-applied-index.excludes
+++ b/src/main/mima-filters/2.1.0.backwards.excludes/pr-161-replication-failure-based-on-entitys-applied-index.excludes
@@ -1,0 +1,2 @@
+# It's safe to exclude the following since RaftProtocol is package-private.
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.akka.entityreplication.raft.RaftProtocol#Replicate.unapply")

--- a/src/main/scala/lerna/akka/entityreplication/ReplicationActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/ReplicationActor.scala
@@ -179,6 +179,7 @@ trait ReplicationActor[StateData] extends Actor with Stash with akka.lerna.Stash
       replyTo = self,
       entityId,
       instanceId,
+      lastAppliedLogEntryIndex,
       originSender = sender(),
     )
   }

--- a/src/main/scala/lerna/akka/entityreplication/raft/Candidate.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/Candidate.scala
@@ -191,10 +191,11 @@ private[raft] trait Candidate { this: RaftActor =>
   private def receiveReplicate(replicate: Replicate): Unit = {
     if (log.isWarningEnabled) {
       log.warning(
-        "[Candidate] cannot replicate the event: type=[{}], entityId=[{}], instanceId=[{}]",
+        "[Candidate] cannot replicate the event: type=[{}], entityId=[{}], instanceId=[{}], entityLastAppliedIndex=[{}]",
         replicate.event.getClass.getName,
         replicate.entityId.map(_.raw),
         replicate.instanceId.map(_.underlying),
+        replicate.entityLastAppliedIndex.map(_.underlying),
       )
     }
     replicate.replyTo ! ReplicationFailed

--- a/src/main/scala/lerna/akka/entityreplication/raft/Follower.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/Follower.scala
@@ -162,10 +162,11 @@ private[raft] trait Follower { this: RaftActor =>
   private def receiveReplicate(replicate: Replicate): Unit = {
     if (log.isWarningEnabled) {
       log.warning(
-        "[Follower] cannot replicate the event: type=[{}], entityId=[{}], instanceId=[{}]",
+        "[Follower] cannot replicate the event: type=[{}], entityId=[{}], instanceId=[{}], entityLastAppliedIndex=[{}]",
         replicate.event.getClass.getName,
         replicate.entityId.map(_.raw),
         replicate.instanceId.map(_.underlying),
+        replicate.entityLastAppliedIndex.map(_.underlying),
       )
     }
     replicate.replyTo ! ReplicationFailed

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftMemberData.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftMemberData.scala
@@ -438,12 +438,6 @@ private[entityreplication] trait RaftMemberData
     replicatedLog.sliceEntries(from, to).filter(_.event.entityId.contains(entityId))
   }
 
-  def hasUncommittedLogEntryOf(entityId: NormalizedEntityId): Boolean = {
-    replicatedLog
-      .entriesAfter(index = commitIndex) // uncommitted entries
-      .exists(_.event.entityId.contains(entityId))
-  }
-
   def alreadyVotedOthers(candidate: MemberIndex): Boolean = votedFor.exists(candidate != _)
 
   def hasMatchLogEntry(prevLogIndex: LogEntryIndex, prevLogTerm: Term): Boolean = {

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftProtocol.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftProtocol.scala
@@ -36,6 +36,7 @@ private[entityreplication] object RaftProtocol {
     def replyTo: ActorRef
     def entityId: Option[NormalizedEntityId]
     def instanceId: Option[EntityInstanceId]
+    def entityLastAppliedIndex: Option[LogEntryIndex]
     def originSender: Option[ActorRef]
   }
   object Replicate {
@@ -45,9 +46,10 @@ private[entityreplication] object RaftProtocol {
         event: Any,
         replyTo: ActorRef,
     ) extends Replicate {
-      override def entityId: Option[NormalizedEntityId] = None
-      override def instanceId: Option[EntityInstanceId] = None
-      override def originSender: Option[ActorRef]       = None
+      override def entityId: Option[NormalizedEntityId]          = None
+      override def instanceId: Option[EntityInstanceId]          = None
+      override def entityLastAppliedIndex: Option[LogEntryIndex] = None
+      override def originSender: Option[ActorRef]                = None
     }
 
     /** used for an entity (An entity sends this message to its RaftActor) */
@@ -56,11 +58,13 @@ private[entityreplication] object RaftProtocol {
         replyTo: ActorRef,
         _entityId: NormalizedEntityId,
         _instanceId: EntityInstanceId,
+        _entityLastAppliedIndex: LogEntryIndex,
         _originSender: ActorRef,
     ) extends Replicate {
-      override def entityId: Option[NormalizedEntityId] = Option(_entityId)
-      override def instanceId: Option[EntityInstanceId] = Option(_instanceId)
-      override def originSender: Option[ActorRef]       = Option(_originSender)
+      override def entityId: Option[NormalizedEntityId]          = Option(_entityId)
+      override def instanceId: Option[EntityInstanceId]          = Option(_instanceId)
+      override def entityLastAppliedIndex: Option[LogEntryIndex] = Option(_entityLastAppliedIndex)
+      override def originSender: Option[ActorRef]                = Option(_originSender)
     }
 
     /** Creates a [[Replicate]] message for an entity */
@@ -69,9 +73,10 @@ private[entityreplication] object RaftProtocol {
         replyTo: ActorRef,
         entityId: NormalizedEntityId,
         instanceId: EntityInstanceId,
+        entityLastAppliedIndex: LogEntryIndex,
         originSender: ActorRef,
     ): Replicate = {
-      ReplicateForEntity(event, replyTo, entityId, instanceId, originSender)
+      ReplicateForEntity(event, replyTo, entityId, instanceId, entityLastAppliedIndex, originSender)
     }
 
     /** Creates a [[Replicate]] message for internal use */

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftProtocol.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftProtocol.scala
@@ -79,13 +79,6 @@ private[entityreplication] object RaftProtocol {
       ReplicateForInternal(event, replyTo)
     }
 
-    /** Extracts field values from the given `replicate` message */
-    def unapply(
-        replicate: Replicate,
-    ): Option[(Any, ActorRef, Option[NormalizedEntityId], Option[EntityInstanceId], Option[ActorRef])] = {
-      Some((replicate.event, replicate.replyTo, replicate.entityId, replicate.instanceId, replicate.originSender))
-    }
-
   }
 
   sealed trait EntityCommand

--- a/src/main/scala/lerna/akka/entityreplication/raft/model/ReplicatedLog.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/model/ReplicatedLog.scala
@@ -51,9 +51,6 @@ private[entityreplication] final case class ReplicatedLog private[model] (
     entries.slice(toSeqIndex(from), until = toSeqIndex(to.next()))
   }
 
-  def entriesAfter(index: LogEntryIndex): Iterator[LogEntry] =
-    entries.iterator.drop(n = toSeqIndex(index) + 1)
-
   /** Returns the entity's entries with an index greater than or equal to `from` index
     *
     * If `from` index is greater than [[lastLogIndex]], this method returns empty. If `from` index is less than or equal

--- a/src/main/scala/lerna/akka/entityreplication/raft/model/ReplicatedLog.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/model/ReplicatedLog.scala
@@ -1,5 +1,7 @@
 package lerna.akka.entityreplication.raft.model
 
+import lerna.akka.entityreplication.model.NormalizedEntityId
+
 private[entityreplication] object ReplicatedLog {
 
   def apply(): ReplicatedLog = ReplicatedLog(Seq.empty)
@@ -51,6 +53,16 @@ private[entityreplication] final case class ReplicatedLog private[model] (
 
   def entriesAfter(index: LogEntryIndex): Iterator[LogEntry] =
     entries.iterator.drop(n = toSeqIndex(index) + 1)
+
+  /** Returns the entity's entries with an index greater than or equal to `from` index
+    *
+    * If `from` index is greater than [[lastLogIndex]], this method returns empty. If `from` index is less than or equal
+    * to [[ancestorLastIndex]], this method searches and returns the entity's entries from all existing (not deleted) entries.
+    */
+  def sliceEntityEntries(entityId: NormalizedEntityId, from: LogEntryIndex): Seq[LogEntry] = {
+    sliceEntries(from = from, to = lastLogIndex)
+      .filter(_.event.entityId.contains(entityId))
+  }
 
   def nonEmpty: Boolean = entries.nonEmpty
 

--- a/src/main/scala/lerna/akka/entityreplication/typed/internal/behavior/Ready.scala
+++ b/src/main/scala/lerna/akka/entityreplication/typed/internal/behavior/Ready.scala
@@ -121,6 +121,7 @@ private[entityreplication] class Ready[Command, Event, State](
       replyTo = context.self.toClassic,
       entityId = setup.replicationId.entityId,
       instanceId = setup.instanceId,
+      entityLastAppliedIndex = state.lastAppliedLogEntryIndex,
       originSender = context.system.deadLetters.toClassic, // typed API can not use sender
     )
     WaitForReplication.behavior(

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorCandidateSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorCandidateSpec.scala
@@ -815,6 +815,7 @@ class RaftActorCandidateSpec
             replicationActor.ref,
             entityId,
             entityInstanceId,
+            entityLastAppliedIndex = LogEntryIndex(2),
             originSender = system.deadLetters,
           )
           replicationActor.expectMsg(ReplicationFailed)

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorCandidateSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorCandidateSpec.scala
@@ -808,7 +808,7 @@ class RaftActorCandidateSpec
 
       LoggingTestKit
         .warn(
-          "[Candidate] cannot replicate the event: type=[java.lang.String], entityId=[Some(entity-1)], instanceId=[Some(1)]",
+          "[Candidate] cannot replicate the event: type=[java.lang.String], entityId=[Some(entity-1)], instanceId=[Some(1)], entityLastAppliedIndex=[Some(2)]",
         ).expect {
           candidate ! Replicate(
             event = "event-1",

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorFollowerSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorFollowerSpec.scala
@@ -889,6 +889,7 @@ class RaftActorFollowerSpec
             replicationActor.ref,
             entityId,
             entityInstanceId,
+            entityLastAppliedIndex = LogEntryIndex(2),
             originSender = system.deadLetters,
           )
           replicationActor.expectMsg(ReplicationFailed)

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorFollowerSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorFollowerSpec.scala
@@ -882,7 +882,7 @@ class RaftActorFollowerSpec
 
       LoggingTestKit
         .warn(
-          "[Follower] cannot replicate the event: type=[java.lang.String], entityId=[Some(entity-1)], instanceId=[Some(1)]",
+          "[Follower] cannot replicate the event: type=[java.lang.String], entityId=[Some(entity-1)], instanceId=[Some(1)], entityLastAppliedIndex=[Some(2)]",
         ).expect {
           follower ! Replicate(
             event = "event-1",

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorLeaderSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorLeaderSpec.scala
@@ -1033,7 +1033,7 @@ class RaftActorLeaderSpec
       } should contain theSameElementsAs (Set(follower1Index, follower2Index))
 
       val event1 = "a"
-      leader ! Replicate(event1, replicationActor.ref, entityId, entityInstanceId, system.deadLetters)
+      leader ! Replicate(event1, replicationActor.ref, entityId, entityInstanceId, LogEntryIndex(1), system.deadLetters)
 
       region.fishForMessageN(messages = 2) {
 
@@ -1307,7 +1307,7 @@ class RaftActorLeaderSpec
       } should contain theSameElementsAs (Set(follower1Index, follower2Index))
 
       val event1 = "a"
-      leader ! Replicate(event1, replicationActor.ref, entityId, entityInstanceId, system.deadLetters)
+      leader ! Replicate(event1, replicationActor.ref, entityId, entityInstanceId, LogEntryIndex(1), system.deadLetters)
 
       region.fishForMessageN(messages = 2) {
 
@@ -1345,7 +1345,7 @@ class RaftActorLeaderSpec
       }
 
       val event2 = "b"
-      leader ! Replicate(event2, replicationActor.ref, entityId, entityInstanceId, system.deadLetters)
+      leader ! Replicate(event2, replicationActor.ref, entityId, entityInstanceId, LogEntryIndex(2), system.deadLetters)
 
       region.fishForMessageN(messages = 2) {
 
@@ -1386,6 +1386,7 @@ class RaftActorLeaderSpec
         replyTo = replicationActor1.ref,
         entityId1,
         entityInstanceId,
+        LogEntryIndex(3),
         originSender = system.deadLetters,
       )
       replicationActor1.expectNoMessage()
@@ -1395,6 +1396,7 @@ class RaftActorLeaderSpec
         replicationActor2.ref,
         entityId2,
         entityInstanceId,
+        LogEntryIndex(4),
         originSender = system.deadLetters,
       )
       replicationActor2.expectNoMessage()
@@ -1408,6 +1410,7 @@ class RaftActorLeaderSpec
             replicationActor1.ref,
             entityId1,
             entityInstanceId,
+            LogEntryIndex(2),
             originSender = system.deadLetters,
           )
           replicationActor1.expectMsg(ReplicationFailed)

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftProtocolReplicateSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftProtocolReplicateSpec.scala
@@ -85,34 +85,4 @@ final class RaftProtocolReplicateSpec
     )
   }
 
-  "Replicate.unapply should extract values from a ReplicateForInternal instance" in {
-    val replicate = Replicate.ReplicateForInternal("event-1", TestProbe().ref)
-    inside(replicate) {
-      case Replicate(event, replyTo, entityId, instanceId, originSender) =>
-        event should be(replicate.event)
-        replyTo should be(replicate.replyTo)
-        entityId should be(replicate.entityId)
-        instanceId should be(replicate.instanceId)
-        originSender should be(replicate.originSender)
-    }
-  }
-
-  "Replicate.unapply should extract values from a ReplicateForEntity instance" in {
-    val replicate = Replicate.ReplicateForEntity(
-      "event-1",
-      TestProbe().ref,
-      NormalizedEntityId("entity-1"),
-      EntityInstanceId(1),
-      TestProbe().ref,
-    )
-    inside(replicate) {
-      case Replicate(event, replyTo, entityId, instanceId, originSender) =>
-        event should be(replicate.event)
-        replyTo should be(replicate.replyTo)
-        entityId should be(replicate.entityId)
-        instanceId should be(replicate.instanceId)
-        originSender should be(replicate.originSender)
-    }
-  }
-
 }

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftProtocolReplicateSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftProtocolReplicateSpec.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.testkit.{ TestKit, TestProbe }
 import lerna.akka.entityreplication.model.{ EntityInstanceId, NormalizedEntityId }
 import lerna.akka.entityreplication.raft.RaftProtocol.Replicate
+import lerna.akka.entityreplication.raft.model.LogEntryIndex
 import org.scalatest.Inside
 
 final class RaftProtocolReplicateSpec
@@ -21,6 +22,11 @@ final class RaftProtocolReplicateSpec
     replicateForInternal.instanceId should be(None)
   }
 
+  "ReplicateForInternal.entityLastAppliedIndex should be None" in {
+    val replicateForInternal = Replicate.ReplicateForInternal("event-1", TestProbe().ref)
+    replicateForInternal.entityLastAppliedIndex should be(None)
+  }
+
   "ReplicateForInternal.originSender should be None" in {
     val replicateForInternal = Replicate.ReplicateForInternal("event-1", TestProbe().ref)
     replicateForInternal.originSender should be(None)
@@ -32,6 +38,7 @@ final class RaftProtocolReplicateSpec
       TestProbe().ref,
       NormalizedEntityId("entity-1"),
       EntityInstanceId(1),
+      LogEntryIndex(2),
       TestProbe().ref,
     )
     replicateForInternal.entityId should be(Option(NormalizedEntityId("entity-1")))
@@ -43,9 +50,22 @@ final class RaftProtocolReplicateSpec
       TestProbe().ref,
       NormalizedEntityId("entity-1"),
       EntityInstanceId(1),
+      LogEntryIndex(2),
       TestProbe().ref,
     )
     replicateForInternal.instanceId should be(Option(EntityInstanceId(1)))
+  }
+
+  "ReplicateForEntity.entityLastAppliedIndex should be an Option containing the given entityLastAppliedIndex" in {
+    val replicateForInternal = Replicate.ReplicateForEntity(
+      "event-1",
+      TestProbe().ref,
+      NormalizedEntityId("entity-1"),
+      EntityInstanceId(1),
+      LogEntryIndex(2),
+      TestProbe().ref,
+    )
+    replicateForInternal.entityLastAppliedIndex should be(Option(LogEntryIndex(2)))
   }
 
   "ReplicateForEntity.originSender should be an Option containing the given originSender" in {
@@ -55,6 +75,7 @@ final class RaftProtocolReplicateSpec
       TestProbe().ref,
       NormalizedEntityId("entity-1"),
       EntityInstanceId(1),
+      LogEntryIndex(2),
       originSender,
     )
     replicateForInternal.originSender should be(Option(originSender))
@@ -64,13 +85,15 @@ final class RaftProtocolReplicateSpec
 
     val replyTo      = TestProbe().ref
     val originSender = TestProbe().ref
-    val replicate    = Replicate("event-1", replyTo, NormalizedEntityId("entity-1"), EntityInstanceId(1), originSender)
+    val replicate =
+      Replicate("event-1", replyTo, NormalizedEntityId("entity-1"), EntityInstanceId(1), LogEntryIndex(2), originSender)
     replicate should be(
       Replicate.ReplicateForEntity(
         "event-1",
         replyTo,
         NormalizedEntityId("entity-1"),
         EntityInstanceId(1),
+        LogEntryIndex(2),
         originSender,
       ),
     )

--- a/src/test/scala/lerna/akka/entityreplication/raft/model/ReplicatedLogSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/model/ReplicatedLogSpec.scala
@@ -426,48 +426,6 @@ class ReplicatedLogSpec extends WordSpecLike with Matchers {
 
   }
 
-  "ReplicatedLog.entriesAfter" should {
-
-    "returns entries with deleted up to the specified LogEntryIndex" in {
-      val logEntries = Seq(
-        LogEntry(LogEntryIndex(1), EntityEvent(None, "a"), Term(1)),
-        LogEntry(LogEntryIndex(2), EntityEvent(None, "b"), Term(1)),
-        LogEntry(LogEntryIndex(3), EntityEvent(None, "c"), Term(1)),
-      )
-
-      val log = new ReplicatedLog(logEntries)
-
-      log.entriesAfter(index = LogEntryIndex.initial()).map(_.event.event).toList shouldBe List("a", "b", "c")
-      log.entriesAfter(index = LogEntryIndex(1)).map(_.event.event).toList shouldBe List("b", "c")
-      log.entriesAfter(index = LogEntryIndex(2)).map(_.event.event).toList shouldBe List("c")
-      log.entriesAfter(index = LogEntryIndex(3)).map(_.event.event).toList shouldBe List()
-      log.entriesAfter(index = LogEntryIndex(4)).map(_.event.event).toList shouldBe List()
-    }
-
-    "returns entries with deleted up to the specified LogEntryIndex when the log is compressed" in {
-      val logEntries = Seq(
-        LogEntry(LogEntryIndex(1), EntityEvent(None, "a"), Term(1)),
-        LogEntry(LogEntryIndex(2), EntityEvent(None, "b"), Term(1)),
-        LogEntry(LogEntryIndex(3), EntityEvent(None, "c"), Term(1)),
-        LogEntry(LogEntryIndex(4), EntityEvent(None, "d"), Term(1)),
-        LogEntry(LogEntryIndex(5), EntityEvent(None, "e"), Term(1)),
-      )
-
-      val log = new ReplicatedLog(logEntries).deleteOldEntries(to = LogEntryIndex(2), preserveLogSize = 3)
-      require(log.entries.map(_.index.underlying) == List(3, 4, 5))
-      require(log.entries.map(_.event.event) == List("c", "d", "e"))
-
-      log.entriesAfter(index = LogEntryIndex.initial()).map(_.event.event).toList shouldBe List("c", "d", "e")
-      log.entriesAfter(index = LogEntryIndex(1)).map(_.event.event).toList shouldBe List("c", "d", "e")
-      log.entriesAfter(index = LogEntryIndex(2)).map(_.event.event).toList shouldBe List("c", "d", "e")
-      log.entriesAfter(index = LogEntryIndex(3)).map(_.event.event).toList shouldBe List("d", "e")
-      log.entriesAfter(index = LogEntryIndex(4)).map(_.event.event).toList shouldBe List("e")
-      log.entriesAfter(index = LogEntryIndex(5)).map(_.event.event).toList shouldBe List()
-      log.entriesAfter(index = LogEntryIndex(6)).map(_.event.event).toList shouldBe List()
-    }
-
-  }
-
   "ReplicatedLog.sliceEntityEntries" should {
 
     "return empty if the given `from` is greater than `lastLogIndex`" in {

--- a/src/test/scala/lerna/akka/entityreplication/typed/ReplicatedEntityBehaviorSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/typed/ReplicatedEntityBehaviorSpec.scala
@@ -215,10 +215,18 @@ class ReplicatedEntityBehaviorSpec extends WordSpec with BeforeAndAfterAll with 
       val replyProbe = bankAccount.askWithTestProbe(BankAccountBehavior.Deposit(100, _))
       val replicate =
         inside(shardProbe.expectMessageType[RaftProtocol.Replicate]) {
-          case cmd @ RaftProtocol.Replicate.ReplicateForEntity(event, replyTo, entityId, _, originSender) =>
+          case cmd @ RaftProtocol.Replicate.ReplicateForEntity(
+                event,
+                replyTo,
+                entityId,
+                _,
+                entityLastAppliedIndex,
+                originSender,
+              ) =>
             event shouldBe a[BankAccountBehavior.Deposited]
             replyTo should be(bankAccount.toClassic)
             entityId should be(normalizedEntityId)
+            entityLastAppliedIndex should be(LogEntryIndex(0))
             originSender should be(testkit.system.deadLetters.toClassic)
             cmd
         }
@@ -254,10 +262,18 @@ class ReplicatedEntityBehaviorSpec extends WordSpec with BeforeAndAfterAll with 
       val replyProbe = bankAccount.askWithTestProbe(BankAccountBehavior.GetBalance)
       val replicate =
         inside(shardProbe.expectMessageType[RaftProtocol.Replicate]) {
-          case cmd @ RaftProtocol.Replicate.ReplicateForEntity(event, replyTo, entityId, _, originSender) =>
+          case cmd @ RaftProtocol.Replicate.ReplicateForEntity(
+                event,
+                replyTo,
+                entityId,
+                _,
+                entityLastAppliedIndex,
+                originSender,
+              ) =>
             event should be(NoOp)
             replyTo should be(bankAccount.toClassic)
             entityId should be(normalizedEntityId)
+            entityLastAppliedIndex should be(metadata.logEntryIndex)
             originSender should be(testkit.system.deadLetters.toClassic)
             cmd
         }

--- a/src/test/scala/lerna/akka/entityreplication/typed/ReplicatedEntityBehaviorSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/typed/ReplicatedEntityBehaviorSpec.scala
@@ -215,12 +215,11 @@ class ReplicatedEntityBehaviorSpec extends WordSpec with BeforeAndAfterAll with 
       val replyProbe = bankAccount.askWithTestProbe(BankAccountBehavior.Deposit(100, _))
       val replicate =
         inside(shardProbe.expectMessageType[RaftProtocol.Replicate]) {
-          case cmd @ RaftProtocol.Replicate(event, replyTo, entityId, instanceId, originSender) =>
+          case cmd @ RaftProtocol.Replicate.ReplicateForEntity(event, replyTo, entityId, _, originSender) =>
             event shouldBe a[BankAccountBehavior.Deposited]
             replyTo should be(bankAccount.toClassic)
-            entityId should contain(normalizedEntityId)
-            instanceId should not be empty
-            originSender should contain(testkit.system.deadLetters.toClassic)
+            entityId should be(normalizedEntityId)
+            originSender should be(testkit.system.deadLetters.toClassic)
             cmd
         }
       replicate.replyTo ! RaftProtocol.ReplicationSucceeded(replicate.event, nextLogEntryIndex(), replicate.instanceId)
@@ -255,12 +254,11 @@ class ReplicatedEntityBehaviorSpec extends WordSpec with BeforeAndAfterAll with 
       val replyProbe = bankAccount.askWithTestProbe(BankAccountBehavior.GetBalance)
       val replicate =
         inside(shardProbe.expectMessageType[RaftProtocol.Replicate]) {
-          case cmd @ RaftProtocol.Replicate(event, replyTo, entityId, instanceId, originSender) =>
+          case cmd @ RaftProtocol.Replicate.ReplicateForEntity(event, replyTo, entityId, _, originSender) =>
             event should be(NoOp)
             replyTo should be(bankAccount.toClassic)
-            entityId should contain(normalizedEntityId)
-            instanceId should not be empty
-            originSender should contain(testkit.system.deadLetters.toClassic)
+            entityId should be(normalizedEntityId)
+            originSender should be(testkit.system.deadLetters.toClassic)
             cmd
         }
       replicate.replyTo ! RaftProtocol.ReplicationSucceeded(replicate.event, nextLogEntryIndex(), replicate.instanceId)


### PR DESCRIPTION
Closes #153 

An Entity sends a Replicate message containing its `lastAppliedLogEntryIndex`. A leader will reply with  a `ReplicaionFaield` message if the Leader's Raft log (ReplicatedLog) contains an entry that satisfies all of the following conditions:
* The entry is for the entity (`LogEntry.event.entityId` is equal to `Replicate.entityId`)
* The index of the entry is greater than `lastAppliedLogEntryIndex` of the `Replicate` message.