### PR TITLE
Change event sourcing log level to debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 [Unreleased]: https://github.com/lerna-stack/akka-entity-replication/compare/v2.1.0...master
 
+### Changed
+- Change event sourcing log level to debug
+  [PR#163](https://github.com/lerna-stack/akka-entity-replication/pull/163)
+
 ### Fixed
 - RaftActor might delete committed entries [#152](https://github.com/lerna-stack/akka-entity-replication/issues/152)  
   ⚠️ This fix adds a new persistent event type. It doesn't allow downgrading after being updated.

--- a/src/main/scala/lerna/akka/entityreplication/raft/Leader.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/Leader.scala
@@ -299,8 +299,8 @@ private[raft] trait Leader { this: RaftActor =>
     val newCommittedEntriesOrError = currentData.resolveCommittedEntriesForEventSourcing
     newCommittedEntriesOrError match {
       case Left(UnknownCurrentEventSourcingIndex) =>
-        if (log.isInfoEnabled) {
-          log.info(
+        if (log.isDebugEnabled) {
+          log.debug(
             "[Leader] doesn't know eventSourcingIndex yet. " +
             "sending AppendCommittedEntries(shardId=[{}], entries=empty) to CommitLogStore [{}] to fetch such an index.",
             shardId,
@@ -343,8 +343,8 @@ private[raft] trait Leader { this: RaftActor =>
                 settings.eventSourcedMaxAppendCommittedEntriesSize,
                 settings.eventSourcedMaxAppendCommittedEntriesSize,
               ).toSeq
-          if (log.isInfoEnabled) {
-            log.info(
+          if (log.isDebugEnabled) {
+            log.debug(
               s"[Leader] sending [{}] batched AppendCommittedEntries(shardId=[$shardId]). [{}] entries with indices [{}..{}] will be sent in multiple batches.",
               batches.size,
               limitedNewCommittedEntries.size,

--- a/src/main/scala/lerna/akka/entityreplication/raft/Leader.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/Leader.scala
@@ -343,15 +343,6 @@ private[raft] trait Leader { this: RaftActor =>
                 settings.eventSourcedMaxAppendCommittedEntriesSize,
                 settings.eventSourcedMaxAppendCommittedEntriesSize,
               ).toSeq
-          if (log.isDebugEnabled) {
-            log.debug(
-              s"[Leader] sending [{}] batched AppendCommittedEntries(shardId=[$shardId]). [{}] entries with indices [{}..{}] will be sent in multiple batches.",
-              batches.size,
-              limitedNewCommittedEntries.size,
-              limitedNewCommittedEntries.head.index,
-              limitedNewCommittedEntries.last.index,
-            )
-          }
           batches.foreach { batchedEntries =>
             assert(
               batchedEntries.sizeIs > 0,

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
@@ -475,8 +475,8 @@ private[raft] class RaftActor(
     }
 
   def handleSnapshotTick(): Unit = {
-    if (log.isInfoEnabled) {
-      log.info(
+    if (log.isDebugEnabled) {
+      log.debug(
         "[{}] sending AppendCommittedEntries(shardId=[{}], entries=empty) to CommitLogStore [{}] to fetch the latest eventSourcingIndex at SnapshotTick. " +
         "The current eventSourcingIndex is [{}].",
         currentState,

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
@@ -767,16 +767,16 @@ private[raft] class RaftActor(
       case None =>
         val newEventSourcingIndex = appendCommittedEntriesResponse.currentIndex
         applyDomainEvent(DetectedNewEventSourcingIndex(newEventSourcingIndex)) { _ =>
-          if (log.isInfoEnabled) {
-            log.info("[{}] detected new event sourcing index [{}].", currentState, newEventSourcingIndex)
+          if (log.isDebugEnabled) {
+            log.debug("[{}] detected new event sourcing index [{}].", currentState, newEventSourcingIndex)
           }
         }
       case Some(currentEventSourcingIndex) =>
         if (currentEventSourcingIndex < appendCommittedEntriesResponse.currentIndex) {
           val newEventSourcingIndex = appendCommittedEntriesResponse.currentIndex
           applyDomainEvent(DetectedNewEventSourcingIndex(newEventSourcingIndex)) { _ =>
-            if (log.isInfoEnabled) {
-              log.info(
+            if (log.isDebugEnabled) {
+              log.debug(
                 "[{}] detected new event sourcing index [{}]. The old index was [{}].",
                 currentState,
                 newEventSourcingIndex,


### PR DESCRIPTION
RaftActor logged these Event Sourcing info messages frequently. It could be better to use debug level to avoid writing many info logs.