### PR TITLE
Allow only specific actors defined as a sticky leader to become a leader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add function of Disabling raft actor [PR#173](https://github.com/lerna-stack/akka-entity-replication/pull/173)
 - Add diagnostic info to logs of sending replication results
   [PR#179](https://github.com/lerna-stack/akka-entity-replication/pull/179)
-- Allow only specific actors defined as a sticky leader to become a leader when `sticky-leaders` is configured
+- Allow only specific actors defined as a sticky leader to become a leader
   [PR#186](https://github.com/lerna-stack/akka-entity-replication/pull/186)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add function extracting shard id from entity id to lerna.akka.entityreplication.typed.ClusterReplication
   [PR#172](https://github.com/lerna-stack/akka-entity-replication/pull/172)
 - Add function of Disabling raft actor [PR#173](https://github.com/lerna-stack/akka-entity-replication/pull/173)
+- Allow only specific actors defined as a sticky leader to become a leader when `sticky-leaders` is configured
+  [PR#186](https://github.com/lerna-stack/akka-entity-replication/pull/186)
 
 ### Fixed
 - RaftActor might delete committed entries

--- a/docs/implementation_guide.md
+++ b/docs/implementation_guide.md
@@ -168,7 +168,7 @@ AtLeastOnceComplete.askTo(
 
 By default, all raft actors can become a Leader.
 You can fix a Leader actor per shard by setting a sticky leader.
-Fixing leader actor prevent committed event loss during recovery.
+Fixing leader actor prevents committed event loss during recovery.
 
 ```scala
 import akka.actor.typed.ActorSystem

--- a/docs/implementation_guide.md
+++ b/docs/implementation_guide.md
@@ -168,6 +168,7 @@ AtLeastOnceComplete.askTo(
 
 By default, all raft actors can become a Leader.
 You can fix a Leader actor per shard by setting a sticky leader.
+Fixing leader actor prevent committed event loss during recovery.
 
 ```scala
 import akka.actor.typed.ActorSystem

--- a/docs/implementation_guide.md
+++ b/docs/implementation_guide.md
@@ -164,10 +164,10 @@ AtLeastOnceComplete.askTo(
 )
 ```
 
-### Fixing leader actor every shard
+### Fixing leader actor per shard
 
 By default, all raft actors can become a Leader.
-You can fix a Leader actor every shard by setting a sticky leader.
+You can fix a Leader actor per shard by setting a sticky leader.
 
 ```scala
 import akka.actor.typed.ActorSystem

--- a/docs/implementation_guide.md
+++ b/docs/implementation_guide.md
@@ -164,6 +164,30 @@ AtLeastOnceComplete.askTo(
 )
 ```
 
+### Fixing leader actor every shard
+
+By default, all raft actors can become a Leader.
+You can fix a Leader actor every shard by setting a sticky leader.
+
+```scala
+import akka.actor.typed.ActorSystem
+import lerna.akka.entityreplication.typed._
+
+val system: ActorSystem[_] = ???
+val clusterReplication = ClusterReplication(system)
+
+// Settings for sticky leader. Only a raft actor which have role "replica-group-1" can become Leader in shard given id "1"
+val settings =
+  ClusterReplicationSettings(system)
+    .withStickyLeaders(Map("1" -> "replica-group-1"))
+
+val entity = 
+  ReplicatedEntity(BankAccountBehavior.TypeKey)(entityContext => BankAccountBehavior(entityContext))
+    .withSettings(settings)
+    
+clusterReplication.init(entity)
+```
+
 ### Configuration
 
 On the command side, the related settings are defined at `lerna.akka.entityreplication`(except `lerna.akka.entityreplication.raft.eventsourced`) in [reference.conf](/src/main/resources/reference.conf).

--- a/src/main/mima-filters/2.1.0.backwards.excludes/pr-186-allow-only-specific-actors-to-become-leader.excludes
+++ b/src/main/mima-filters/2.1.0.backwards.excludes/pr-186-allow-only-specific-actors-to-become-leader.excludes
@@ -1,0 +1,2 @@
+# ClusterReplicationSettings should not be extended by users
+ProblemFilters.exclude[ReversedMissingMethodProblem]("lerna.akka.entityreplication.ClusterReplicationSettings.withStickyLeaders")

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -9,6 +9,15 @@ lerna.akka.entityreplication {
     // The time it takes to start electing a new leader after the heartbeat is no longer received from the leader.
     election-timeout = 750 ms
 
+    // `sticky-leaders` hold key-value pairs which represent raft actors which can be a leader.
+    // Key represent shard id and value represent raft role.
+    // e.g.{
+    //       "1" = "replica-group-1"
+    //       "3" = "replica-group-3"
+    //     }
+    // If it's empty, all raft actors are allowed to become a leader.
+    sticky-leaders = {}
+
     // The interval between leaders sending heartbeats to their followers
     heartbeat-interval = 100 ms
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -9,15 +9,6 @@ lerna.akka.entityreplication {
     // The time it takes to start electing a new leader after the heartbeat is no longer received from the leader.
     election-timeout = 750 ms
 
-    // `sticky-leaders` hold key-value pairs which represent raft actors which can be a leader.
-    // Key represent shard id and value represent raft role.
-    // e.g.{
-    //       "1" = "replica-group-1"
-    //       "3" = "replica-group-3"
-    //     }
-    // If it's empty, all raft actors are allowed to become a leader.
-    sticky-leaders = {}
-
     // The interval between leaders sending heartbeats to their followers
     heartbeat-interval = 100 ms
 

--- a/src/main/scala/lerna/akka/entityreplication/ClusterReplicationSettings.scala
+++ b/src/main/scala/lerna/akka/entityreplication/ClusterReplicationSettings.scala
@@ -40,6 +40,7 @@ trait ClusterReplicationSettings {
   def selfMemberIndex: MemberIndex
 
   def withStickyLeaders(stickyLeaders: Map[String, String]): ClusterReplicationSettings
+
   def withRaftJournalPluginId(pluginId: String): ClusterReplicationSettings
 
   def withRaftSnapshotPluginId(pluginId: String): ClusterReplicationSettings

--- a/src/main/scala/lerna/akka/entityreplication/ClusterReplicationSettings.scala
+++ b/src/main/scala/lerna/akka/entityreplication/ClusterReplicationSettings.scala
@@ -39,6 +39,7 @@ trait ClusterReplicationSettings {
 
   def selfMemberIndex: MemberIndex
 
+  def withStickyLeaders(stickyLeaders: Map[String, String]): ClusterReplicationSettings
   def withRaftJournalPluginId(pluginId: String): ClusterReplicationSettings
 
   def withRaftSnapshotPluginId(pluginId: String): ClusterReplicationSettings

--- a/src/main/scala/lerna/akka/entityreplication/internal/ClusterReplicationSettingsImpl.scala
+++ b/src/main/scala/lerna/akka/entityreplication/internal/ClusterReplicationSettingsImpl.scala
@@ -18,6 +18,9 @@ private[entityreplication] final case class ClusterReplicationSettingsImpl(
 ) extends ClusterReplicationSettings
     with typed.ClusterReplicationSettings {
 
+  override def withStickyLeaders(stickyLeaders: Map[String, String]): ClusterReplicationSettingsImpl =
+    copy(raftSettings = raftSettings.withStickyLeaders(stickyLeaders))
+
   override def withRaftJournalPluginId(pluginId: String): ClusterReplicationSettingsImpl =
     copy(raftSettings = raftSettings.withJournalPluginId(pluginId))
 

--- a/src/main/scala/lerna/akka/entityreplication/raft/Candidate.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/Candidate.scala
@@ -42,7 +42,7 @@ private[raft] trait Candidate { this: RaftActor =>
       log.info("[Candidate] Election timeout at {}. Retrying leader election.", currentData.currentTerm)
     val newTerm = currentData.currentTerm.next()
     cancelElectionTimeoutTimer()
-    if (canBecomeCandidate(this.shardId, this.selfMemberIndex)) {
+    if (canBecomeCandidate) {
       broadcast(
         RequestVote(
           shardId,

--- a/src/main/scala/lerna/akka/entityreplication/raft/Candidate.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/Candidate.scala
@@ -42,10 +42,7 @@ private[raft] trait Candidate { this: RaftActor =>
       log.info("[Candidate] Election timeout at {}. Retrying leader election.", currentData.currentTerm)
     val newTerm = currentData.currentTerm.next()
     cancelElectionTimeoutTimer()
-    if (
-      settings.stickyLeaders.isEmpty || settings.stickyLeaders
-        .get(this.shardId.raw).fold(false)(_ == this.selfMemberIndex.role)
-    ) {
+    if (canBecomeCandidate(this.shardId, this.selfMemberIndex)) {
       broadcast(
         RequestVote(
           shardId,

--- a/src/main/scala/lerna/akka/entityreplication/raft/Follower.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/Follower.scala
@@ -12,15 +12,7 @@ private[raft] trait Follower { this: RaftActor =>
   import RaftActor._
 
   def followerBehavior: Receive = {
-
-    case ElectionTimeout =>
-      if (currentData.leaderMember.isEmpty) {
-        if (log.isDebugEnabled) log.debug("=== [Follower] election timeout ===")
-      } else {
-        if (log.isWarningEnabled) log.warning("[{}] election timeout. Leader will be changed", currentState)
-      }
-      requestVote(currentData)
-
+    case ElectionTimeout                                 => receiveElectionTimeout()
     case request: RequestVote                            => receiveRequestVote(request)
     case request: AppendEntries                          => receiveAppendEntries(request)
     case request: InstallSnapshot                        => receiveInstallSnapshot(request)
@@ -43,6 +35,21 @@ private[raft] trait Follower { this: RaftActor =>
     case response: CommitLogStoreActor.AppendCommittedEntriesResponse =>
       receiveAppendCommittedEntriesResponse(response)
 
+  }
+
+  def receiveElectionTimeout(): Unit = {
+    if (currentData.leaderMember.isEmpty) {
+      if (log.isDebugEnabled) log.debug("=== [Follower] election timeout ===")
+    } else {
+      if (log.isWarningEnabled) log.warning("[{}] election timeout. Leader will be changed", currentState)
+    }
+    cancelElectionTimeoutTimer()
+    if (
+      settings.stickyLeaders.isEmpty || settings.stickyLeaders
+        .get(this.shardId.raw).fold(false)(_ == this.selfMemberIndex.role)
+    ) {
+      requestVote(currentData)
+    }
   }
 
   private[this] def receiveRequestVote(request: RequestVote): Unit =
@@ -150,7 +157,6 @@ private[raft] trait Follower { this: RaftActor =>
 
   private[this] def requestVote(data: RaftMemberData): Unit = {
     val newTerm = data.currentTerm.next()
-    cancelElectionTimeoutTimer()
     broadcast(
       RequestVote(shardId, newTerm, selfMemberIndex, data.replicatedLog.lastLogIndex, data.replicatedLog.lastLogTerm),
     ) // TODO: 永続化前に broadcast して問題ないか調べる

--- a/src/main/scala/lerna/akka/entityreplication/raft/Follower.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/Follower.scala
@@ -37,7 +37,7 @@ private[raft] trait Follower { this: RaftActor =>
 
   }
 
-  def receiveElectionTimeout(): Unit = {
+  private[this] def receiveElectionTimeout(): Unit = {
     if (currentData.leaderMember.isEmpty) {
       if (log.isDebugEnabled) log.debug("=== [Follower] election timeout ===")
     } else {

--- a/src/main/scala/lerna/akka/entityreplication/raft/Follower.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/Follower.scala
@@ -44,7 +44,7 @@ private[raft] trait Follower { this: RaftActor =>
       if (log.isWarningEnabled) log.warning("[{}] election timeout. Leader will be changed", currentState)
     }
     cancelElectionTimeoutTimer()
-    if (canBecomeCandidate(this.shardId, this.selfMemberIndex)) {
+    if (canBecomeCandidate) {
       requestVote(currentData)
     }
   }

--- a/src/main/scala/lerna/akka/entityreplication/raft/Follower.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/Follower.scala
@@ -44,10 +44,7 @@ private[raft] trait Follower { this: RaftActor =>
       if (log.isWarningEnabled) log.warning("[{}] election timeout. Leader will be changed", currentState)
     }
     cancelElectionTimeoutTimer()
-    if (
-      settings.stickyLeaders.isEmpty || settings.stickyLeaders
-        .get(this.shardId.raw).fold(false)(_ == this.selfMemberIndex.role)
-    ) {
+    if (canBecomeCandidate(this.shardId, this.selfMemberIndex)) {
       requestVote(currentData)
     }
   }

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
@@ -157,7 +157,7 @@ private[raft] class RaftActor(
   import RaftActor._
   import context.dispatcher
 
-  if (settings.stickyLeaders.get(shardId.raw).fold(false)(_ == selfMemberIndex.role) && log.isWarningEnabled) {
+  if (isStickyLeader && log.isWarningEnabled) {
     log.warning(
       "This raft actor is defined as sticky leader. shard id = {} , role = {}, stickyLeaders = {}. sticky leaders are not able to failover to other multi-raft-roles. This means that some entities can be unavailable by some failures. Please unset sticky-leaders settings if there is no need.",
       shardId.raw,
@@ -165,6 +165,9 @@ private[raft] class RaftActor(
       settings.stickyLeaders,
     )
   }
+
+  private def isStickyLeader: Boolean =
+    settings.stickyLeaders.get(this.shardId.raw).fold(false)(_ == this.selfMemberIndex.role)
 
   protected def canBecomeCandidate(shardId: NormalizedShardId, memberIndex: MemberIndex): Boolean =
     settings.stickyLeaders.get(shardId.raw).fold(true)(_ == memberIndex.role)

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
@@ -169,8 +169,8 @@ private[raft] class RaftActor(
   private def isStickyLeader: Boolean =
     settings.stickyLeaders.get(this.shardId.raw).fold(false)(_ == this.selfMemberIndex.role)
 
-  protected def canBecomeCandidate(shardId: NormalizedShardId, memberIndex: MemberIndex): Boolean =
-    settings.stickyLeaders.get(shardId.raw).fold(true)(_ == memberIndex.role)
+  protected def canBecomeCandidate: Boolean =
+    settings.stickyLeaders.get(this.shardId.raw).fold(true)(_ == this.selfMemberIndex.role)
 
   protected[this] def shardId: NormalizedShardId = NormalizedShardId.from(self.path)
 

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
@@ -159,9 +159,7 @@ private[raft] class RaftActor(
 
   if (settings.stickyLeaders.get(shardId.raw).fold(false)(_ == selfMemberIndex.role) && log.isWarningEnabled) {
     log.warning(
-      """This raft actor is defined as sticky leader.
-        | shard id = {} , role = {}, stickyLeaders = {}
-        | sticky leaders are not able to failover to other multi-raft-roles. This means that some entities can be unavailable by some failures. Please unset sticky-leaders settings if there is no need.""".stripMargin,
+      "This raft actor is defined as sticky leader. shard id = {} , role = {}, stickyLeaders = {}. sticky leaders are not able to failover to other multi-raft-roles. This means that some entities can be unavailable by some failures. Please unset sticky-leaders settings if there is no need.",
       shardId.raw,
       selfMemberIndex.role,
       settings.stickyLeaders,

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
@@ -171,6 +171,9 @@ private[raft] class RaftActor(
     }
   }
 
+  protected def canBecomeCandidate(shardId: NormalizedShardId, memberIndex: MemberIndex): Boolean =
+    settings.stickyLeaders.get(shardId.raw).fold(true)(_ == memberIndex.role)
+
   protected[this] def shardId: NormalizedShardId = NormalizedShardId.from(self.path)
 
   protected[this] def region: ActorRef = _region

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
@@ -160,7 +160,7 @@ private[raft] class RaftActor(
   if (settings.stickyLeaders.nonEmpty) {
     if (log.isWarningEnabled) {
       log.warning(
-        "`sticky-leaders` is configured: {}. This raft actor's shard id = {} and role = {}",
+        "`sticky leaders` are configured: {}. This raft actor's shard id = {} and role = {}",
         settings.stickyLeaders,
         shardId.raw,
         selfMemberIndex.role,

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
@@ -157,18 +157,15 @@ private[raft] class RaftActor(
   import RaftActor._
   import context.dispatcher
 
-  if (settings.stickyLeaders.nonEmpty) {
-    if (log.isWarningEnabled) {
-      log.warning(
-        "`sticky leaders` are configured: {}. This raft actor's shard id = {} and role = {}",
-        settings.stickyLeaders,
-        shardId.raw,
-        selfMemberIndex.role,
-      )
-      if (settings.stickyLeaders.get(shardId.raw).fold(false)(_ == selfMemberIndex.role)) {
-        log.warning("This raft actor is defined as sticky leader")
-      }
-    }
+  if (settings.stickyLeaders.get(shardId.raw).fold(false)(_ == selfMemberIndex.role) && log.isWarningEnabled) {
+    log.warning(
+      """This raft actor is defined as sticky leader.
+        | shard id = {} , role = {}, stickyLeaders = {}
+        | sticky leaders are not able to failover to other multi-raft-roles. This means that some entities can be unavailable by some failures. Please unset sticky-leaders settings if there is no need.""".stripMargin,
+      shardId.raw,
+      selfMemberIndex.role,
+      settings.stickyLeaders,
+    )
   }
 
   protected def canBecomeCandidate(shardId: NormalizedShardId, memberIndex: MemberIndex): Boolean =

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
@@ -157,6 +157,20 @@ private[raft] class RaftActor(
   import RaftActor._
   import context.dispatcher
 
+  if (settings.stickyLeaders.nonEmpty) {
+    if (log.isWarningEnabled) {
+      log.warning(
+        "`sticky-leaders` is configured: {}. This raft actor's shard id = {} and role = {}",
+        settings.stickyLeaders,
+        shardId.raw,
+        selfMemberIndex.role,
+      )
+      if (settings.stickyLeaders.get(shardId.raw).fold(false)(_ == selfMemberIndex.role)) {
+        log.warning("This raft actor is defined as sticky leader")
+      }
+    }
+  }
+
   protected[this] def shardId: NormalizedShardId = NormalizedShardId.from(self.path)
 
   protected[this] def region: ActorRef = _region

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftSettings.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftSettings.scala
@@ -80,7 +80,7 @@ trait RaftSettings {
 
   def eventSourcedSnapshotEvery: Int
 
-  private [entityreplication] def withStickyLeaders(stickyLeaders: Map[String, String]): RaftSettings
+  private[entityreplication] def withStickyLeaders(stickyLeaders: Map[String, String]): RaftSettings
 
   private[entityreplication] def withJournalPluginId(pluginId: String): RaftSettings
 

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftSettings.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftSettings.scala
@@ -14,6 +14,8 @@ trait RaftSettings {
 
   def electionTimeout: FiniteDuration
 
+  def stickyLeaders: Map[String, String]
+
   private[raft] def randomizedElectionTimeout(): FiniteDuration
 
   def heartbeatInterval: FiniteDuration

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftSettings.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftSettings.scala
@@ -80,6 +80,8 @@ trait RaftSettings {
 
   def eventSourcedSnapshotEvery: Int
 
+  private [entityreplication] def withStickyLeaders(stickyLeaders: Map[String, String]): RaftSettings
+
   private[entityreplication] def withJournalPluginId(pluginId: String): RaftSettings
 
   private[entityreplication] def withSnapshotPluginId(pluginId: String): RaftSettings

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftSettingsImpl.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftSettingsImpl.scala
@@ -56,6 +56,9 @@ private[entityreplication] final case class RaftSettingsImpl(
       ).asJava
     }
 
+  override private[entityreplication] def withStickyLeaders(stickyLeaders: Map[String, String]) =
+    copy(stickyLeaders = stickyLeaders)
+
   override private[entityreplication] def withJournalPluginId(pluginId: String): RaftSettings =
     copy(journalPluginId = pluginId)
 
@@ -81,8 +84,7 @@ private[entityreplication] object RaftSettingsImpl {
 
     val electionTimeout: FiniteDuration = config.getDuration("election-timeout").toScala
 
-    val stickyLeaders: Map[String, String] =
-      config.getConfig("sticky-leaders").entrySet.asScala.map(e => e.getKey -> e.getValue.unwrapped().toString).toMap
+    val stickyLeaders: Map[String, String] = Map.empty
 
     val heartbeatInterval: FiniteDuration = config.getDuration("heartbeat-interval").toScala
 

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftSettingsImpl.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftSettingsImpl.scala
@@ -11,6 +11,7 @@ import scala.util.Random
 private[entityreplication] final case class RaftSettingsImpl(
     config: Config,
     electionTimeout: FiniteDuration,
+    stickyLeaders: Map[String, String],
     heartbeatInterval: FiniteDuration,
     electionTimeoutMin: Duration,
     multiRaftRoles: Set[String],
@@ -79,6 +80,9 @@ private[entityreplication] object RaftSettingsImpl {
     val config: Config = root.getConfig("lerna.akka.entityreplication.raft")
 
     val electionTimeout: FiniteDuration = config.getDuration("election-timeout").toScala
+
+    val stickyLeaders: Map[String, String] =
+      config.getConfig("sticky-leaders").entrySet.asScala.map(e => e.getKey -> e.getValue.unwrapped().toString).toMap
 
     val heartbeatInterval: FiniteDuration = config.getDuration("heartbeat-interval").toScala
 
@@ -221,6 +225,7 @@ private[entityreplication] object RaftSettingsImpl {
     RaftSettingsImpl(
       config = config,
       electionTimeout = electionTimeout,
+      stickyLeaders = stickyLeaders,
       heartbeatInterval = heartbeatInterval,
       electionTimeoutMin = electionTimeoutMin,
       multiRaftRoles = multiRaftRoles,

--- a/src/test/scala/lerna/akka/entityreplication/ClusterReplicationSettingsSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/ClusterReplicationSettingsSpec.scala
@@ -55,6 +55,12 @@ class ClusterReplicationSettingsSpec extends WordSpec with Matchers {
       )
     }
 
+    "change value of raftSettings.stickyLeaders by withStickyLeaders" in {
+      val settings    = ClusterReplicationSettingsImpl(config, correctClusterRoles.headOption.toSet)
+      val newSettings = settings.withStickyLeaders(Map("1" -> "replica-group-1"))
+      newSettings.raftSettings.stickyLeaders should be(Map("1" -> "replica-group-1"))
+    }
+
     "change value of raftSettings.journalPluginId by withRaftJournalPluginId" in {
       val settings         = ClusterReplicationSettingsImpl(config, correctClusterRoles.headOption.toSet)
       val expectedPluginId = "new-raft-journal-plugin-id"

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorCandidateSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorCandidateSpec.scala
@@ -217,18 +217,13 @@ class RaftActorCandidateSpec
       val shardId              = createUniqueShardId()
       val candidateMemberIndex = createUniqueMemberIndex()
       val regionProbe          = TestProbe()
-      val configStickyLeader = ConfigFactory
-        .parseString(s"""
-        lerna.akka.entityreplication.raft.sticky-leaders = {
-          "${shardId.raw}" = "${candidateMemberIndex.role}"
-        }
-        // electionTimeout がテスト中に自動で発生しないようにする
-        lerna.akka.entityreplication.raft.election-timeout = 999999s""").withFallback(config)
+      val customSettings =
+        RaftSettings(defaultRaftConfig).withStickyLeaders(Map(shardId.raw -> candidateMemberIndex.role))
       val candidate = createRaftActor(
         shardId = shardId,
         selfMemberIndex = candidateMemberIndex,
         region = regionProbe.ref,
-        settings = RaftSettings(configStickyLeader),
+        settings = customSettings,
       )
       val currentTerm   = Term(2)
       val candidateData = createCandidateData(currentTerm, ReplicatedLog())
@@ -258,18 +253,13 @@ class RaftActorCandidateSpec
       val shardId              = createUniqueShardId()
       val candidateMemberIndex = createUniqueMemberIndex()
       val regionProbe          = TestProbe()
-      val configStickyLeader = ConfigFactory
-        .parseString(s"""
-        lerna.akka.entityreplication.raft.sticky-leaders = {
-          "other-actors-shard-id" = "other-actors-role"
-        }
-        // electionTimeout がテスト中に自動で発生しないようにする
-        lerna.akka.entityreplication.raft.election-timeout = 999999s""").withFallback(config)
+      val customSettings =
+        RaftSettings(defaultRaftConfig).withStickyLeaders(Map("other-actors-shard-id" -> "other-actors-role"))
       val candidate = createRaftActor(
         shardId = shardId,
         selfMemberIndex = candidateMemberIndex,
         region = regionProbe.ref,
-        settings = RaftSettings(configStickyLeader),
+        settings = customSettings,
       )
       val currentTerm   = Term(2)
       val candidateData = createCandidateData(currentTerm, ReplicatedLog())

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorCandidateSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorCandidateSpec.scala
@@ -242,12 +242,12 @@ class RaftActorCandidateSpec
       }
     }
 
-    "not send RequestVote on ElectionTimeout if other raft actors are defined as a sticky leader and it's not defined as a sticky leader" in {
+    "not send RequestVote on ElectionTimeout if another raft actor which belongs same shard is defined as a sticky leader" in {
       val shardId              = createUniqueShardId()
       val candidateMemberIndex = createUniqueMemberIndex()
       val regionProbe          = TestProbe()
       val customSettings =
-        RaftSettings(defaultRaftConfig).withStickyLeaders(Map("other-actors-shard-id" -> "other-actors-role"))
+        RaftSettings(defaultRaftConfig).withStickyLeaders(Map(s"${shardId.raw}" -> "other-actors-role"))
       val candidate = createRaftActor(
         shardId = shardId,
         selfMemberIndex = candidateMemberIndex,

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorCandidateSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorCandidateSpec.scala
@@ -5,16 +5,9 @@ import akka.actor.testkit.typed.scaladsl.LoggingTestKit
 import akka.actor.typed.scaladsl.adapter.ClassicActorSystemOps
 import akka.persistence.testkit.scaladsl.PersistenceTestKit
 import akka.testkit.{ TestKit, TestProbe }
-import com.typesafe.config.ConfigFactory
 import lerna.akka.entityreplication.ReplicationRegion
 import lerna.akka.entityreplication.model.{ EntityInstanceId, NormalizedEntityId, NormalizedShardId }
-import lerna.akka.entityreplication.raft.RaftProtocol.{
-  Command,
-  ForwardedCommand,
-  ProcessCommand,
-  Replicate,
-  ReplicationFailed,
-}
+import lerna.akka.entityreplication.raft.RaftProtocol._
 import lerna.akka.entityreplication.raft.model._
 import lerna.akka.entityreplication.raft.protocol.RaftCommands._
 import lerna.akka.entityreplication.raft.routing.MemberIndex

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorFollowerSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorFollowerSpec.scala
@@ -5,7 +5,6 @@ import akka.actor.testkit.typed.scaladsl.LoggingTestKit
 import akka.actor.typed.scaladsl.adapter.ClassicActorSystemOps
 import akka.persistence.testkit.scaladsl.PersistenceTestKit
 import akka.testkit.{ TestKit, TestProbe }
-import com.typesafe.config.ConfigFactory
 import lerna.akka.entityreplication.ReplicationRegion
 import lerna.akka.entityreplication.model.{ EntityInstanceId, NormalizedEntityId }
 import lerna.akka.entityreplication.raft.RaftProtocol._

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorFollowerSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorFollowerSpec.scala
@@ -210,18 +210,13 @@ class RaftActorFollowerSpec
       val shardId             = createUniqueShardId()
       val followerMemberIndex = createUniqueMemberIndex()
       val regionProbe         = TestProbe()
-      val configStickyLeader = ConfigFactory
-        .parseString(s"""
-        lerna.akka.entityreplication.raft.sticky-leaders = {
-          "${shardId.raw}" = "${followerMemberIndex.role}"
-        }
-        // electionTimeout がテスト中に自動で発生しないようにする
-        lerna.akka.entityreplication.raft.election-timeout = 999999s""").withFallback(config)
+      val customSettings =
+        RaftSettings(defaultRaftConfig).withStickyLeaders(Map(shardId.raw -> followerMemberIndex.role))
       val follower = createRaftActor(
         shardId = shardId,
         selfMemberIndex = followerMemberIndex,
         region = regionProbe.ref,
-        settings = RaftSettings(configStickyLeader),
+        settings = customSettings,
       )
       val currentTerm  = Term(2)
       val followerData = createFollowerData(currentTerm, ReplicatedLog())
@@ -251,18 +246,13 @@ class RaftActorFollowerSpec
       val shardId             = createUniqueShardId()
       val followerMemberIndex = createUniqueMemberIndex()
       val regionProbe         = TestProbe()
-      val configStickyLeader = ConfigFactory
-        .parseString(s"""
-        lerna.akka.entityreplication.raft.sticky-leaders = {
-          "other-actors-shard-id" = "other-actors-role"
-        }
-        // electionTimeout がテスト中に自動で発生しないようにする
-        lerna.akka.entityreplication.raft.election-timeout = 999999s""").withFallback(config)
+      val customSettings =
+        RaftSettings(defaultRaftConfig).withStickyLeaders(Map("other-actors-shard-id" -> "other-actors-role"))
       val follower = createRaftActor(
         shardId = shardId,
         selfMemberIndex = followerMemberIndex,
         region = regionProbe.ref,
-        settings = RaftSettings(configStickyLeader),
+        settings = customSettings,
       )
       val currentTerm  = Term(2)
       val followerData = createFollowerData(currentTerm, ReplicatedLog())

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorFollowerSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorFollowerSpec.scala
@@ -241,12 +241,12 @@ class RaftActorFollowerSpec
       }
     }
 
-    "not send RequestVote on ElectionTimeout if other raft actors are defined as a sticky leader and it's not defined as a sticky leader" in {
+    "not send RequestVote on ElectionTimeout if another raft actor which belongs same shard is defined as a sticky leader" in {
       val shardId             = createUniqueShardId()
       val followerMemberIndex = createUniqueMemberIndex()
       val regionProbe         = TestProbe()
       val customSettings =
-        RaftSettings(defaultRaftConfig).withStickyLeaders(Map("other-actors-shard-id" -> "other-actors-role"))
+        RaftSettings(defaultRaftConfig).withStickyLeaders(Map(s"${shardId.raw}" -> "other-actors-role"))
       val follower = createRaftActor(
         shardId = shardId,
         selfMemberIndex = followerMemberIndex,

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorFollowerSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorFollowerSpec.scala
@@ -205,6 +205,41 @@ class RaftActorFollowerSpec
       }
     }
 
+    "send RequestVote on ElectionTimeout if a shard which it's belongs to doesn't have a sticky leader" in {
+      val shardId             = createUniqueShardId()
+      val followerMemberIndex = createUniqueMemberIndex()
+      val regionProbe         = TestProbe()
+      val customSettings      = RaftSettings(defaultRaftConfig).withStickyLeaders(Map.empty)
+      val follower = createRaftActor(
+        shardId = shardId,
+        selfMemberIndex = followerMemberIndex,
+        region = regionProbe.ref,
+        settings = customSettings,
+      )
+      val currentTerm  = Term(2)
+      val followerData = createFollowerData(currentTerm, ReplicatedLog())
+      setState(follower, Follower, followerData)
+
+      // ElectionTimeout triggers that this follower sends a RequestVote.
+      follower ! ElectionTimeout
+      val expectedRequestVote =
+        RequestVote(
+          shardId,
+          term = Term(3),
+          candidate = followerMemberIndex,
+          lastLogIndex = LogEntryIndex(0),
+          lastLogTerm = Term(0),
+        )
+      regionProbe.expectMsg(ReplicationRegion.Broadcast(expectedRequestVote))
+      awaitAssert {
+        assert(getState(follower).stateName == Candidate)
+        val stateData = getState(follower).stateData
+        assert(stateData.currentTerm == Term(3))
+        assert(stateData.votedFor.isEmpty)
+        assert(stateData.acceptedMembers.isEmpty)
+      }
+    }
+
     "send RequestVote on ElectionTimeout if it is defined as sticky leader" in {
       val shardId             = createUniqueShardId()
       val followerMemberIndex = createUniqueMemberIndex()

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorSpec.scala
@@ -709,18 +709,16 @@ class RaftActorSpec
       expectTerminated(ref)
     }
 
-    "notice warning log when `sticky-learders` is configured" in {
+    "notice warning log when sticky learders are configured" in {
       val shardId             = createUniqueShardId()
       val followerMemberIndex = createUniqueMemberIndex()
-      val raftConfig = ConfigFactory
-        .parseString(s"""
-                        | lerna.akka.entityreplication.raft.sticky-leaders = { "${shardId.raw}" = "${followerMemberIndex.role}" }
-                        |""".stripMargin).withFallback(ConfigFactory.load())
-      LoggingTestKit.warn("`sticky-leaders` is configured").expect {
+      val customSettings =
+        RaftSettings(defaultRaftConfig).withStickyLeaders(Map(shardId.raw -> followerMemberIndex.role))
+      LoggingTestKit.warn("`sticky leaders` are configured").expect {
         createRaftActor(
           shardId = shardId,
           selfMemberIndex = followerMemberIndex,
-          settings = RaftSettings(raftConfig),
+          settings = customSettings,
         )
       }
     }

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorSpec.scala
@@ -709,12 +709,12 @@ class RaftActorSpec
       expectTerminated(ref)
     }
 
-    "notice warning log when sticky learders are configured" in {
+    "notice warning log when it is defined as sticky leader" in {
       val shardId             = createUniqueShardId()
       val followerMemberIndex = createUniqueMemberIndex()
       val customSettings =
         RaftSettings(defaultRaftConfig).withStickyLeaders(Map(shardId.raw -> followerMemberIndex.role))
-      LoggingTestKit.warn("`sticky leaders` are configured").expect {
+      LoggingTestKit.warn("This raft actor is defined as sticky leader").expect {
         createRaftActor(
           shardId = shardId,
           selfMemberIndex = followerMemberIndex,

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorSpec.scala
@@ -708,6 +708,22 @@ class RaftActorSpec
       watch(ref)
       expectTerminated(ref)
     }
+
+    "notice warning log when `sticky-learders` is configured" in {
+      val shardId             = createUniqueShardId()
+      val followerMemberIndex = createUniqueMemberIndex()
+      val raftConfig = ConfigFactory
+        .parseString(s"""
+                        | lerna.akka.entityreplication.raft.sticky-leaders = { "${shardId.raw}" = "${followerMemberIndex.role}" }
+                        |""".stripMargin).withFallback(ConfigFactory.load())
+      LoggingTestKit.warn("`sticky-leaders` is configured").expect {
+        createRaftActor(
+          shardId = shardId,
+          selfMemberIndex = followerMemberIndex,
+          settings = RaftSettings(raftConfig),
+        )
+      }
+    }
   }
 
 }

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftSettingsSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftSettingsSpec.scala
@@ -20,6 +20,7 @@ final class RaftSettingsSpec extends TestKit(ActorSystem("RaftSettingsSpec")) wi
       val settings = RaftSettings(defaultConfig)
       settings.config shouldBe defaultConfig.getConfig("lerna.akka.entityreplication.raft")
       settings.electionTimeout shouldBe 750.millis
+      settings.stickyLeaders shouldBe Map.empty
       settings.heartbeatInterval shouldBe 100.millis
       settings.multiRaftRoles shouldBe Set("replica-group-1", "replica-group-2", "replica-group-3")
       settings.replicationFactor shouldBe 3


### PR DESCRIPTION
Allow only specific actors defined as a sticky leader to become a leader when `RaftSettings.stickyLeaders` is not empty.

* add API of `withStickyLeaders`
* add following features to `Follower.scala` and `Candidate.scala`
  * if `stickyLeaders` is not empty, only raft actors defined as a sticky leader can become `Leader`
  * if `stickyLeaders` is empty, all raft actors can become `Leader`
* add following feature to `RaftActor.scala`
  * notice warn log when creation of raft actor if  `stickyLeaders` is not empty