### PR TITLE
RaftActor commits index not to conflict with succeeding AppendEntries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [Unreleased]: https://github.com/lerna-stack/akka-entity-replication/compare/v2.1.0...master
 
 ### Fixed
-- RaftActor might delete committed entries [#152](https://github.com/lerna-stack/akka-entity-replication/issues/152)  
+- RaftActor might delete committed entries
+  [#152](https://github.com/lerna-stack/akka-entity-replication/issues/152)
+  [#165](https://github.com/lerna-stack/akka-entity-replication/issues/165)
+  [PR#151](https://github.com/lerna-stack/akka-entity-replication/pull/151)
+  [PR#166](https://github.com/lerna-stack/akka-entity-replication/pull/166)  
   ⚠️ This fix adds a new persistent event type. It doesn't allow downgrading after being updated.
 - An entity on a follower could stick at `WaitForReplication` if the entity has a `ProcessCommand` in its mailbox
   [#157](https://github.com/lerna-stack/akka-entity-replication/issues/157),

--- a/src/main/scala/lerna/akka/entityreplication/raft/Candidate.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/Candidate.scala
@@ -142,7 +142,7 @@ private[raft] trait Candidate { this: RaftActor =>
           cancelElectionTimeoutTimer()
           if (appendEntries.entries.isEmpty && appendEntries.term == currentData.currentTerm) {
             // do not persist event when no need
-            applyDomainEvent(FollowedLeaderCommit(appendEntries.leader, appendEntries.leaderCommit)) { _ =>
+            applyDomainEvent(FollowedLeaderCommit(appendEntries.leader, appendEntries.committableIndex)) { _ =>
               sender() ! AppendEntriesSucceeded(
                 appendEntries.term,
                 currentData.replicatedLog.lastLogIndex,
@@ -153,7 +153,7 @@ private[raft] trait Candidate { this: RaftActor =>
           } else {
             val newEntries = currentData.resolveNewLogEntries(appendEntries.entries)
             applyDomainEvent(AppendedEntries(appendEntries.term, newEntries)) { domainEvent =>
-              applyDomainEvent(FollowedLeaderCommit(appendEntries.leader, appendEntries.leaderCommit)) { _ =>
+              applyDomainEvent(FollowedLeaderCommit(appendEntries.leader, appendEntries.committableIndex)) { _ =>
                 sender() ! AppendEntriesSucceeded(
                   domainEvent.term,
                   currentData.replicatedLog.lastLogIndex,

--- a/src/main/scala/lerna/akka/entityreplication/raft/Follower.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/Follower.scala
@@ -99,7 +99,7 @@ private[raft] trait Follower { this: RaftActor =>
           cancelElectionTimeoutTimer()
           if (appendEntries.entries.isEmpty && appendEntries.term == currentData.currentTerm) {
             // do not persist event when no need
-            applyDomainEvent(FollowedLeaderCommit(appendEntries.leader, appendEntries.leaderCommit)) { _ =>
+            applyDomainEvent(FollowedLeaderCommit(appendEntries.leader, appendEntries.committableIndex)) { _ =>
               sender() ! AppendEntriesSucceeded(
                 appendEntries.term,
                 currentData.replicatedLog.lastLogIndex,
@@ -110,7 +110,7 @@ private[raft] trait Follower { this: RaftActor =>
           } else {
             val newEntries = currentData.resolveNewLogEntries(appendEntries.entries)
             applyDomainEvent(AppendedEntries(appendEntries.term, newEntries)) { domainEvent =>
-              applyDomainEvent(FollowedLeaderCommit(appendEntries.leader, appendEntries.leaderCommit)) { _ =>
+              applyDomainEvent(FollowedLeaderCommit(appendEntries.leader, appendEntries.committableIndex)) { _ =>
                 sender() ! AppendEntriesSucceeded(
                   domainEvent.term,
                   currentData.replicatedLog.lastLogIndex,

--- a/src/main/scala/lerna/akka/entityreplication/raft/Leader.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/Leader.scala
@@ -98,7 +98,7 @@ private[raft] trait Leader { this: RaftActor =>
           if (log.isDebugEnabled) log.debug("=== [Leader] append {} ===", appendEntries)
           val newEntries = currentData.resolveNewLogEntries(appendEntries.entries)
           applyDomainEvent(AppendedEntries(appendEntries.term, newEntries)) { domainEvent =>
-            applyDomainEvent(FollowedLeaderCommit(appendEntries.leader, appendEntries.leaderCommit)) { _ =>
+            applyDomainEvent(FollowedLeaderCommit(appendEntries.leader, appendEntries.committableIndex)) { _ =>
               sender() ! AppendEntriesSucceeded(
                 domainEvent.term,
                 currentData.replicatedLog.lastLogIndex,

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftMemberData.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftMemberData.scala
@@ -173,6 +173,13 @@ private[entityreplication] trait FollowerData { self: RaftMemberData =>
     updateFollowerVolatileState(leaderMember = Some(leaderMember))
   }
 
+  /** Updates [[commitIndex]] to the given `leaderCommit` if needed
+    *
+    * Updates [[commitIndex]] to `leaderCommit` if `leaderCommit` is greater than [[commitIndex]].
+    * Otherwise, [[commitIndex]] doesn't change.
+    *
+    * Throws an [[IllegalArgumentException]] if `leaderCommit` is greater than the last index of [[ReplicatedLog]] ([[ReplicatedLog.lastLogIndex]]).
+    */
   def followLeaderCommit(leaderCommit: LogEntryIndex): RaftMemberData = {
     require(
       leaderCommit <= replicatedLog.lastLogIndex,

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftMemberData.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftMemberData.scala
@@ -179,13 +179,8 @@ private[entityreplication] trait FollowerData { self: RaftMemberData =>
       s"The given leaderCommit [$leaderCommit] should be less than or equal to ReplicatedLog.lastLogIndex [${replicatedLog.lastLogIndex}]. " +
       s"The caller should append entries with indices (from=[${replicatedLog.lastLogIndex}], to=[${leaderCommit}]) into ReplicatedLog before committing the given leaderCommit.",
     )
-    if (leaderCommit >= commitIndex) {
-      import LogEntryIndex.min
-      val newCommitIndex = replicatedLog.lastIndexOption
-        .map { lastIndex =>
-          if (leaderCommit > commitIndex) min(leaderCommit, lastIndex) else commitIndex
-        }.getOrElse(commitIndex)
-      updateVolatileState(commitIndex = newCommitIndex)
+    if (leaderCommit > commitIndex) {
+      updateVolatileState(commitIndex = leaderCommit)
     } else {
       // If a new leader is elected even if the leader is alive,
       // leaderCommit is less than commitIndex when the old leader didn't tell the follower the new commitIndex.

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftMemberData.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftMemberData.scala
@@ -174,6 +174,11 @@ private[entityreplication] trait FollowerData { self: RaftMemberData =>
   }
 
   def followLeaderCommit(leaderCommit: LogEntryIndex): RaftMemberData = {
+    require(
+      leaderCommit <= replicatedLog.lastLogIndex,
+      s"The given leaderCommit [$leaderCommit] should be less than or equal to ReplicatedLog.lastLogIndex [${replicatedLog.lastLogIndex}]. " +
+      s"The caller should append entries with indices (from=[${replicatedLog.lastLogIndex}], to=[${leaderCommit}]) into ReplicatedLog before committing the given leaderCommit.",
+    )
     if (leaderCommit >= commitIndex) {
       import LogEntryIndex.min
       val newCommitIndex = replicatedLog.lastIndexOption

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorFollowerSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorFollowerSpec.scala
@@ -600,6 +600,50 @@ class RaftActorFollowerSpec
       getState(follower).stateData.commitIndex should be(leaderCommit)
     }
 
+    "update commitIndex to the last index of received entries (AppendEntries.entries.last.index) " +
+    "if AppendEntries.leaderCommit is greater than commitIndex and the last index of received entries" in {
+      val shardId             = createUniqueShardId()
+      val followerMemberIndex = createUniqueMemberIndex()
+      val follower = createRaftActor(
+        shardId = shardId,
+        selfMemberIndex = followerMemberIndex,
+      )
+      val replicatedLog =
+        ReplicatedLog().truncateAndAppend(
+          Seq(
+            LogEntry(LogEntryIndex(1), EntityEvent(None, NoOp), Term(1)),
+            LogEntry(LogEntryIndex(2), EntityEvent(Some(entityId), "event-1"), Term(1)),
+            LogEntry(LogEntryIndex(3), EntityEvent(None, NoOp), Term(2)),
+            LogEntry(LogEntryIndex(4), EntityEvent(Some(entityId), "event-2"), Term(2)),
+            LogEntry(LogEntryIndex(5), EntityEvent(Some(entityId), "event-3"), Term(2)),
+          ),
+        )
+      setState(follower, Follower, createFollowerData(Term(2), replicatedLog, commitIndex = LogEntryIndex(4)))
+
+      val leaderMemberIndex = createUniqueMemberIndex()
+      val leader            = TestProbe()
+
+      follower.tell(
+        createAppendEntries(
+          shardId,
+          Term(3),
+          leaderMemberIndex,
+          prevLogIndex = LogEntryIndex(3),
+          prevLogTerm = Term(2),
+          entries = Seq(
+            LogEntry(LogEntryIndex(4), EntityEvent(Some(entityId), "event-2"), Term(2)),
+            // The following entries will be sent in another AppendEntries batch and will be in conflict.
+            // LogEntry(LogEntryIndex(5), EntityEvent(None, NoOp), Term(3)),
+          ),
+          leaderCommit = LogEntryIndex(5),
+        ),
+        leader.ref,
+      )
+
+      leader.expectMsgType[AppendEntriesSucceeded]
+      getState(follower).stateData.commitIndex should be(LogEntryIndex(4))
+    }
+
     "prevLogIndex の Term が prevLogTerm に一致するログエントリでない場合は AppendEntriesFailed を返す" in {
       val shardId             = createUniqueShardId()
       val term1               = Term(1)

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorLeaderSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorLeaderSpec.scala
@@ -196,6 +196,50 @@ class RaftActorLeaderSpec
       getState(leader).stateData.commitIndex should be(leaderCommit)
     }
 
+    "update commitIndex to the last index of received entries (AppendEntries.entries.last.index) " +
+    "if AppendEntries.leaderCommit is greater than commitIndex and the last index of received entries" in {
+      val shardId           = createUniqueShardId()
+      val leaderMemberIndex = createUniqueMemberIndex()
+      val leader = createRaftActor(
+        shardId = shardId,
+        selfMemberIndex = leaderMemberIndex,
+      )
+      val replicatedLog =
+        ReplicatedLog().truncateAndAppend(
+          Seq(
+            LogEntry(LogEntryIndex(1), EntityEvent(None, NoOp), Term(1)),
+            LogEntry(LogEntryIndex(2), EntityEvent(Some(entityId), "event-1"), Term(1)),
+            LogEntry(LogEntryIndex(3), EntityEvent(None, NoOp), Term(2)),
+            LogEntry(LogEntryIndex(4), EntityEvent(Some(entityId), "event-2"), Term(2)),
+            LogEntry(LogEntryIndex(5), EntityEvent(Some(entityId), "event-3"), Term(2)),
+          ),
+        )
+      setState(leader, Follower, createLeaderData(Term(2), replicatedLog, commitIndex = LogEntryIndex(4)))
+
+      val newLeaderMemberIndex = createUniqueMemberIndex()
+      val newLeader            = TestProbe()
+
+      leader.tell(
+        createAppendEntries(
+          shardId,
+          Term(3),
+          newLeaderMemberIndex,
+          prevLogIndex = LogEntryIndex(3),
+          prevLogTerm = Term(2),
+          entries = Seq(
+            LogEntry(LogEntryIndex(4), EntityEvent(Some(entityId), "event-2"), Term(2)),
+            // The following entries will be sent in another AppendEntries batch and will be in conflict.
+            // LogEntry(LogEntryIndex(5), EntityEvent(None, NoOp), Term(3)),
+          ),
+          leaderCommit = LogEntryIndex(5),
+        ),
+        newLeader.ref,
+      )
+
+      newLeader.expectMsgType[AppendEntriesSucceeded]
+      getState(leader).stateData.commitIndex should be(LogEntryIndex(4))
+    }
+
     "keep commitIndex even if leaderCommit is less than commitIndex" in {
       val leaderMemberIndex = createUniqueMemberIndex()
       val leader = createRaftActor(

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftMemberDataSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftMemberDataSpec.scala
@@ -865,6 +865,103 @@ final class RaftMemberDataSpec extends FlatSpec with Matchers with Inside {
     assert(discardedClients.contains(client2))
   }
 
+  behavior of "RaftMemberData.followLeaderCommit"
+
+  it should "not update commitIndex if the given leaderCommit is less than commitIndex" in {
+    val replicatedLog = ReplicatedLog().truncateAndAppend(
+      Seq(
+        LogEntry(LogEntryIndex(1), EntityEvent(None, NoOp), Term(1)),
+        LogEntry(LogEntryIndex(2), EntityEvent(None, NoOp), Term(2)),
+        LogEntry(LogEntryIndex(3), EntityEvent(None, NoOp), Term(3)),
+        LogEntry(LogEntryIndex(4), EntityEvent(None, NoOp), Term(4)),
+      ),
+    )
+    val data = RaftMemberData(
+      commitIndex = LogEntryIndex(3),
+      replicatedLog = replicatedLog,
+    )
+    val newData = data.followLeaderCommit(LogEntryIndex(2))
+    newData.commitIndex should be(LogEntryIndex(3))
+  }
+
+  it should "not update commitIndex if the given leaderCommit is equal to commitIndex" in {
+    val replicatedLog = ReplicatedLog().truncateAndAppend(
+      Seq(
+        LogEntry(LogEntryIndex(1), EntityEvent(None, NoOp), Term(1)),
+        LogEntry(LogEntryIndex(2), EntityEvent(None, NoOp), Term(2)),
+        LogEntry(LogEntryIndex(3), EntityEvent(None, NoOp), Term(3)),
+        LogEntry(LogEntryIndex(4), EntityEvent(None, NoOp), Term(4)),
+      ),
+    )
+    val data = RaftMemberData(
+      commitIndex = LogEntryIndex(3),
+      replicatedLog = replicatedLog,
+    )
+    val newData = data.followLeaderCommit(LogEntryIndex(3))
+    newData.commitIndex should be(LogEntryIndex(3))
+  }
+
+  it should "not update commitIndex if replicatedLog is empty" in {
+    val replicatedLog = ReplicatedLog().reset(Term(3), LogEntryIndex(10))
+    val data = RaftMemberData(
+      commitIndex = LogEntryIndex(10),
+      replicatedLog = replicatedLog,
+    )
+    val newData = data.followLeaderCommit(LogEntryIndex(11))
+    newData.commitIndex should be(LogEntryIndex(10))
+  }
+
+  it should "update commitIndex to leaderCommit if leaderCommit is greater than commitIndex and less than the last index of replicatedLog" in {
+    val replicatedLog = ReplicatedLog().truncateAndAppend(
+      Seq(
+        LogEntry(LogEntryIndex(1), EntityEvent(None, NoOp), Term(1)),
+        LogEntry(LogEntryIndex(2), EntityEvent(None, NoOp), Term(2)),
+        LogEntry(LogEntryIndex(3), EntityEvent(None, NoOp), Term(3)),
+        LogEntry(LogEntryIndex(4), EntityEvent(None, NoOp), Term(4)),
+      ),
+    )
+    val data = RaftMemberData(
+      commitIndex = LogEntryIndex(2),
+      replicatedLog = replicatedLog,
+    )
+    val newData = data.followLeaderCommit(LogEntryIndex(3))
+    newData.commitIndex should be(LogEntryIndex(3))
+  }
+
+  it should "update commitIndex to leaderCommit if leaderCommit is greater than commitIndex and equal to the last index of replicatedLog" in {
+    val replicatedLog = ReplicatedLog().truncateAndAppend(
+      Seq(
+        LogEntry(LogEntryIndex(1), EntityEvent(None, NoOp), Term(1)),
+        LogEntry(LogEntryIndex(2), EntityEvent(None, NoOp), Term(2)),
+        LogEntry(LogEntryIndex(3), EntityEvent(None, NoOp), Term(3)),
+        LogEntry(LogEntryIndex(4), EntityEvent(None, NoOp), Term(4)),
+      ),
+    )
+    val data = RaftMemberData(
+      commitIndex = LogEntryIndex(2),
+      replicatedLog = replicatedLog,
+    )
+    val newData = data.followLeaderCommit(LogEntryIndex(4))
+    newData.commitIndex should be(LogEntryIndex(4))
+  }
+
+  it should "update commitIndex to the last index of replicatedLog if leaderCommit is greater than commitIndex and the last index" in {
+    val replicatedLog = ReplicatedLog().truncateAndAppend(
+      Seq(
+        LogEntry(LogEntryIndex(1), EntityEvent(None, NoOp), Term(1)),
+        LogEntry(LogEntryIndex(2), EntityEvent(None, NoOp), Term(2)),
+        LogEntry(LogEntryIndex(3), EntityEvent(None, NoOp), Term(3)),
+        LogEntry(LogEntryIndex(4), EntityEvent(None, NoOp), Term(4)),
+      ),
+    )
+    val data = RaftMemberData(
+      commitIndex = LogEntryIndex(3),
+      replicatedLog = replicatedLog,
+    )
+    val newData = data.followLeaderCommit(LogEntryIndex(5))
+    newData.commitIndex should be(LogEntryIndex(4))
+  }
+
   private def generateEntityId() = {
     NormalizedEntityId.from(UUID.randomUUID().toString)
   }

--- a/src/test/scala/lerna/akka/entityreplication/raft/protocol/RaftCommandsAppendEntriesSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/protocol/RaftCommandsAppendEntriesSpec.scala
@@ -1,0 +1,112 @@
+package lerna.akka.entityreplication.raft.protocol
+
+import lerna.akka.entityreplication.model.NormalizedShardId
+import lerna.akka.entityreplication.raft.model.{ EntityEvent, LogEntry, LogEntryIndex, NoOp, Term }
+import lerna.akka.entityreplication.raft.routing.MemberIndex
+import org.scalatest.{ Matchers, WordSpec }
+
+final class RaftCommandsAppendEntriesSpec extends WordSpec with Matchers {
+
+  import RaftCommands.AppendEntries
+
+  "AppendEntries.committableIndex" should {
+
+    "be leaderCommit if entries are empty" in {
+      val appendEntries = AppendEntries(
+        shardId = NormalizedShardId("shard-1"),
+        term = Term(3),
+        leader = MemberIndex("member-1"),
+        prevLogIndex = LogEntryIndex(10),
+        prevLogTerm = Term(3),
+        entries = Seq.empty,
+        leaderCommit = LogEntryIndex(10),
+      )
+      appendEntries.committableIndex should be(LogEntryIndex(10))
+    }
+
+    "be leaderCommit if leaderCommit is less than the first index of entries" in {
+      val appendEntries = AppendEntries(
+        shardId = NormalizedShardId("shard-1"),
+        term = Term(3),
+        leader = MemberIndex("member-1"),
+        prevLogIndex = LogEntryIndex(5),
+        prevLogTerm = Term(2),
+        entries = Seq(
+          LogEntry(LogEntryIndex(6), EntityEvent(None, NoOp), Term(3)),
+        ),
+        leaderCommit = LogEntryIndex(5),
+      )
+      appendEntries.committableIndex should be(LogEntryIndex(5))
+    }
+
+    "be leaderCommit if leaderCommit is equal to the first index of entries" in {
+      val appendEntries = AppendEntries(
+        shardId = NormalizedShardId("shard-1"),
+        term = Term(5),
+        leader = MemberIndex("member-1"),
+        prevLogIndex = LogEntryIndex(5),
+        prevLogTerm = Term(2),
+        entries = Seq(
+          LogEntry(LogEntryIndex(6), EntityEvent(None, NoOp), Term(3)),
+          LogEntry(LogEntryIndex(7), EntityEvent(None, NoOp), Term(4)),
+          LogEntry(LogEntryIndex(8), EntityEvent(None, NoOp), Term(5)),
+        ),
+        leaderCommit = LogEntryIndex(6),
+      )
+      appendEntries.committableIndex should be(LogEntryIndex(6))
+    }
+
+    "be leaderCommit if leaderCommit is between the first and last index of entries" in {
+      val appendEntries = AppendEntries(
+        shardId = NormalizedShardId("shard-1"),
+        term = Term(5),
+        leader = MemberIndex("member-1"),
+        prevLogIndex = LogEntryIndex(5),
+        prevLogTerm = Term(2),
+        entries = Seq(
+          LogEntry(LogEntryIndex(6), EntityEvent(None, NoOp), Term(3)),
+          LogEntry(LogEntryIndex(7), EntityEvent(None, NoOp), Term(4)),
+          LogEntry(LogEntryIndex(8), EntityEvent(None, NoOp), Term(5)),
+        ),
+        leaderCommit = LogEntryIndex(7),
+      )
+      appendEntries.committableIndex should be(LogEntryIndex(7))
+    }
+
+    "be leaderCommit if leaderCommit is equal to the last index of entries" in {
+      val appendEntries = AppendEntries(
+        shardId = NormalizedShardId("shard-1"),
+        term = Term(5),
+        leader = MemberIndex("member-1"),
+        prevLogIndex = LogEntryIndex(5),
+        prevLogTerm = Term(2),
+        entries = Seq(
+          LogEntry(LogEntryIndex(6), EntityEvent(None, NoOp), Term(3)),
+          LogEntry(LogEntryIndex(7), EntityEvent(None, NoOp), Term(4)),
+          LogEntry(LogEntryIndex(8), EntityEvent(None, NoOp), Term(5)),
+        ),
+        leaderCommit = LogEntryIndex(8),
+      )
+      appendEntries.committableIndex should be(LogEntryIndex(8))
+    }
+
+    "be the last index of entries if the leaderCommit is greater than the last index of entries" in {
+      val appendEntries = AppendEntries(
+        shardId = NormalizedShardId("shard-1"),
+        term = Term(5),
+        leader = MemberIndex("member-1"),
+        prevLogIndex = LogEntryIndex(5),
+        prevLogTerm = Term(2),
+        entries = Seq(
+          LogEntry(LogEntryIndex(6), EntityEvent(None, NoOp), Term(3)),
+          LogEntry(LogEntryIndex(7), EntityEvent(None, NoOp), Term(4)),
+          LogEntry(LogEntryIndex(8), EntityEvent(None, NoOp), Term(5)),
+        ),
+        leaderCommit = LogEntryIndex(9),
+      )
+      appendEntries.committableIndex should be(LogEntryIndex(8))
+    }
+
+  }
+
+}


### PR DESCRIPTION
Closes #165 

On the receiving of AppendEntries message, except for empty entries, the receiver RaftActor cannot commit `leaderCommit` if `leaderCommit` is greater than or equal to the last index of received entries. Other succeeding AppendEntries messages can conflict with an existing entry with an index less than or equal to `leaderCommit` but greater than the last index of received entries. Instead, the receiver can commit the last index of received entries.