### PR TITLE
Add diagnostic logging to CommitLogStoreActor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 [Unreleased]: https://github.com/lerna-stack/akka-entity-replication/compare/v2.1.0...master
 
+### Changed
+- Add diagnostic logging to CommitLogStoreActor
+  [PR#164](https://github.com/lerna-stack/akka-entity-replication/pull/164)
+
 ### Fixed
 - RaftActor might delete committed entries [#152](https://github.com/lerna-stack/akka-entity-replication/issues/152)  
   ⚠️ This fix adds a new persistent event type. It doesn't allow downgrading after being updated.


### PR DESCRIPTION
Add the following diagnostic logging to `CommitLogStoreActor`:
* [INFO] recovery completed
  * Use INFO level since it is not frequently logged and is useful for log diving.
* [DEBUG] `AppendCommittedEntries` with empty entries
  * Use DEBUG level since it is frequently logged.
* [INFO] saving snapshot
  * Use INFO level since it is not frequently logged and is useful for log diving.