### PR TITLE
Add unit tests of SnapshotStore

### DIFF
--- a/src/main/scala/lerna/akka/entityreplication/raft/snapshot/SnapshotStore.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/snapshot/SnapshotStore.scala
@@ -17,6 +17,11 @@ private[entityreplication] object SnapshotStore {
       selfMemberIndex: MemberIndex,
   ): Props =
     Props(new SnapshotStore(typeName, entityId, settings, selfMemberIndex))
+
+  /** Returns a persistence ID of SnapshotStore */
+  def persistenceId(typeName: TypeName, entityId: NormalizedEntityId, selfMemberIndex: MemberIndex): String =
+    ActorIds.persistenceId("SnapshotStore", typeName.underlying, entityId.underlying, selfMemberIndex.role)
+
 }
 
 private[entityreplication] class SnapshotStore(

--- a/src/main/scala/lerna/akka/entityreplication/raft/snapshot/SnapshotStore.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/snapshot/SnapshotStore.scala
@@ -34,7 +34,7 @@ private[entityreplication] class SnapshotStore(
   import SnapshotProtocol._
 
   override def persistenceId: String =
-    ActorIds.persistenceId("SnapshotStore", typeName.underlying, entityId.underlying, selfMemberIndex.role)
+    SnapshotStore.persistenceId(typeName, entityId, selfMemberIndex)
 
   override def journalPluginId: String = settings.journalPluginId
 

--- a/src/test/scala/lerna/akka/entityreplication/raft/snapshot/ShardSnapshotStoreFailureSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/snapshot/ShardSnapshotStoreFailureSpec.scala
@@ -1,20 +1,31 @@
 package lerna.akka.entityreplication.raft.snapshot
 
+import akka.actor.testkit.typed.scaladsl.LoggingTestKit
+import akka.actor.typed.scaladsl.adapter.ClassicActorSystemOps
+
 import java.util.concurrent.atomic.AtomicInteger
 import akka.actor.{ ActorRef, ActorSystem }
 import akka.persistence.testkit.scaladsl.SnapshotTestKit
+import akka.persistence.testkit.{
+  ProcessingResult,
+  ProcessingSuccess,
+  SnapshotOperation,
+  SnapshotStorage,
+  WriteSnapshot,
+}
 import akka.testkit.TestKit
 import lerna.akka.entityreplication.model.{ NormalizedEntityId, TypeName }
 import lerna.akka.entityreplication.raft.model.LogEntryIndex
 import lerna.akka.entityreplication.raft.routing.MemberIndex
-import lerna.akka.entityreplication.raft.snapshot.ShardSnapshotStoreFailureSpec._
 import lerna.akka.entityreplication.raft.snapshot.SnapshotProtocol._
 import lerna.akka.entityreplication.raft.{ ActorSpec, RaftSettings }
 import lerna.akka.entityreplication.testkit.KryoSerializable
 
+import scala.concurrent.Promise
+import scala.util.Using
+
 object ShardSnapshotStoreFailureSpec {
   final case object DummyState extends KryoSerializable
-
 }
 
 class ShardSnapshotStoreFailureSpec
@@ -22,6 +33,7 @@ class ShardSnapshotStoreFailureSpec
       ActorSystem("ShardSnapshotStoreFailureSpec", ShardSnapshotStoreSpecBase.configWithPersistenceTestKits),
     )
     with ActorSpec {
+  import ShardSnapshotStoreFailureSpec._
 
   private val snapshotTestKit = SnapshotTestKit(system)
 
@@ -72,6 +84,89 @@ class ShardSnapshotStoreFailureSpec
       shardSnapshotStore ! SaveSnapshot(snapshot, replyTo = testActor)
       expectMsg(SaveSnapshotFailure(metadata))
     }
+  }
+
+  "ShardSnapshotStore (with time-consuming writes)" should {
+
+    // Emulates a time-consuming write
+    class TimeConsumingWriteSnapshotPolicy extends SnapshotStorage.SnapshotPolicies.PolicyType with AutoCloseable {
+      val processingResultPromise = Promise[ProcessingResult]()
+      override def tryProcess(persistenceId: String, processingUnit: SnapshotOperation): ProcessingResult = {
+        processingUnit match {
+          case _: WriteSnapshot => processingResultPromise.future.await
+          case _                => ProcessingSuccess
+        }
+      }
+      override def close(): Unit = {
+        processingResultPromise.trySuccess(ProcessingSuccess)
+      }
+    }
+
+    "reply with `SnapshotNotFound` to `FetchSnapshot` if it has no EntitySnapshot and is saving an EntitySnapshot" ignore {
+      // TODO Change SnapshotStore.savingSnapshot such that this test passes.
+      val entityId           = generateUniqueEntityId()
+      val shardSnapshotStore = createShardSnapshotStore()
+      val metadata           = EntitySnapshotMetadata(entityId, LogEntryIndex(1))
+      val snapshot           = EntitySnapshot(metadata, EntityState(DummyState))
+
+      Using(new TimeConsumingWriteSnapshotPolicy()) { timeConsumingWriteSnapshotPolicy =>
+        // Prepare: SnapshotStore is saving the snapshot
+        snapshotTestKit.withPolicy(timeConsumingWriteSnapshotPolicy)
+        shardSnapshotStore ! SaveSnapshot(snapshot, replyTo = testActor)
+
+        // Test:
+        shardSnapshotStore ! FetchSnapshot(entityId, replyTo = testActor)
+        expectMsg(SnapshotNotFound)
+      }
+    }
+
+    "reply with `SnapshotFound` to `FetchSnapshot` if it has an EntitySnapshot and is saving a new EntitySnapshot" in {
+      val entityId           = generateUniqueEntityId()
+      val shardSnapshotStore = createShardSnapshotStore()
+
+      val firstSnapshotMetadata = EntitySnapshotMetadata(entityId, LogEntryIndex(1))
+      val firstSnapshot =
+        EntitySnapshot(firstSnapshotMetadata, EntityState(DummyState))
+      shardSnapshotStore ! SaveSnapshot(firstSnapshot, replyTo = testActor)
+      expectMsg(SaveSnapshotSuccess(firstSnapshotMetadata))
+
+      Using(new TimeConsumingWriteSnapshotPolicy()) { timeConsumingWriteSnapshotPolicy =>
+        // Prepare: SnapshotStore is saving the second snapshot
+        snapshotTestKit.withPolicy(timeConsumingWriteSnapshotPolicy)
+        val secondSnapshot =
+          EntitySnapshot(EntitySnapshotMetadata(entityId, LogEntryIndex(5)), EntityState(DummyState))
+        shardSnapshotStore ! SaveSnapshot(secondSnapshot, replyTo = testActor)
+
+        // Test:
+        shardSnapshotStore ! FetchSnapshot(entityId, replyTo = testActor)
+        expectMsg(SnapshotFound(firstSnapshot))
+      }
+    }
+
+    "reply with nothing to `SaveSnapshot` and log a warning if it is saving an EntitySnapshot" in {
+      implicit val typedSystem: akka.actor.typed.ActorSystem[Nothing] = system.toTyped
+
+      val entityId           = generateUniqueEntityId()
+      val shardSnapshotStore = createShardSnapshotStore()
+      val metadata           = EntitySnapshotMetadata(entityId, LogEntryIndex(1))
+      val snapshot           = EntitySnapshot(metadata, EntityState(DummyState))
+
+      Using(new TimeConsumingWriteSnapshotPolicy()) { timeConsumingWriteSnapshotPolicy =>
+        // Prepare: SnapshotStore is saving the snapshot
+        snapshotTestKit.withPolicy(timeConsumingWriteSnapshotPolicy)
+        shardSnapshotStore ! SaveSnapshot(snapshot, replyTo = testActor)
+
+        // Test:
+        LoggingTestKit
+          .warn(
+            s"Saving snapshot for an entity ($entityId) currently. Consider to increase log-size-threshold or log-size-check-interval.",
+          ).expect {
+            shardSnapshotStore ! SaveSnapshot(snapshot, replyTo = testActor)
+          }
+        expectNoMessage()
+      }
+    }
+
   }
 
 }

