### PR TITLE
Disabling specific raft actor's launching by its own shard id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [PR#164](https://github.com/lerna-stack/akka-entity-replication/pull/164)
 - Add function extracting shard id from entity id to lerna.akka.entityreplication.typed.ClusterReplication
   [PR#172](https://github.com/lerna-stack/akka-entity-replication/pull/172)
+- Add function of Disabling raft actor [PR#173](https://github.com/lerna-stack/akka-entity-replication/pull/173)
 
 ### Fixed
 - RaftActor might delete committed entries

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -111,6 +111,9 @@ lerna.akka.entityreplication {
       // Snapshot synchronization reads events that related to Raft.
       query.plugin = ""
     }
+
+    // Shard Ids of raft actors to disable.
+    disabled-shards = []
   }
 
   raft.eventsourced {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -113,6 +113,7 @@ lerna.akka.entityreplication {
     }
 
     // Shard Ids of raft actors to disable.
+    // e.g. ["2", "5"]
     disabled-shards = []
   }
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -22,6 +22,10 @@ lerna.akka.entityreplication {
     // Changing this value will cause data inconsistency.
     number-of-shards = 100
 
+    // Shard Ids of raft actors to disable.
+    // e.g. ["2", "5"]
+    disabled-shards = []
+
     // Maximum number of entries which AppendEntries contains.
     // The too large size will cause message serialization failure.
     max-append-entries-size = 16
@@ -112,9 +116,6 @@ lerna.akka.entityreplication {
       query.plugin = ""
     }
 
-    // Shard Ids of raft actors to disable.
-    // e.g. ["2", "5"]
-    disabled-shards = []
   }
 
   raft.eventsourced {

--- a/src/main/scala/lerna/akka/entityreplication/ReplicationRegion.scala
+++ b/src/main/scala/lerna/akka/entityreplication/ReplicationRegion.scala
@@ -137,7 +137,7 @@ private[entityreplication] class ReplicationRegion(
   private[this] val regions: Map[MemberIndex, mutable.Set[Member]] =
     allMemberIndexes.map(i => i -> mutable.Set.empty[Member]).toMap
 
-  private val disabledShards = settings.raftSettings.disabledShards
+  private val disabledShards: Set[ShardId] = settings.raftSettings.disabledShards
 
   // TODO 変数名を実態にあったものに変更
   private[this] val shardingRouters: Map[MemberIndex, ActorRef] = allMemberIndexes.map { memberIndex =>

--- a/src/main/scala/lerna/akka/entityreplication/ReplicationRegion.scala
+++ b/src/main/scala/lerna/akka/entityreplication/ReplicationRegion.scala
@@ -264,7 +264,11 @@ private[entityreplication] class ReplicationRegion(
         )
         handleRoutingCommand(DeliverSomewhere(Command(message)))
       } else if (log.isWarningEnabled) {
-        log.warning(s"Following command had sent to disabled shards was dropped: ${message.getClass.getName}")
+        log.warning(
+          s"Following command had sent to disabled shards was dropped: {}(shardId={})",
+          message.getClass.getName,
+          shardId,
+        )
       }
     } else {
       if (log.isWarningEnabled)

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
@@ -1,7 +1,7 @@
 package lerna.akka.entityreplication.raft
 
 import akka.actor.{ ActorRef, Cancellable, Props, Stash }
-import akka.persistence.RuntimePluginConfig
+import akka.persistence.{ Recovery, RuntimePluginConfig }
 import com.typesafe.config.{ Config, ConfigFactory }
 import lerna.akka.entityreplication.ClusterReplication.EntityPropsProvider
 import lerna.akka.entityreplication.ReplicationRegion.Msg
@@ -215,6 +215,14 @@ private[raft] class RaftActor(
   override def snapshotPluginConfig: Config = ConfigFactory.empty()
 
   private def isDisabled: Boolean = settings.disabledShards.contains(shardId.raw)
+
+  override def recovery: Recovery = {
+    if (isDisabled) {
+      Recovery.none
+    } else {
+      Recovery()
+    }
+  }
 
   override def preStart(): Unit = {
     if (isDisabled) {

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
@@ -214,6 +214,14 @@ private[raft] class RaftActor(
 
   override def snapshotPluginConfig: Config = ConfigFactory.empty()
 
+  private def isDisabled: Boolean = settings.disabledShards.contains(shardId.raw)
+
+  override def preStart(): Unit = {
+    if (isDisabled) {
+      context.stop(self)
+    }
+  }
+
   val numberOfMembers: Int = settings.replicationFactor
 
   @nowarn("msg=Use RaftMemberData.truncateAndAppendEntries instead.")

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftSettings.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftSettings.scala
@@ -86,4 +86,5 @@ trait RaftSettings {
 
   private[entityreplication] def withEventSourcedSnapshotStorePluginId(pluginId: String): RaftSettings
 
+  def disabledShards: List[String]
 }

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftSettings.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftSettings.scala
@@ -86,5 +86,5 @@ trait RaftSettings {
 
   private[entityreplication] def withEventSourcedSnapshotStorePluginId(pluginId: String): RaftSettings
 
-  def disabledShards: List[String]
+  def disabledShards: Set[String]
 }

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftSettings.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftSettings.scala
@@ -28,6 +28,8 @@ trait RaftSettings {
 
   def numberOfShards: Int
 
+  def disabledShards: Set[String]
+
   def maxAppendEntriesSize: Int
 
   def maxAppendEntriesBatchSize: Int
@@ -86,5 +88,4 @@ trait RaftSettings {
 
   private[entityreplication] def withEventSourcedSnapshotStorePluginId(pluginId: String): RaftSettings
 
-  def disabledShards: Set[String]
 }

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftSettingsImpl.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftSettingsImpl.scala
@@ -39,6 +39,7 @@ private[entityreplication] final case class RaftSettingsImpl(
     eventSourcedJournalPluginId: String,
     eventSourcedSnapshotStorePluginId: String,
     eventSourcedSnapshotEvery: Int,
+    disabledShards: List[String],
 ) extends RaftSettings {
 
   override private[raft] def randomizedElectionTimeout(): FiniteDuration =
@@ -215,6 +216,8 @@ private[entityreplication] object RaftSettingsImpl {
       s"snapshot-every ($eventSourcedSnapshotEvery) should be greater than 0.",
     )
 
+    val disabledShards: List[String] = config.getStringList("disabled-shards").asScala.toList
+
     RaftSettingsImpl(
       config = config,
       electionTimeout = electionTimeout,
@@ -246,6 +249,7 @@ private[entityreplication] object RaftSettingsImpl {
       eventSourcedJournalPluginId = eventSourcedJournalPluginId,
       eventSourcedSnapshotStorePluginId = eventSourcedSnapshotStorePluginId,
       eventSourcedSnapshotEvery = eventSourcedSnapshotEvery,
+      disabledShards = disabledShards,
     )
   }
 

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftSettingsImpl.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftSettingsImpl.scala
@@ -39,7 +39,7 @@ private[entityreplication] final case class RaftSettingsImpl(
     eventSourcedJournalPluginId: String,
     eventSourcedSnapshotStorePluginId: String,
     eventSourcedSnapshotEvery: Int,
-    disabledShards: List[String],
+    disabledShards: Set[String],
 ) extends RaftSettings {
 
   override private[raft] def randomizedElectionTimeout(): FiniteDuration =
@@ -216,7 +216,7 @@ private[entityreplication] object RaftSettingsImpl {
       s"snapshot-every ($eventSourcedSnapshotEvery) should be greater than 0.",
     )
 
-    val disabledShards: List[String] = config.getStringList("disabled-shards").asScala.toList
+    val disabledShards: Set[String] = config.getStringList("disabled-shards").asScala.toSet
 
     RaftSettingsImpl(
       config = config,

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftSettingsImpl.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftSettingsImpl.scala
@@ -17,6 +17,7 @@ private[entityreplication] final case class RaftSettingsImpl(
     replicationFactor: Int,
     quorumSize: Int,
     numberOfShards: Int,
+    disabledShards: Set[String],
     maxAppendEntriesSize: Int,
     maxAppendEntriesBatchSize: Int,
     compactionSnapshotCacheTimeToLive: FiniteDuration,
@@ -39,7 +40,6 @@ private[entityreplication] final case class RaftSettingsImpl(
     eventSourcedJournalPluginId: String,
     eventSourcedSnapshotStorePluginId: String,
     eventSourcedSnapshotEvery: Int,
-    disabledShards: Set[String],
 ) extends RaftSettings {
 
   override private[raft] def randomizedElectionTimeout(): FiniteDuration =
@@ -227,6 +227,7 @@ private[entityreplication] object RaftSettingsImpl {
       replicationFactor = replicationFactor,
       quorumSize = quorumSize,
       numberOfShards = numberOfShards,
+      disabledShards = disabledShards,
       maxAppendEntriesSize = maxAppendEntriesSize,
       maxAppendEntriesBatchSize = maxAppendEntriesBatchSize,
       compactionSnapshotCacheTimeToLive = compactionSnapshotCacheTimeToLive,
@@ -249,7 +250,6 @@ private[entityreplication] object RaftSettingsImpl {
       eventSourcedJournalPluginId = eventSourcedJournalPluginId,
       eventSourcedSnapshotStorePluginId = eventSourcedSnapshotStorePluginId,
       eventSourcedSnapshotEvery = eventSourcedSnapshotEvery,
-      disabledShards = disabledShards,
     )
   }
 

--- a/src/multi-jvm/scala/lerna/akka/entityreplication/ReplicationRegionSpec.scala
+++ b/src/multi-jvm/scala/lerna/akka/entityreplication/ReplicationRegionSpec.scala
@@ -350,7 +350,7 @@ class ReplicationRegionSpec extends MultiNodeSpec(ReplicationRegionSpecConfig) w
       runOn(node4) {
         LoggingTestKit
           .warn(
-            "Following command had sent to disabled shards was dropped: lerna.akka.entityreplication.ReplicationRegionSpec$DummyReplicationActor$Cmd",
+            "Following command had sent to disabled shards was dropped: lerna.akka.entityreplication.ReplicationRegionSpec$DummyReplicationActor$Cmd(shardId=12)",
           ).expect {
             clusterReplication ! Cmd(entityId)
           }(system.toTyped)

--- a/src/multi-jvm/scala/lerna/akka/entityreplication/ReplicationRegionSpec.scala
+++ b/src/multi-jvm/scala/lerna/akka/entityreplication/ReplicationRegionSpec.scala
@@ -352,7 +352,6 @@ class ReplicationRegionSpec extends MultiNodeSpec(ReplicationRegionSpecConfig) w
           .warn(
             "Following command had sent to disabled shards was dropped: lerna.akka.entityreplication.ReplicationRegionSpec$DummyReplicationActor$Cmd",
           ).expect {
-            println("this is here.")
             clusterReplication ! Cmd(entityId)
           }(system.toTyped)
       }

--- a/src/multi-jvm/scala/lerna/akka/entityreplication/ReplicationRegionSpec.scala
+++ b/src/multi-jvm/scala/lerna/akka/entityreplication/ReplicationRegionSpec.scala
@@ -1,6 +1,8 @@
 package lerna.akka.entityreplication
 
 import akka.Done
+import akka.actor.testkit.typed.scaladsl.LoggingTestKit
+import akka.actor.typed.scaladsl.adapter.ClassicActorSystemOps
 
 import java.util.concurrent.atomic.AtomicInteger
 import akka.actor.{ Actor, ActorRef, ActorSelection, DiagnosticActorLogging, Props, RootActorPath, Terminated }
@@ -120,6 +122,7 @@ object ReplicationRegionSpecConfig extends MultiNodeConfig {
       lerna.akka.entityreplication.raft.compaction.log-size-threshold = 2
       lerna.akka.entityreplication.raft.compaction.preserve-log-size = 1
       lerna.akka.entityreplication.raft.compaction.log-size-check-interval = 0.1s
+      lerna.akka.entityreplication.raft.disabled-shards = ["12"]
       """))
       .withValue(
         "lerna.akka.entityreplication.raft.multi-raft-roles",
@@ -332,6 +335,28 @@ class ReplicationRegionSpec extends MultiNodeSpec(ReplicationRegionSpecConfig) w
         clusterReplication ! GetStatusWithEnsuringConsistency(entityId)
         expectMsg(Status(3))
       }
+    }
+
+    "drop all messages sent to disabled shards" in {
+      val typeName = createSeqTypeName()
+
+      runOn(node4, node5, node6) {
+        clusterReplication = createReplication(typeName)
+      }
+      enterBarrier("ReplicationRegion created")
+
+      // "disable-id"'s shard id is "12" and the shard id have been defined as disabled id.
+      val entityId = "disabled-id"
+      runOn(node4) {
+        LoggingTestKit
+          .warn(
+            "Following command had sent to disabled shards was dropped: lerna.akka.entityreplication.ReplicationRegionSpec$DummyReplicationActor$Cmd",
+          ).expect {
+            println("this is here.")
+            clusterReplication ! Cmd(entityId)
+          }(system.toTyped)
+      }
+      enterBarrier("Some command sent")
     }
 
     "Broadcast" when {

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftSettingsSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftSettingsSpec.scala
@@ -25,6 +25,7 @@ final class RaftSettingsSpec extends TestKit(ActorSystem("RaftSettingsSpec")) wi
       settings.replicationFactor shouldBe 3
       settings.quorumSize shouldBe 2
       settings.numberOfShards shouldBe 100
+      settings.disabledShards shouldBe Set.empty
       settings.maxAppendEntriesSize shouldBe 16
       settings.maxAppendEntriesBatchSize shouldBe 10
       settings.compactionSnapshotCacheTimeToLive shouldBe 10.seconds

--- a/src/test/scala/lerna/akka/entityreplication/raft/eventsourced/CommitLogStoreActorSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/eventsourced/CommitLogStoreActorSpec.scala
@@ -30,6 +30,7 @@ object CommitLogStoreActorSpec {
       |  snapshot-store.plugin = ${PersistenceTestKitSnapshotPlugin.PluginId}
       |  snapshot-every = $snapshotEvery
       |}
+      |lerna.akka.entityreplication.raft.disabled-shards = ["disabled-shard-id"]
       |""".stripMargin)
 
   def config: Config = {
@@ -568,6 +569,11 @@ final class CommitLogStoreActorSpec
       snapshotTestKit.expectNothingPersisted(persistenceId)
     }
 
+    "stop itself when its shard id is defined as disabled" in {
+      val (commitLogStoreActor, _, _) = spawnCommitLogStoreActor(name = Some("disabled-shard-id"))
+      watch(commitLogStoreActor)
+      expectTerminated(commitLogStoreActor)
+    }
   }
 
 }


### PR DESCRIPTION
Add feature of disabling raft actor's launching by specifying its own shard id.

Ignore following launching trigger of RaftActor
- `ReplicationRegionRaftActorStarter`
- `ReplicationRegion`
- `RaftActor`