### PR TITLE
Persit EntitySnapshot as an event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add function extracting shard id from entity id to lerna.akka.entityreplication.typed.ClusterReplication
   [PR#172](https://github.com/lerna-stack/akka-entity-replication/pull/172)
 - Add function of Disabling raft actor [PR#173](https://github.com/lerna-stack/akka-entity-replication/pull/173)
+- Persist EntitySnapshot as an event
+  [PR#184](https://github.com/lerna-stack/akka-entity-replication/pull/184)
 
 ### Fixed
 - RaftActor might delete committed entries

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -70,6 +70,13 @@ lerna.akka.entityreplication {
       max-snapshot-batch-size = 1000
     }
 
+    // Snapshot store settings
+    snapshot-store {
+
+      // Number of persistent events that will trigger snapshot saving.
+      snapshot-interval = 1
+    }
+
     sharding = ${akka.cluster.sharding} {
       // Maximum number of messages that are buffered by a ShardRegion actor.
       // Make it smaller than the default value to discard messages that are too old.

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -70,10 +70,13 @@ lerna.akka.entityreplication {
       max-snapshot-batch-size = 1000
     }
 
-    // Snapshot store settings
-    snapshot-store {
+    // Entity snapshot store settings
+    // All entity snapshot histries are persisted for data recovery.
+    entity-snapshot-store {
 
-      // Number of persistent events that will trigger snapshot saving.
+      // Frequency of taking snapshot of entity snapshot.
+      // By taking snapshot, optimizing recovery times of an Entity.
+      // Increasing this value increases snapshot writing, decreasing it increases recovery times.
       snapshot-every = 1
     }
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -74,7 +74,7 @@ lerna.akka.entityreplication {
     snapshot-store {
 
       // Number of persistent events that will trigger snapshot saving.
-      snapshot-interval = 1
+      snapshot-every = 1
     }
 
     sharding = ${akka.cluster.sharding} {

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftSettings.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftSettings.scala
@@ -50,7 +50,7 @@ trait RaftSettings {
 
   def snapshotSyncMaxSnapshotBatchSize: Int
 
-  def snapshotStoreSnapshotInterval: Int
+  def snapshotStoreSnapshotEvery: Int
 
   def clusterShardingConfig: Config
 

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftSettings.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftSettings.scala
@@ -50,6 +50,8 @@ trait RaftSettings {
 
   def snapshotSyncMaxSnapshotBatchSize: Int
 
+  def snapshotStoreSnapshotInterval: Int
+
   def clusterShardingConfig: Config
 
   def raftActorAutoStartFrequency: FiniteDuration

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftSettingsImpl.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftSettingsImpl.scala
@@ -27,7 +27,7 @@ private[entityreplication] final case class RaftSettingsImpl(
     snapshotSyncCopyingParallelism: Int,
     snapshotSyncPersistenceOperationTimeout: FiniteDuration,
     snapshotSyncMaxSnapshotBatchSize: Int,
-    snapshotStoreSnapshotInterval: Int,
+    snapshotStoreSnapshotEvery: Int,
     clusterShardingConfig: Config,
     raftActorAutoStartFrequency: FiniteDuration,
     raftActorAutoStartNumberOfActors: Int,
@@ -157,10 +157,10 @@ private[entityreplication] object RaftSettingsImpl {
       s"snapshot-sync.max-snapshot-batch-size (${snapshotSyncMaxSnapshotBatchSize}) should be larger than 0",
     )
 
-    val snapshotStoreSnapshotInterval: Int = config.getInt("snapshot-store.snapshot-interval")
+    val snapshotStoreSnapshotEvery: Int = config.getInt("snapshot-store.snapshot-every")
     require(
-      snapshotStoreSnapshotInterval > 0,
-      s"snapshot-store.snapshot-interval ($snapshotStoreSnapshotInterval) should be larger than 0",
+      snapshotStoreSnapshotEvery > 0,
+      s"snapshot-store.snapshot-every ($snapshotStoreSnapshotEvery) should be larger than 0",
     )
 
     val clusterShardingConfig: Config = config.getConfig("sharding")
@@ -244,7 +244,7 @@ private[entityreplication] object RaftSettingsImpl {
       snapshotSyncCopyingParallelism = snapshotSyncCopyingParallelism,
       snapshotSyncPersistenceOperationTimeout = snapshotSyncPersistenceOperationTimeout,
       snapshotSyncMaxSnapshotBatchSize = snapshotSyncMaxSnapshotBatchSize,
-      snapshotStoreSnapshotInterval = snapshotStoreSnapshotInterval,
+      snapshotStoreSnapshotEvery = snapshotStoreSnapshotEvery,
       clusterShardingConfig = clusterShardingConfig,
       raftActorAutoStartFrequency = raftActorAutoStartFrequency,
       raftActorAutoStartNumberOfActors = raftActorAutoStartNumberOfActors,

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftSettingsImpl.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftSettingsImpl.scala
@@ -27,6 +27,7 @@ private[entityreplication] final case class RaftSettingsImpl(
     snapshotSyncCopyingParallelism: Int,
     snapshotSyncPersistenceOperationTimeout: FiniteDuration,
     snapshotSyncMaxSnapshotBatchSize: Int,
+    snapshotStoreSnapshotInterval: Int,
     clusterShardingConfig: Config,
     raftActorAutoStartFrequency: FiniteDuration,
     raftActorAutoStartNumberOfActors: Int,
@@ -156,6 +157,12 @@ private[entityreplication] object RaftSettingsImpl {
       s"snapshot-sync.max-snapshot-batch-size (${snapshotSyncMaxSnapshotBatchSize}) should be larger than 0",
     )
 
+    val snapshotStoreSnapshotInterval: Int = config.getInt("snapshot-store.snapshot-interval")
+    require(
+      snapshotStoreSnapshotInterval > 0,
+      s"snapshot-store.snapshot-interval ($snapshotStoreSnapshotInterval) should be larger than 0",
+    )
+
     val clusterShardingConfig: Config = config.getConfig("sharding")
 
     val raftActorAutoStartFrequency: FiniteDuration =
@@ -237,6 +244,7 @@ private[entityreplication] object RaftSettingsImpl {
       snapshotSyncCopyingParallelism = snapshotSyncCopyingParallelism,
       snapshotSyncPersistenceOperationTimeout = snapshotSyncPersistenceOperationTimeout,
       snapshotSyncMaxSnapshotBatchSize = snapshotSyncMaxSnapshotBatchSize,
+      snapshotStoreSnapshotInterval = snapshotStoreSnapshotInterval,
       clusterShardingConfig = clusterShardingConfig,
       raftActorAutoStartFrequency = raftActorAutoStartFrequency,
       raftActorAutoStartNumberOfActors = raftActorAutoStartNumberOfActors,

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftSettingsImpl.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftSettingsImpl.scala
@@ -157,10 +157,10 @@ private[entityreplication] object RaftSettingsImpl {
       s"snapshot-sync.max-snapshot-batch-size (${snapshotSyncMaxSnapshotBatchSize}) should be larger than 0",
     )
 
-    val snapshotStoreSnapshotEvery: Int = config.getInt("snapshot-store.snapshot-every")
+    val snapshotStoreSnapshotEvery: Int = config.getInt("entity-snapshot-store.snapshot-every")
     require(
       snapshotStoreSnapshotEvery > 0,
-      s"snapshot-store.snapshot-every ($snapshotStoreSnapshotEvery) should be larger than 0",
+      s"entity-snapshot-store.snapshot-every ($snapshotStoreSnapshotEvery) should be larger than 0",
     )
 
     val clusterShardingConfig: Config = config.getConfig("sharding")

--- a/src/main/scala/lerna/akka/entityreplication/raft/snapshot/SnapshotStore.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/snapshot/SnapshotStore.scala
@@ -2,7 +2,7 @@ package lerna.akka.entityreplication.raft.snapshot
 
 import akka.actor.{ ActorLogging, ActorRef, Props, ReceiveTimeout }
 import akka.persistence
-import akka.persistence.{ PersistentActor, Recovery, SnapshotSelectionCriteria }
+import akka.persistence.PersistentActor
 import lerna.akka.entityreplication.model.{ NormalizedEntityId, TypeName }
 import lerna.akka.entityreplication.raft.RaftSettings
 import lerna.akka.entityreplication.raft.routing.MemberIndex
@@ -33,6 +33,8 @@ private[entityreplication] class SnapshotStore(
     with ActorLogging {
   import SnapshotProtocol._
 
+  private var replayRefCache: Option[ActorRef] = None
+
   override def persistenceId: String =
     SnapshotStore.persistenceId(typeName, entityId, selfMemberIndex)
 
@@ -42,19 +44,29 @@ private[entityreplication] class SnapshotStore(
 
   context.setReceiveTimeout(settings.compactionSnapshotCacheTimeToLive)
 
-  // SequenceNr is always 0 because SnapshotStore doesn't persist events (only persist snapshots).
-  override def recovery: Recovery =
-    Recovery(
-      toSequenceNr = 0L,
-      fromSnapshot = SnapshotSelectionCriteria(maxSequenceNr = 0L, maxTimestamp = Long.MaxValue),
-    )
-
   override def receiveRecover: Receive = {
+    case snapshot: EntitySnapshot => context.become(hasSnapshot(snapshot))
     case akka.persistence.SnapshotOffer(_, s: EntitySnapshot) =>
       context.become(hasSnapshot(s))
   }
 
   override def receiveCommand: Receive = hasNoSnapshot
+
+  override protected def onPersistFailure(cause: Throwable, event: Any, seqNr: Long): Unit = {
+    if (log.isWarningEnabled) {
+      log.warning(
+        "Saving snapshot failed - {}: {}",
+        cause.getClass.getCanonicalName,
+        cause.getMessage,
+      )
+    }
+    super.onPersistFailure(cause, event, seqNr)
+    replayRefCache.fold(
+      if (log.isWarningEnabled) log.warning("missing reply reference - {}", cause.getClass.getCanonicalName),
+    )(
+      _ ! SaveSnapshotFailure(event.asInstanceOf[EntitySnapshot].metadata),
+    )
+  }
 
   def hasNoSnapshot: Receive = {
     case command: Command =>
@@ -81,7 +93,11 @@ private[entityreplication] class SnapshotStore(
       // reduce IO: don't save if same as cached snapshot
       command.replyTo ! SaveSnapshotSuccess(command.snapshot.metadata)
     } else {
-      saveSnapshot(command.snapshot)
+      replayRefCache = Some(command.replyTo)
+      persistAsync(command.snapshot) { _ =>
+        command.replyTo ! SaveSnapshotSuccess(command.snapshot.metadata)
+        context.become(hasSnapshot(command.snapshot))
+      }
       context.become(savingSnapshot(command.replyTo, command.snapshot, prevSnapshot))
     }
   }
@@ -103,17 +119,6 @@ private[entityreplication] class SnapshotStore(
               replyTo ! SnapshotProtocol.SnapshotNotFound(entityId)
           }
       }
-    case _: persistence.SaveSnapshotSuccess =>
-      replyTo ! SaveSnapshotSuccess(snapshot.metadata)
-      context.become(hasSnapshot(snapshot))
-    case failure: persistence.SaveSnapshotFailure =>
-      if (log.isWarningEnabled)
-        log.warning(
-          "Saving snapshot failed - {}: {}",
-          failure.cause.getClass.getCanonicalName,
-          failure.cause.getMessage,
-        )
-      replyTo ! SaveSnapshotFailure(snapshot.metadata)
   }
 
   override def unhandled(message: Any): Unit =

--- a/src/main/scala/lerna/akka/entityreplication/raft/snapshot/SnapshotStore.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/snapshot/SnapshotStore.scala
@@ -133,8 +133,8 @@ private[entityreplication] class SnapshotStore(
           log.debug("Saving EntitySnapshot as a snapshot succeeded.")
         }
       case failure: persistence.SaveSnapshotFailure =>
-        if (log.isDebugEnabled) {
-          log.debug(
+        if (log.isWarningEnabled) {
+          log.warning(
             "Saving EntitySnapshot as a snapshot failed. - {}: {}",
             failure.cause.getClass.getCanonicalName,
             failure.cause.getMessage,

--- a/src/main/scala/lerna/akka/entityreplication/raft/snapshot/SnapshotStore.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/snapshot/SnapshotStore.scala
@@ -96,7 +96,7 @@ private[entityreplication] class SnapshotStore(
       replyRefCache = Some(command.replyTo)
       persistAsync(command.snapshot) { _ =>
         command.replyTo ! SaveSnapshotSuccess(command.snapshot.metadata)
-        if (lastSequenceNr % settings.snapshotStoreSnapshotInterval == 0 && lastSequenceNr != 0) {
+        if (lastSequenceNr % settings.snapshotStoreSnapshotEvery == 0 && lastSequenceNr != 0) {
           saveSnapshot(command.snapshot)
         }
         context.become(hasSnapshot(command.snapshot))

--- a/src/main/scala/lerna/akka/entityreplication/raft/snapshot/SnapshotStore.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/snapshot/SnapshotStore.scala
@@ -101,11 +101,11 @@ private[entityreplication] class SnapshotStore(
         }
         context.become(hasSnapshot(command.snapshot))
       }
-      context.become(savingSnapshot(command.replyTo, command.snapshot, prevSnapshot))
+      context.become(savingSnapshot(prevSnapshot))
     }
   }
 
-  def savingSnapshot(replyTo: ActorRef, snapshot: EntitySnapshot, prevSnapshot: Option[EntitySnapshot]): Receive = {
+  def savingSnapshot(prevSnapshot: Option[EntitySnapshot]): Receive = {
     case command: Command =>
       command match {
         case cmd: SaveSnapshot =>

--- a/src/main/scala/lerna/akka/entityreplication/raft/snapshot/SnapshotStore.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/snapshot/SnapshotStore.scala
@@ -93,7 +93,7 @@ private[entityreplication] class SnapshotStore(
       // reduce IO: don't save if same as cached snapshot
       command.replyTo ! SaveSnapshotSuccess(command.snapshot.metadata)
     } else {
-      replyRefCache = Some(command.replyTo)
+      replyRefCache = Option(command.replyTo)
       persistAsync(command.snapshot) { _ =>
         command.replyTo ! SaveSnapshotSuccess(command.snapshot.metadata)
         if (lastSequenceNr % settings.snapshotStoreSnapshotEvery == 0 && lastSequenceNr != 0) {

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftSettingsSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftSettingsSpec.scala
@@ -180,11 +180,11 @@ final class RaftSettingsSpec extends TestKit(ActorSystem("RaftSettingsSpec")) wi
       }
     }
 
-    "throw an IllegalArgumentException if the given snapshot-store.snapshot-every is less than or equal to 0" in {
+    "throw an IllegalArgumentException if the given entity-snapshot-store.snapshot-every is less than or equal to 0" in {
       {
         val config = ConfigFactory
           .parseString("""
-              |lerna.akka.entityreplication.raft.snapshot-store.snapshot-every = -1
+              |lerna.akka.entityreplication.raft.entity-snapshot-store.snapshot-every = -1
               |""".stripMargin)
           .withFallback(defaultConfig)
         a[IllegalArgumentException] shouldBe thrownBy {
@@ -194,7 +194,7 @@ final class RaftSettingsSpec extends TestKit(ActorSystem("RaftSettingsSpec")) wi
       {
         val config = ConfigFactory
           .parseString("""
-              |lerna.akka.entityreplication.raft.snapshot-store.snapshot-every = 0
+              |lerna.akka.entityreplication.raft.entity-snapshot-store.snapshot-every = 0
               |""".stripMargin)
           .withFallback(defaultConfig)
         a[IllegalArgumentException] shouldBe thrownBy {

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftSettingsSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftSettingsSpec.scala
@@ -35,6 +35,7 @@ final class RaftSettingsSpec extends TestKit(ActorSystem("RaftSettingsSpec")) wi
       settings.snapshotSyncCopyingParallelism shouldBe 10
       settings.snapshotSyncPersistenceOperationTimeout shouldBe 10.seconds
       settings.snapshotSyncMaxSnapshotBatchSize shouldBe 1_000
+      settings.snapshotStoreSnapshotInterval shouldBe 1
       settings.clusterShardingConfig shouldBe defaultConfig.getConfig("lerna.akka.entityreplication.raft.sharding")
       settings.raftActorAutoStartFrequency shouldBe 3.seconds
       settings.raftActorAutoStartNumberOfActors shouldBe 5
@@ -171,6 +172,29 @@ final class RaftSettingsSpec extends TestKit(ActorSystem("RaftSettingsSpec")) wi
         val config = ConfigFactory
           .parseString("""
               |lerna.akka.entityreplication.raft.snapshot-sync.max-snapshot-batch-size = 0
+              |""".stripMargin)
+          .withFallback(defaultConfig)
+        a[IllegalArgumentException] shouldBe thrownBy {
+          RaftSettings(config)
+        }
+      }
+    }
+
+    "throw an IllegalArgumentException if the given snapshot-store.snapshot-interval is less than or equal to 0" in {
+      {
+        val config = ConfigFactory
+          .parseString("""
+              |lerna.akka.entityreplication.raft.snapshot-store.snapshot-interval = -1
+              |""".stripMargin)
+          .withFallback(defaultConfig)
+        a[IllegalArgumentException] shouldBe thrownBy {
+          RaftSettings(config)
+        }
+      }
+      {
+        val config = ConfigFactory
+          .parseString("""
+              |lerna.akka.entityreplication.raft.snapshot-store.snapshot-interval = 0
               |""".stripMargin)
           .withFallback(defaultConfig)
         a[IllegalArgumentException] shouldBe thrownBy {

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftSettingsSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftSettingsSpec.scala
@@ -35,7 +35,7 @@ final class RaftSettingsSpec extends TestKit(ActorSystem("RaftSettingsSpec")) wi
       settings.snapshotSyncCopyingParallelism shouldBe 10
       settings.snapshotSyncPersistenceOperationTimeout shouldBe 10.seconds
       settings.snapshotSyncMaxSnapshotBatchSize shouldBe 1_000
-      settings.snapshotStoreSnapshotInterval shouldBe 1
+      settings.snapshotStoreSnapshotEvery shouldBe 1
       settings.clusterShardingConfig shouldBe defaultConfig.getConfig("lerna.akka.entityreplication.raft.sharding")
       settings.raftActorAutoStartFrequency shouldBe 3.seconds
       settings.raftActorAutoStartNumberOfActors shouldBe 5
@@ -180,11 +180,11 @@ final class RaftSettingsSpec extends TestKit(ActorSystem("RaftSettingsSpec")) wi
       }
     }
 
-    "throw an IllegalArgumentException if the given snapshot-store.snapshot-interval is less than or equal to 0" in {
+    "throw an IllegalArgumentException if the given snapshot-store.snapshot-every is less than or equal to 0" in {
       {
         val config = ConfigFactory
           .parseString("""
-              |lerna.akka.entityreplication.raft.snapshot-store.snapshot-interval = -1
+              |lerna.akka.entityreplication.raft.snapshot-store.snapshot-every = -1
               |""".stripMargin)
           .withFallback(defaultConfig)
         a[IllegalArgumentException] shouldBe thrownBy {
@@ -194,7 +194,7 @@ final class RaftSettingsSpec extends TestKit(ActorSystem("RaftSettingsSpec")) wi
       {
         val config = ConfigFactory
           .parseString("""
-              |lerna.akka.entityreplication.raft.snapshot-store.snapshot-interval = 0
+              |lerna.akka.entityreplication.raft.snapshot-store.snapshot-every = 0
               |""".stripMargin)
           .withFallback(defaultConfig)
         a[IllegalArgumentException] shouldBe thrownBy {

--- a/src/test/scala/lerna/akka/entityreplication/raft/snapshot/ShardSnapshotStoreFailureSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/snapshot/ShardSnapshotStoreFailureSpec.scala
@@ -90,7 +90,7 @@ class ShardSnapshotStoreFailureSpec
 
       val config = ConfigFactory
         .parseString("""
-                       |lerna.akka.entityreplication.raft.snapshot-store.snapshot-every = 1
+                       |lerna.akka.entityreplication.raft.entity-snapshot-store.snapshot-every = 1
                        |""".stripMargin)
         .withFallback(system.settings.config)
       val entityId                   = generateUniqueEntityId()

--- a/src/test/scala/lerna/akka/entityreplication/raft/snapshot/ShardSnapshotStoreFailureSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/snapshot/ShardSnapshotStoreFailureSpec.scala
@@ -98,7 +98,7 @@ class ShardSnapshotStoreFailureSpec
 
       // Test:
       LoggingTestKit.warn("Saving EntitySnapshot as a snapshot failed.").expect {
-        // In this test, lerna.akka.entityreplication.raft.snapshot-store.snapshot-interval = 1
+        // In this test, lerna.akka.entityreplication.raft.snapshot-store.snapshot-every = 1
         shardSnapshotStore ! SaveSnapshot(snapshot, replyTo = testActor)
         persistenceTestKit.expectNextPersisted(snapshotStorePersistenceId, snapshot)
         expectMsg(SaveSnapshotSuccess(metadata))

--- a/src/test/scala/lerna/akka/entityreplication/raft/snapshot/ShardSnapshotStoreFailureSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/snapshot/ShardSnapshotStoreFailureSpec.scala
@@ -114,19 +114,6 @@ class ShardSnapshotStoreFailureSpec
     // Note:
     //   The promise (`processingResultPromise`) must be fulfilled.
     //   The succeeding tests will fail unless the promise is fulfilled.
-    class TimeConsumingWriteSnapshotPolicy extends SnapshotStorage.SnapshotPolicies.PolicyType {
-      val processingResultPromise = Promise[ProcessingResult]()
-      override def tryProcess(persistenceId: String, processingUnit: SnapshotOperation): ProcessingResult = {
-        processingUnit match {
-          case _: WriteSnapshot => processingResultPromise.future.await
-          case _                => ProcessingSuccess
-        }
-      }
-      def trySuccess(): Unit = {
-        processingResultPromise.trySuccess(ProcessingSuccess)
-      }
-    }
-
     class TimeConsumingPersistEventPolicy extends EventStorage.JournalPolicies.PolicyType {
       private val processingResultPromise = Promise[ProcessingResult]()
       override def tryProcess(persistenceId: String, processingUnit: JournalOperation): ProcessingResult = {

--- a/src/test/scala/lerna/akka/entityreplication/raft/snapshot/ShardSnapshotStoreFailureSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/snapshot/ShardSnapshotStoreFailureSpec.scala
@@ -84,7 +84,7 @@ class ShardSnapshotStoreFailureSpec
       expectMsg(SaveSnapshotFailure(metadata))
     }
 
-    "output debug log when save EntitySnapshot as a snapshot failed" in {
+    "output warn log when save EntitySnapshot as a snapshot failed" in {
       implicit val typedSystem: akka.actor.typed.ActorSystem[Nothing] = system.toTyped
 
       val entityId                   = generateUniqueEntityId()
@@ -97,7 +97,7 @@ class ShardSnapshotStoreFailureSpec
       snapshotTestKit.failNextPersisted(snapshotStorePersistenceId)
 
       // Test:
-      LoggingTestKit.debug("Saving EntitySnapshot as a snapshot failed.").expect {
+      LoggingTestKit.warn("Saving EntitySnapshot as a snapshot failed.").expect {
         // In this test, lerna.akka.entityreplication.raft.snapshot-store.snapshot-interval = 1
         shardSnapshotStore ! SaveSnapshot(snapshot, replyTo = testActor)
         persistenceTestKit.expectNextPersisted(snapshotStorePersistenceId, snapshot)

--- a/src/test/scala/lerna/akka/entityreplication/raft/snapshot/ShardSnapshotStoreSuccessSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/snapshot/ShardSnapshotStoreSuccessSpec.scala
@@ -121,12 +121,12 @@ class ShardSnapshotStoreSuccessSpec
       expectTerminated(snapshotStore)
     }
 
-    "save EntitySnapshot as a snapshot per lerna.akka.entityreplication.raft.snapshot-store.snapshot-every" in {
+    "save EntitySnapshot as a snapshot per lerna.akka.entityreplication.raft.entity-snapshot-store.snapshot-every" in {
       implicit val typedSystem: akka.actor.typed.ActorSystem[Nothing] = system.toTyped
 
       val config = ConfigFactory
         .parseString("""
-                       |lerna.akka.entityreplication.raft.snapshot-store.snapshot-every = 1
+                       |lerna.akka.entityreplication.raft.entity-snapshot-store.snapshot-every = 1
                        |""".stripMargin)
         .withFallback(system.settings.config)
       val entityId                   = generateUniqueEntityId()

--- a/src/test/scala/lerna/akka/entityreplication/raft/snapshot/ShardSnapshotStoreSuccessSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/snapshot/ShardSnapshotStoreSuccessSpec.scala
@@ -121,7 +121,7 @@ class ShardSnapshotStoreSuccessSpec
       expectTerminated(snapshotStore)
     }
 
-    "save EntitySnapshot as a snapshot per lerna.akka.entityreplication.raft.snapshot-store.snapshot-interval" in {
+    "save EntitySnapshot as a snapshot per lerna.akka.entityreplication.raft.snapshot-store.snapshot-every" in {
       implicit val typedSystem: akka.actor.typed.ActorSystem[Nothing] = system.toTyped
 
       val entityId                   = generateUniqueEntityId()
@@ -131,7 +131,7 @@ class ShardSnapshotStoreSuccessSpec
       val snapshot                   = EntitySnapshot(metadata, dummyEntityState)
 
       LoggingTestKit.debug("Saving EntitySnapshot as a snapshot succeeded.").expect {
-        // In this test, lerna.akka.entityreplication.raft.snapshot-store.snapshot-interval = 1
+        // In this test, lerna.akka.entityreplication.raft.snapshot-store.snapshot-every = 1
         shardSnapshotStore ! SaveSnapshot(snapshot, replyTo = testActor)
         persistenceTestKit.expectNextPersisted(snapshotStorePersistenceId, snapshot)
         expectMsg(SaveSnapshotSuccess(metadata))


### PR DESCRIPTION
made following changes for implementing EntitySnapshot backup:

- save EntitySnapshot as an Event
  - use `persistAsync` for avoiding performance degradation
  - if `persistAsync` failed, return `SaveSnapshotFailure` by `onPersistFailure` function
- save EntitySnapshot as an Snapshot per configuration of `lerna.akka.entityreplication.raft.snapshot-store.snapshot-every`
  - if `saveSnapshot` return `persistence.SaveSnapshotSuccess`, output debug log.
  - if `saveSnapshot` return `persistence.SaveSnapshotFailure` output warn log.