--- a/src/test/scala/lerna/akka/entityreplication/raft/snapshot/ShardSnapshotStoreFailureSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/snapshot/ShardSnapshotStoreFailureSpec.scala
@@ -3,9 +3,7 @@ package lerna.akka.entityreplication.raft.snapshot
 import java.util.concurrent.atomic.AtomicInteger
 import akka.actor.{ ActorRef, ActorSystem }
 import akka.persistence.testkit.scaladsl.SnapshotTestKit
-import akka.persistence.testkit.{ PersistenceTestKitPlugin, PersistenceTestKitSnapshotPlugin }
 import akka.testkit.TestKit
-import com.typesafe.config.{ Config, ConfigFactory }
 import lerna.akka.entityreplication.model.{ NormalizedEntityId, TypeName }
 import lerna.akka.entityreplication.raft.model.LogEntryIndex
 import lerna.akka.entityreplication.raft.routing.MemberIndex
@@ -17,29 +15,11 @@ import lerna.akka.entityreplication.testkit.KryoSerializable
 object ShardSnapshotStoreFailureSpec {
   final case object DummyState extends KryoSerializable
 
-  def configWithPersistenceTestKits: Config = {
-    PersistenceTestKitPlugin.config
-      .withFallback(PersistenceTestKitSnapshotPlugin.config)
-      .withFallback(raftPersistenceConfigWithPersistenceTestKits)
-      .withFallback(ConfigFactory.load())
-  }
-
-  private val raftPersistenceConfigWithPersistenceTestKits: Config = ConfigFactory.parseString(
-    s"""
-       |lerna.akka.entityreplication.raft.persistence {
-       |  journal.plugin = ${PersistenceTestKitPlugin.PluginId}
-       |  snapshot-store.plugin = ${PersistenceTestKitSnapshotPlugin.PluginId}
-       |  # Might be possible to use PersistenceTestKitReadJournal
-       |  // query.plugin = ""
-       |}
-       |""".stripMargin,
-  )
-
 }
 
 class ShardSnapshotStoreFailureSpec
     extends TestKit(
-      ActorSystem("ShardSnapshotStoreFailureSpec", ShardSnapshotStoreFailureSpec.configWithPersistenceTestKits),
+      ActorSystem("ShardSnapshotStoreFailureSpec", ShardSnapshotStoreSpecBase.configWithPersistenceTestKits),
     )
     with ActorSpec {
 

--- a/src/test/scala/lerna/akka/entityreplication/raft/snapshot/ShardSnapshotStoreSpecBase.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/snapshot/ShardSnapshotStoreSpecBase.scala
@@ -1,0 +1,26 @@
+package lerna.akka.entityreplication.raft.snapshot
+
+import akka.persistence.testkit.{ PersistenceTestKitPlugin, PersistenceTestKitSnapshotPlugin }
+import com.typesafe.config.{ Config, ConfigFactory }
+
+object ShardSnapshotStoreSpecBase {
+
+  def configWithPersistenceTestKits: Config = {
+    PersistenceTestKitPlugin.config
+      .withFallback(PersistenceTestKitSnapshotPlugin.config)
+      .withFallback(raftPersistenceConfigWithPersistenceTestKits)
+      .withFallback(ConfigFactory.load())
+  }
+
+  private val raftPersistenceConfigWithPersistenceTestKits: Config = ConfigFactory.parseString(
+    s"""
+       |lerna.akka.entityreplication.raft.persistence {
+       |  journal.plugin = ${PersistenceTestKitPlugin.PluginId}
+       |  snapshot-store.plugin = ${PersistenceTestKitSnapshotPlugin.PluginId}
+       |  # Might be possible to use PersistenceTestKitReadJournal
+       |  // query.plugin = ""
+       |}
+       |""".stripMargin,
+  )
+
+}

--- a/src/test/scala/lerna/akka/entityreplication/raft/snapshot/SnapshotStoreSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/snapshot/SnapshotStoreSpec.scala
@@ -1,0 +1,24 @@
+package lerna.akka.entityreplication.raft.snapshot
+
+import akka.actor.ActorSystem
+import akka.testkit.TestKit
+import lerna.akka.entityreplication.model.{ NormalizedEntityId, TypeName }
+import lerna.akka.entityreplication.raft.ActorSpec
+import lerna.akka.entityreplication.raft.routing.MemberIndex
+
+final class SnapshotStoreSpec extends TestKit(ActorSystem("SnapshotStoreSpec")) with ActorSpec {
+
+  "SnapshotStore.persistenceId" should {
+
+    "return a persistence ID for the given type name, entity ID, and member index" in {
+      val persistenceId = SnapshotStore.persistenceId(
+        TypeName.from("test-type-name"),
+        NormalizedEntityId.from("test-entity-id"),
+        MemberIndex("test-member-index"),
+      )
+      assert(persistenceId === "SnapshotStore:test-type-name:test-entity-id:test-member-index")
+    }
+
+  }
+
+}


### PR DESCRIPTION
Prepares for https://github.com/lerna-stack/akka-entity-replication/issues/174

Add the following method and its unit test:
* `SnapshotStore$.persistenceId`: returns a persistence ID of `SnapshotStore`

Add the following unit tests:
* `SnapshotStore` should save the given `EntitySnapshot`.
* `SnapshotStore` should save nothing if it has the same `EntitySnapshot`.
* `SnapshotStore` should reply to `FetchSnapshot` even if it is saving an `EntitySnapshot`.
* `SnapshotStore` should log a warning if it is saving an `EntitySnapshot` and receives a `SaveSnapshot` command.

Change the following unit tests:
* The existing unit tests of `ShardSnapshotStoreFailureSpec` give a persistence ID to `SnapshotTestKit` for clarifying the persistence ID to fail.