### PR TITLE
Notify replication failure to conflict clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - An entity on a follower could stick at `WaitForReplication` if the entity has a `ProcessCommand` in its mailbox
   [#157](https://github.com/lerna-stack/akka-entity-replication/issues/157),
   [PR#158](https://github.com/lerna-stack/akka-entity-replication/pull/158)
+- An entity could stick at WaitForReplication when a Raft log entry is truncated by conflict
+  [#155](https://github.com/lerna-stack/akka-entity-replication/issues/155),
+  [#PR162](https://github.com/lerna-stack/akka-entity-replication/pull/162)
+- A RaftAcotor(Leader) could mis-deliver a ReplicationSucceeded message to a different entity
+  [156](https://github.com/lerna-stack/akka-entity-replication/issues/156),
+  [#PR162](https://github.com/lerna-stack/akka-entity-replication/pull/162)
 
 ## [v2.1.0] - 2022-03-24
 [v2.1.0]: https://github.com/lerna-stack/akka-entity-replication/compare/v2.0.0...v2.1.0

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
@@ -276,10 +276,7 @@ private[raft] class RaftActor(
               case (logEntry, Some(client)) =>
                 if (log.isDebugEnabled)
                   log.debug("=== [Leader] committed {} and will notify it to {} ===", logEntry, client)
-                client.ref.tell(
-                  ReplicationSucceeded(logEntry.event.event, logEntry.index, client.instanceId),
-                  client.originSender.getOrElse(ActorRef.noSender),
-                )
+                client.forward(ReplicationSucceeded(logEntry.event.event, logEntry.index, client.instanceId))
               case (logEntry, None) =>
                 // 復旧中の commit or リーダー昇格時に未コミットのログがあった場合の commit
                 applyToReplicationActor(logEntry)

--- a/src/main/scala/lerna/akka/entityreplication/raft/model/ClientContext.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/model/ClientContext.scala
@@ -7,4 +7,14 @@ private[entityreplication] final case class ClientContext(
     ref: ActorRef,
     instanceId: Option[EntityInstanceId],
     originSender: Option[ActorRef],
-)
+) {
+
+  /** Sends the given `message` to the actor `ref`, including the sender `originSender`
+    *
+    * If `originSender` is `None`, [[ActorRef.noSender]] is included as the sender.
+    */
+  def forward(message: Any): Unit = {
+    ref.tell(message, originSender.getOrElse(ActorRef.noSender))
+  }
+
+}

--- a/src/test/scala/lerna/akka/entityreplication/raft/ActorSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/ActorSpec.scala
@@ -77,10 +77,20 @@ trait ActorSpec extends WordSpecLike with Matchers with BeforeAndAfterEach with 
   override def beforeEach(): Unit = {
     super.beforeEach()
     (autoKillManager ? Identify("to wait for start-up")).await
+
+    // Ignoring all messages sent in the previous unit test case
+    ignoreAllMessagesSentBefore()
   }
 
   override def afterEach(): Unit = {
     (autoKillManager ? TestActorAutoKillManager.KillAll).await
     super.afterEach()
   }
+
+  private def ignoreAllMessagesSentBefore(): Unit = {
+    case object SentinelMessage
+    testActor.tell(SentinelMessage, ActorRef.noSender)
+    fishForMessage(hint = "ignoring all messages sent before")(_ == SentinelMessage)
+  }
+
 }

--- a/src/test/scala/lerna/akka/entityreplication/raft/model/ClientContextSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/model/ClientContextSpec.scala
@@ -1,0 +1,26 @@
+package lerna.akka.entityreplication.raft.model
+
+import akka.actor.ActorSystem
+import akka.testkit.{ TestKit, TestProbe }
+import lerna.akka.entityreplication.raft.ActorSpec
+
+final class ClientContextSpec extends TestKit(ActorSystem("ClientContextSpec")) with ActorSpec {
+
+  "ClientContext.forward should send the given message to the actor, including no sender, if the context doesn't have an original sender" in {
+    val probe         = TestProbe()
+    val clientContext = ClientContext(probe.ref, instanceId = None, originSender = None)
+    clientContext.forward("message-1")
+    probe.expectMsg("message-1")
+    probe.sender() should be(system.deadLetters)
+  }
+
+  "ClientContext.forward should send the given message to the actor, including an original sender, if the context has the original sender" in {
+    val probe          = TestProbe()
+    val originalSender = TestProbe().ref
+    val clientContext  = ClientContext(probe.ref, instanceId = None, originSender = Some(originalSender))
+    clientContext.forward("message-1")
+    probe.expectMsg("message-1")
+    probe.sender() should be(originalSender)
+  }
+
+}


### PR DESCRIPTION
Closes #155, #156 

If conflict clients exist, RaftActor sends `ReplicationFaield` messages to these clients and removes clients from `LeaderData.clients`. A client is considered a conflict if an index associated with the client (`LeaderData.clients`) is conflict one.