### PR TITLE
Set disabled shards only by API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [PR#177](https://github.com/lerna-stack/akka-entity-replication/pull/177)
 - Add function extracting shard id from entity id to lerna.akka.entityreplication.typed.ClusterReplication
   [PR#172](https://github.com/lerna-stack/akka-entity-replication/pull/172)
-- Add function of Disabling raft actor [PR#173](https://github.com/lerna-stack/akka-entity-replication/pull/173)
+- Add function of Disabling raft actor
+  [PR#173](https://github.com/lerna-stack/akka-entity-replication/pull/173),
+  [PR#188](https://github.com/lerna-stack/akka-entity-replication/pull/188)
 
 ### Changed
 - Enhance leader's replication response handling [PR#160](https://github.com/lerna-stack/akka-entity-replication/pull/160)

--- a/docs/typed/implementation_guide.md
+++ b/docs/typed/implementation_guide.md
@@ -409,6 +409,31 @@ clusterReplication.init(entity)
 
 This is useful when you would like to change the datastore that persists events or snapshots for each type key.
 
+### Disable specific Raft shards
+
+By default, akka-entity-replication enables all Raft shards. You can disable specific Raft shards as the following:
+```scala
+import akka.actor.typed.ActorSystem
+import lerna.akka.entityreplication.typed._
+
+val system: ActorSystem[_] = ???
+val clusterReplication = ClusterReplication(system)
+
+// Settings for disabling Raft shards ("1" and "3")
+val settings =
+  ClusterReplicationSettings(system)
+    .withDisabledShards(Set("1", "3"))
+
+val entity = 
+  ReplicatedEntity(BankAccountBehavior.TypeKey)(entityContext => BankAccountBehavior(entityContext))
+    .withSettings(settings)
+    
+clusterReplication.init(entity)
+```
+
+This disabling is helpful when making the specific Raft shards maintenance mode. Persistent actors (including Raft actors)
+in disabled Raft shards don't start, which enables maintenance tools to write data store directly.
+
 ### Configuration
 
 On the command side, the related settings are defined at `lerna.akka.entityreplication`(except `lerna.akka.entityreplication.raft.eventsourced`) in [reference.conf](/src/main/resources/reference.conf).

--- a/src/main/mima-filters/2.1.0.backwards.excludes/pr-188-set-disabled-shards-only-api.excludes
+++ b/src/main/mima-filters/2.1.0.backwards.excludes/pr-188-set-disabled-shards-only-api.excludes
@@ -1,0 +1,2 @@
+# ClusterReplicationSettings should not be extended by users
+ProblemFilters.exclude[ReversedMissingMethodProblem]("lerna.akka.entityreplication.ClusterReplicationSettings.withDisabledShards")

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -22,10 +22,6 @@ lerna.akka.entityreplication {
     // Changing this value will cause data inconsistency.
     number-of-shards = 100
 
-    // Shard Ids of raft actors to disable.
-    // e.g. ["2", "5"]
-    disabled-shards = []
-
     // Maximum number of entries which AppendEntries contains.
     // The too large size will cause message serialization failure.
     max-append-entries-size = 16

--- a/src/main/scala/lerna/akka/entityreplication/ClusterReplicationSettings.scala
+++ b/src/main/scala/lerna/akka/entityreplication/ClusterReplicationSettings.scala
@@ -39,6 +39,8 @@ trait ClusterReplicationSettings {
 
   def selfMemberIndex: MemberIndex
 
+  def withDisabledShards(disabledShards: Set[String]): ClusterReplicationSettings
+
   def withRaftJournalPluginId(pluginId: String): ClusterReplicationSettings
 
   def withRaftSnapshotPluginId(pluginId: String): ClusterReplicationSettings

--- a/src/main/scala/lerna/akka/entityreplication/internal/ClusterReplicationSettingsImpl.scala
+++ b/src/main/scala/lerna/akka/entityreplication/internal/ClusterReplicationSettingsImpl.scala
@@ -18,6 +18,9 @@ private[entityreplication] final case class ClusterReplicationSettingsImpl(
 ) extends ClusterReplicationSettings
     with typed.ClusterReplicationSettings {
 
+  override def withDisabledShards(disabledShards: Set[String]): ClusterReplicationSettings =
+    copy(raftSettings = raftSettings.withDisabledShards(disabledShards))
+
   override def withRaftJournalPluginId(pluginId: String): ClusterReplicationSettingsImpl =
     copy(raftSettings = raftSettings.withJournalPluginId(pluginId))
 

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftSettings.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftSettings.scala
@@ -28,6 +28,11 @@ trait RaftSettings {
 
   def numberOfShards: Int
 
+  /** Shard IDs of Raft actors to disable
+    *
+    * The default value is `Set.empty`, which means no RaftActors are disabled. This value is not loaded from the config
+    * to preventing stopping RaftActors across all type names. It only can be changed via [[withDisabledShards]].
+    */
   def disabledShards: Set[String]
 
   def maxAppendEntriesSize: Int
@@ -77,6 +82,8 @@ trait RaftSettings {
   def eventSourcedSnapshotStorePluginId: String
 
   def eventSourcedSnapshotEvery: Int
+
+  private[entityreplication] def withDisabledShards(disabledShards: Set[String]): RaftSettings
 
   private[entityreplication] def withJournalPluginId(pluginId: String): RaftSettings
 

--- a/src/main/scala/lerna/akka/entityreplication/raft/RaftSettingsImpl.scala
+++ b/src/main/scala/lerna/akka/entityreplication/raft/RaftSettingsImpl.scala
@@ -55,6 +55,9 @@ private[entityreplication] final case class RaftSettingsImpl(
       ).asJava
     }
 
+  override private[entityreplication] def withDisabledShards(disabledShards: Set[String]): RaftSettings =
+    copy(disabledShards = disabledShards)
+
   override private[entityreplication] def withJournalPluginId(pluginId: String): RaftSettings =
     copy(journalPluginId = pluginId)
 
@@ -107,6 +110,8 @@ private[entityreplication] object RaftSettingsImpl {
       numberOfShards > 0,
       s"number-of-shards ($numberOfShards) should be larger than 0",
     )
+
+    val disabledShards: Set[String] = Set.empty
 
     val maxAppendEntriesSize: Int = config.getInt("max-append-entries-size")
     require(
@@ -215,8 +220,6 @@ private[entityreplication] object RaftSettingsImpl {
       eventSourcedSnapshotEvery > 0,
       s"snapshot-every ($eventSourcedSnapshotEvery) should be greater than 0.",
     )
-
-    val disabledShards: Set[String] = config.getStringList("disabled-shards").asScala.toSet
 
     RaftSettingsImpl(
       config = config,

--- a/src/test/scala/lerna/akka/entityreplication/ClusterReplicationSettingsSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/ClusterReplicationSettingsSpec.scala
@@ -55,6 +55,12 @@ class ClusterReplicationSettingsSpec extends WordSpec with Matchers {
       )
     }
 
+    "change value of raftSettings.disabledShards by withDisabledShards" in {
+      val settings    = ClusterReplicationSettingsImpl(config, correctClusterRoles.headOption.toSet)
+      val newSettings = settings.withDisabledShards(Set("1", "3"))
+      newSettings.raftSettings.disabledShards should be(Set("1", "3"))
+    }
+
     "change value of raftSettings.journalPluginId by withRaftJournalPluginId" in {
       val settings         = ClusterReplicationSettingsImpl(config, correctClusterRoles.headOption.toSet)
       val expectedPluginId = "new-raft-journal-plugin-id"

--- a/src/test/scala/lerna/akka/entityreplication/ReplicationRegionRaftActorStarterSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/ReplicationRegionRaftActorStarterSpec.scala
@@ -77,12 +77,8 @@ final class ReplicationRegionRaftActorStarterSpec
     "trigger all actor starts without disabled actor" in {
       val shardRegionProbe = TestProbe()
 
-      val customSettings = RaftSettings(
-        ConfigFactory
-          .parseString("""
-              |lerna.akka.entityreplication.raft.disabled-shards = ["2"]
-              |""".stripMargin).withFallback(system.settings.config),
-      )
+      val customSettings = RaftSettings(system.settings.config)
+        .withDisabledShards(Set("2"))
       val raftActorStarter =
         spawnRaftActorStarter(shardRegionProbe.ref, Set("1", "2", "3"), customSettings)
 

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftActorSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftActorSpec.scala
@@ -674,10 +674,8 @@ class RaftActorSpec
 
     "stop itself when its shard id is defined as disabled" in {
       val shardId = createUniqueShardId()
-      val raftConfig = ConfigFactory
-        .parseString(s"""
-            | lerna.akka.entityreplication.raft.disabled-shards = ["${shardId.raw}"]
-            |""".stripMargin).withFallback(ConfigFactory.load())
+      val raftSettings = RaftSettings(defaultRaftConfig)
+        .withDisabledShards(Set(shardId.raw))
       val ref = system.actorOf(
         Props(
           new RaftActor(
@@ -699,7 +697,7 @@ class RaftActorSpec
             }),
             _selfMemberIndex = createUniqueMemberIndex(),
             _otherMemberIndexes = Set(),
-            settings = RaftSettings(raftConfig),
+            settings = raftSettings,
             _commitLogStore = TestProbe().ref,
           ),
         ),

--- a/src/test/scala/lerna/akka/entityreplication/raft/RaftSettingsSpec.scala
+++ b/src/test/scala/lerna/akka/entityreplication/raft/RaftSettingsSpec.scala
@@ -283,6 +283,13 @@ final class RaftSettingsSpec extends TestKit(ActorSystem("RaftSettingsSpec")) wi
       }
     }
 
+    "create new settings using withDisabledShards" in {
+      val settings    = RaftSettings(defaultConfig)
+      val newSettings = settings.withDisabledShards(Set("1", "3"))
+      newSettings.disabledShards shouldNot be(settings.disabledShards)
+      newSettings.disabledShards shouldBe Set("1", "3")
+    }
+
     "create new settings using withJournalPluginId" in {
       val settings    = RaftSettings(defaultConfig)
       val newSettings = settings.withJournalPluginId("new-journal-plugin-id")


### PR DESCRIPTION
* Provide API `ClusterReplicationSettings.withDisabledShards` for setting disabled shards
* Not to provide a config entry (`lerna.akka.entityreplication.raft.disabled-shards`) to prevent stopping RaftActors across all type names (for now)
* Provide document about disabling Raft shards