### PR TITLE
typed.ClusterReplicationSettings supports new methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [PR#172](https://github.com/lerna-stack/akka-entity-replication/pull/172)
 - Add function of Disabling raft actor
   [PR#173](https://github.com/lerna-stack/akka-entity-replication/pull/173),
-  [PR#188](https://github.com/lerna-stack/akka-entity-replication/pull/188)
+  [PR#188](https://github.com/lerna-stack/akka-entity-replication/pull/188),
+  [PR#189](https://github.com/lerna-stack/akka-entity-replication/pull/189)
 
 ### Changed
 - Enhance leader's replication response handling [PR#160](https://github.com/lerna-stack/akka-entity-replication/pull/160)
@@ -29,7 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Persist EntitySnapshot as an event
   [PR#184](https://github.com/lerna-stack/akka-entity-replication/pull/184)
 - Allow only specific actors defined as a sticky leader to become a leader
-  [PR#186](https://github.com/lerna-stack/akka-entity-replication/pull/186)
+  [PR#186](https://github.com/lerna-stack/akka-entity-replication/pull/186),
+  [PR#189](https://github.com/lerna-stack/akka-entity-replication/pull/189)
 
 ### Fixed
 - RaftActor might delete committed entries

--- a/src/main/mima-filters/2.1.0.backwards.excludes/pr-189-typed-cluster-replication-settings-supports-new-methods.excludes
+++ b/src/main/mima-filters/2.1.0.backwards.excludes/pr-189-typed-cluster-replication-settings-supports-new-methods.excludes
@@ -1,0 +1,3 @@
+# typed.ClusterReplicationSettings should not be extended by users
+ProblemFilters.exclude[ReversedMissingMethodProblem]("lerna.akka.entityreplication.typed.ClusterReplicationSettings.withDisabledShards")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("lerna.akka.entityreplication.typed.ClusterReplicationSettings.withStickyLeaders")

--- a/src/main/scala/lerna/akka/entityreplication/internal/ClusterReplicationSettingsImpl.scala
+++ b/src/main/scala/lerna/akka/entityreplication/internal/ClusterReplicationSettingsImpl.scala
@@ -18,7 +18,7 @@ private[entityreplication] final case class ClusterReplicationSettingsImpl(
 ) extends ClusterReplicationSettings
     with typed.ClusterReplicationSettings {
 
-  override def withDisabledShards(disabledShards: Set[String]): ClusterReplicationSettings =
+  override def withDisabledShards(disabledShards: Set[String]): ClusterReplicationSettingsImpl =
     copy(raftSettings = raftSettings.withDisabledShards(disabledShards))
 
   override def withStickyLeaders(stickyLeaders: Map[String, String]): ClusterReplicationSettingsImpl =

--- a/src/main/scala/lerna/akka/entityreplication/typed/ClusterReplicationSettings.scala
+++ b/src/main/scala/lerna/akka/entityreplication/typed/ClusterReplicationSettings.scala
@@ -27,6 +27,8 @@ trait ClusterReplicationSettings extends classic.ClusterReplicationSettings {
 
   override def withDisabledShards(disabledShards: Set[String]): ClusterReplicationSettings
 
+  override def withStickyLeaders(stickyLeaders: Map[String, String]): ClusterReplicationSettings
+
   override def withRaftJournalPluginId(pluginId: String): ClusterReplicationSettings
 
   override def withRaftSnapshotPluginId(pluginId: String): ClusterReplicationSettings

--- a/src/main/scala/lerna/akka/entityreplication/typed/ClusterReplicationSettings.scala
+++ b/src/main/scala/lerna/akka/entityreplication/typed/ClusterReplicationSettings.scala
@@ -25,6 +25,8 @@ trait ClusterReplicationSettings extends classic.ClusterReplicationSettings {
    * This trait allows us to use type API by just importing lerna.akka.entityreplication.typed_.
    */
 
+  override def withDisabledShards(disabledShards: Set[String]): ClusterReplicationSettings
+
   override def withRaftJournalPluginId(pluginId: String): ClusterReplicationSettings
 
   override def withRaftSnapshotPluginId(pluginId: String): ClusterReplicationSettings


### PR DESCRIPTION
`typed.ClusterReplicationSettings` supports the following methods:
* `withDisabledShards`: should return `typed.ClusterReplicationSettings`
* `withStickyLeaders`: should return `typed.ClusterReplicationSettings`