### PR TITLE
Rollback deletes only tagged events (of tag_view) after the given sequence number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 [Unreleased]: https://github.com/lerna-stack/akka-entity-replication/compare/v2.2.0...master
 
+### Changed
+* Rollback deletes only tagged events after the given sequence number
+  [#202](https://github.com/lerna-stack/akka-entity-replication/issues/202),
+  [PR#203](https://github.com/lerna-stack/akka-entity-replication/pull/203)
+
 ### Fixed
 - Dead letters about ReplicationRegion$Passivate continue
   [#199](https://github.com/lerna-stack/akka-entity-replication/issues/199),

--- a/rollback-tool-cassandra/src/main/scala/akka/persistence/cassandra/lerna/CassandraReadJournalExt.scala
+++ b/rollback-tool-cassandra/src/main/scala/akka/persistence/cassandra/lerna/CassandraReadJournalExt.scala
@@ -1,0 +1,64 @@
+package akka.persistence.cassandra.lerna
+
+import akka.NotUsed
+import akka.actor.{ ActorSystem, ExtendedActorSystem }
+import akka.persistence.cassandra.PluginSettings
+import akka.persistence.cassandra.journal.TimeBucket
+import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal
+import akka.persistence.query.Offset
+import akka.stream.scaladsl.Source
+
+import java.util.UUID
+
+object CassandraReadJournalExt {
+
+  final case class CassandraEventEnvelope(
+      persistenceId: String,
+      sequenceNr: Long,
+      timeBucket: Long,
+      timestamp: UUID,
+      tagPidSequenceNr: Long,
+  )
+
+  /** Creates a [[CassandraReadJournalExt]] from the given system and config path
+    *
+    * It resolves a config at the given path from the system's config. The resolved config should have the same structure
+    * as the one of Akka Persistence Cassandra plugin (`akka.persistence.cassandra`).
+    */
+  def apply(system: ActorSystem, configPath: String): CassandraReadJournalExt = {
+    val config   = system.settings.config.getConfig(configPath)
+    val queries  = new CassandraReadJournal(system.asInstanceOf[ExtendedActorSystem], config, configPath)
+    val settings = new PluginSettings(system, config)
+    new CassandraReadJournalExt(queries, settings)
+  }
+
+}
+
+/** Provides Akka Persistence Cassandra Queries ([[akka.persistence.cassandra.query.scaladsl.CassandraReadJournal]])
+  *
+  * Since it depends on internal APIs of Akka Persistence Cassandra, this class is under namespace `akka.persistence.cassandra`.
+  */
+final class CassandraReadJournalExt private (
+    queries: CassandraReadJournal,
+    settings: PluginSettings,
+) {
+  import CassandraReadJournalExt._
+
+  /** Returns an event source that emits events with the given tag
+    *
+    * It's an alternative version of the public API [[akka.persistence.cassandra.query.scaladsl.CassandraReadJournal.currentEventsByTag]].
+    * This method returns some internal information (`timebucket` and `tag_pid_sequence_nr`) that the public API doesn't provide.
+    */
+  def currentEventsByTag(tag: String, offset: Offset): Source[CassandraEventEnvelope, NotUsed] = {
+    queries.currentEventsByTagInternal(tag, offset).map { repr =>
+      CassandraEventEnvelope(
+        repr.persistentRepr.persistenceId,
+        repr.persistentRepr.sequenceNr,
+        TimeBucket(repr.offset, settings.eventsByTagSettings.bucketSize).key,
+        repr.offset,
+        repr.tagPidSequenceNr,
+      )
+    }
+  }
+
+}

--- a/rollback-tool-cassandra/src/main/scala/lerna/akka/entityreplication/rollback/cassandra/CassandraEventsByTagSettings.scala
+++ b/rollback-tool-cassandra/src/main/scala/lerna/akka/entityreplication/rollback/cassandra/CassandraEventsByTagSettings.scala
@@ -1,0 +1,35 @@
+package lerna.akka.entityreplication.rollback.cassandra
+
+import com.typesafe.config.Config
+
+private object CassandraEventsByTagSettings {
+
+  /** Creates a [[CassandraEventsByTagSettings]] from the given config
+    *
+    * The given config should have the same structure as the one of Akka Persistence Cassandra plugin (`akka.persistence.cassandra`).
+    */
+  def apply(pluginConfig: Config): CassandraEventsByTagSettings = {
+    val keyspace =
+      pluginConfig.getString("journal.keyspace")
+    val table =
+      pluginConfig.getString("events-by-tag.table")
+    new CassandraEventsByTagSettings(keyspace, table)
+  }
+
+}
+
+private final class CassandraEventsByTagSettings private (
+    val keyspace: String,
+    val table: String,
+) {
+
+  /** The tag_views table name qualified with the keyspace name */
+  def tagViewsTableName: String = s"${keyspace}.${table}"
+
+  /** The tag_write_progress table name qualified with the keyspace name */
+  def tagWriteProgressTableName: String = s"${keyspace}.tag_write_progress"
+
+  /** The tag_scanning table name qualified with the keyspace name */
+  def tagScanningTableName: String = s"${keyspace}.tag_scanning"
+
+}

--- a/rollback-tool-cassandra/src/main/scala/lerna/akka/entityreplication/rollback/cassandra/CassandraPersistentActorRollbackSettings.scala
+++ b/rollback-tool-cassandra/src/main/scala/lerna/akka/entityreplication/rollback/cassandra/CassandraPersistentActorRollbackSettings.scala
@@ -37,6 +37,9 @@ private final class CassandraPersistentActorRollbackSettings private (
   private[cassandra] val query: CassandraQuerySettings =
     CassandraQuerySettings(pluginConfig)
 
+  private[cassandra] val eventsByTag: CassandraEventsByTagSettings =
+    CassandraEventsByTagSettings(pluginConfig)
+
   private[cassandra] val snapshot: CassandraSnapshotSettings =
     CassandraSnapshotSettings(pluginConfig)
 

--- a/rollback-tool-cassandra/src/main/scala/lerna/akka/entityreplication/rollback/cassandra/CassandraPersistentActorRollbackStatements.scala
+++ b/rollback-tool-cassandra/src/main/scala/lerna/akka/entityreplication/rollback/cassandra/CassandraPersistentActorRollbackStatements.scala
@@ -11,6 +11,47 @@ private final class CassandraPersistentActorRollbackStatements(settings: Cassand
          partition_nr = ? AND
          sequence_nr >= ?
        """
+
+    val deleteTagViews: String =
+      s"""
+       DELETE FROM ${settings.eventsByTag.tagViewsTableName}
+       WHERE
+         tag_name = ? AND
+         timebucket = ? AND
+         timestamp = ? AND
+         persistence_id = ? AND
+         tag_pid_sequence_nr = ?
+       """
+
+    val insertTagWriteProgress: String =
+      s"""
+       INSERT INTO ${settings.eventsByTag.tagWriteProgressTableName}
+       (persistence_id, tag, sequence_nr, tag_pid_sequence_nr, offset)
+       VALUES (?, ?, ?, ?, ?)
+       """
+
+    val insertTagScanning: String =
+      s"""
+       INSERT INTO ${settings.eventsByTag.tagScanningTableName}
+       (persistence_id, sequence_nr)
+       VALUES (?, ?)
+       """
+
+    val deleteTagWriteProgress: String =
+      s"""
+       DELETE FROM ${settings.eventsByTag.tagWriteProgressTableName}
+       WHERE
+         persistence_id = ? AND
+         tag = ?
+       """
+
+    val deleteTagScanning: String =
+      s"""
+       DELETE FROM ${settings.eventsByTag.tagScanningTableName}
+       WHERE
+         persistence_id = ?
+       """
+
   }
 
   object snapshot {

--- a/rollback-tool-cassandra/src/main/scala/lerna/akka/entityreplication/rollback/cassandra/DeleteTagViews.scala
+++ b/rollback-tool-cassandra/src/main/scala/lerna/akka/entityreplication/rollback/cassandra/DeleteTagViews.scala
@@ -1,0 +1,239 @@
+package lerna.akka.entityreplication.rollback.cassandra
+
+import akka.Done
+import akka.actor.{ ActorSystem, ClassicActorSystemProvider }
+import akka.event.{ Logging, LoggingAdapter }
+import akka.persistence.cassandra.lerna.CassandraReadJournalExt
+import akka.persistence.cassandra.lerna.CassandraReadJournalExt.CassandraEventEnvelope
+import akka.persistence.query.Offset
+import akka.stream.alpakka.cassandra.scaladsl.{ CassandraSession, CassandraSessionRegistry }
+import akka.stream.scaladsl.Sink
+import com.datastax.oss.driver.api.core.cql.{ PreparedStatement, Statement }
+import lerna.akka.entityreplication.rollback.SequenceNr
+
+import java.util.UUID
+import scala.concurrent.{ ExecutionContext, Future }
+
+private object DeleteTagViews {
+
+  private final case class TagWriteProgress(tagPidSequenceNr: Long, sequenceNr: Long, offset: UUID)
+
+  private final case class TagScanning(sequenceNr: Long)
+
+  private final case class TagViewMetadata(progress: TagWriteProgress, scanning: TagScanning)
+
+  private final case class DeleteTagViewElement(
+      envelope: Option[CassandraEventEnvelope],
+      lastMetadata: Option[TagViewMetadata],
+  )
+
+}
+
+private final class DeleteTagViews(
+    systemProvider: ClassicActorSystemProvider,
+    settings: CassandraPersistentActorRollbackSettings,
+) {
+  import DeleteTagViews._
+
+  private implicit val system: ActorSystem =
+    systemProvider.classicSystem
+
+  private implicit val executionContext: ExecutionContext =
+    system.dispatcher
+
+  private val queries: CassandraReadJournalExt =
+    CassandraReadJournalExt(system, settings.pluginLocation)
+
+  private lazy val session: CassandraSession =
+    CassandraSessionRegistry(system).sessionFor(settings.pluginLocation)
+  private lazy val statements: CassandraPersistentActorRollbackStatements =
+    new CassandraPersistentActorRollbackStatements(settings)
+  private lazy val deleteTagViews: Future[PreparedStatement] =
+    session.prepare(statements.journal.deleteTagViews)
+  private lazy val insertTagWriteProgress: Future[PreparedStatement] =
+    session.prepare(statements.journal.insertTagWriteProgress)
+  private lazy val insertTagScanning: Future[PreparedStatement] =
+    session.prepare(statements.journal.insertTagScanning)
+  private lazy val deleteTagWriteProgress: Future[PreparedStatement] =
+    session.prepare(statements.journal.deleteTagWriteProgress)
+  private lazy val deleteTagScanning: Future[PreparedStatement] =
+    session.prepare(statements.journal.deleteTagScanning)
+
+  private val log: LoggingAdapter =
+    Logging(system, getClass)
+
+  /** Deletes `tag_views` after the given sequence number (inclusive) for the persistence ID and tag
+    *
+    * It also updates (or deletes) metadata (`tag_write_progress`, `tag_scanning`) for `tag_views`.
+    */
+  def execute(persistenceId: String, tag: String, from: SequenceNr): Future[Done] = {
+    if (log.isDebugEnabled) {
+      log.debug(
+        "Deleting tag_views, tag_write_progress, and tag_scanning: persistence_id=[{}], tag=[{}], from=[{}]",
+        persistenceId,
+        tag,
+        from.value,
+      )
+    }
+    val deletionFuture = queries
+      .currentEventsByTag(tag, Offset.noOffset)
+      .filter(_.persistenceId == persistenceId)
+      .statefulMapConcat { () =>
+        // Collecting the last (after the deletion completes) metadata for updating tag_write_progress and tag_scanning.
+        var lastMetadata: Option[TagViewMetadata] = None
+
+        { envelope =>
+          if (envelope.sequenceNr < from.value) {
+            val progress = TagWriteProgress(envelope.tagPidSequenceNr, envelope.sequenceNr, envelope.timestamp)
+            val scanning = TagScanning(envelope.sequenceNr)
+            lastMetadata.foreach { metadata =>
+              assert(
+                metadata.progress.tagPidSequenceNr < envelope.tagPidSequenceNr,
+                s"tag_pid_sequence_nr of tagged events (persistence_id=[$persistenceId], tag=[$tag]) should always increase, but decreased:" +
+                s" [${metadata.progress.tagPidSequenceNr}] -> [${envelope.tagPidSequenceNr}]",
+              )
+              assert(
+                metadata.progress.sequenceNr < envelope.sequenceNr,
+                s"sequence_nr of tagged events (persistence_id=[$persistenceId], tag=[$tag}) should always increase, but decreased:" +
+                s" [${metadata.progress.sequenceNr}] -> [${envelope.sequenceNr}]",
+              )
+            }
+            lastMetadata = Option(TagViewMetadata(progress, scanning))
+            Seq(DeleteTagViewElement(None, lastMetadata))
+          } else {
+            Seq(DeleteTagViewElement(Option(envelope), lastMetadata))
+          }
+        }
+      }
+      .mapAsync(1) { element =>
+        element.envelope match {
+          case Some(envelope) =>
+            deleteTagView(tag, envelope).map(_ => element.lastMetadata)
+          case None =>
+            Future.successful(element.lastMetadata)
+        }
+      }
+      .runWith(Sink.lastOption)
+      .map(_.flatten)
+      .flatMap { lastMetadata =>
+        lastMetadata.foreach { metadata =>
+          assert(
+            metadata.progress.sequenceNr < from.value,
+            s"sequence_nr [${metadata.progress.sequenceNr}] of tag_view_progress (persistence_id=[$persistenceId], tag=[$tag])" +
+            s" should always be less than from_sequence_nr [${from.value}]",
+          )
+          assert(
+            metadata.scanning.sequenceNr < from.value,
+            s"sequence_nr [${metadata.scanning.sequenceNr}] of tag_scanning (persistence_id=[$persistenceId], tag=[$tag])" +
+            s" should always be less than from_sequence_nr [${from.value}]",
+          )
+        }
+        updateTagViewMetadata(persistenceId, tag, lastMetadata)
+      }
+    deletionFuture.foreach { _ =>
+      if (log.isDebugEnabled) {
+        log.debug(
+          "Deleted tag_views, tag_write_progress, and tag_scanning: persistence_id=[{}], tag=[{}], from=[{}]",
+          persistenceId,
+          tag,
+          from.value,
+        )
+      }
+    }
+    deletionFuture
+  }
+
+  private def updateTagViewMetadata(
+      persistenceId: String,
+      tag: String,
+      lastMetadata: Option[TagViewMetadata],
+  ): Future[Done] = {
+    // There is a subtle timing at which multiple DeleteTagView with the same persistence ID but different tags update
+    // (or delete) the tag_scanning table. It might be a race condition, which make a tag recovery of the persistent
+    // actor inefficient but doesn't break data consistency. The sequence number of tag_scanning table after deletions
+    // (or updates) should be less than `from` sequence number. A higher sequence number as possible is great for the
+    // efficiency of the tag recovery but is not required.
+    lastMetadata match {
+      case Some(metadata) =>
+        val progressUpdate = updateTagWriteProgress(persistenceId, tag, metadata.progress)
+        val scanningUpdate = updateTagScanning(persistenceId, metadata.scanning)
+        Future.sequence(Seq(progressUpdate, scanningUpdate)).map(_ => Done)
+      case None =>
+        val progressDeletion = deleteTagWriteProgress(persistenceId, tag)
+        val scanningDeletion = deleteTagScanning(persistenceId)
+        Future.sequence(Seq(progressDeletion, scanningDeletion)).map(_ => Done)
+    }
+  }
+
+  private def deleteTagView(
+      tag: String,
+      envelope: CassandraEventEnvelope,
+  ): Future[Done] = {
+    if (log.isDebugEnabled) {
+      log.debug(
+        s"Deleting tag_view: tag=[$tag], timebucket=[{}], timestamp=[{}], persistenceId=[{}], tag_pid_sequence_nr=[{}]",
+        envelope.timeBucket,
+        envelope.timestamp,
+        envelope.persistenceId,
+        envelope.tagPidSequenceNr,
+      )
+    }
+    deleteTagViews.flatMap { ps =>
+      executeWrite(
+        ps.bind(tag, envelope.timeBucket, envelope.timestamp, envelope.persistenceId, envelope.tagPidSequenceNr),
+      )
+    }
+  }
+
+  private def updateTagWriteProgress(
+      persistenceId: String,
+      tag: String,
+      progress: TagWriteProgress,
+  ): Future[Done] = {
+    if (log.isDebugEnabled) {
+      log.debug(
+        s"Updating tag_write_progress: persistence_id=[$persistenceId], tag=[{}], sequence_nr=[{}], tag_pid_sequence_nr=[{}], offset=[{}]",
+        tag,
+        progress.sequenceNr,
+        progress.tagPidSequenceNr,
+        progress.offset,
+      )
+    }
+    insertTagWriteProgress.flatMap { ps =>
+      executeWrite(ps.bind(persistenceId, tag, progress.sequenceNr, progress.tagPidSequenceNr, progress.offset))
+    }
+  }
+
+  private def updateTagScanning(persistenceId: String, scanning: TagScanning): Future[Done] = {
+    if (log.isDebugEnabled) {
+      log.debug("Updating tag_scanning: persistence_id=[{}], sequence_nr=[{}]", persistenceId, scanning.sequenceNr)
+    }
+    insertTagScanning.flatMap { ps =>
+      executeWrite(ps.bind(persistenceId, scanning.sequenceNr))
+    }
+  }
+
+  private def deleteTagWriteProgress(persistenceId: String, tag: String): Future[Done] = {
+    if (log.isDebugEnabled) {
+      log.debug("Deleting tag_write_progress: persistence_id=[{}], tag=[{}]", persistenceId, tag)
+    }
+    deleteTagWriteProgress.flatMap { ps =>
+      executeWrite(ps.bind(persistenceId, tag))
+    }
+  }
+
+  private def deleteTagScanning(persistenceId: String): Future[Done] = {
+    if (log.isDebugEnabled) {
+      log.debug("Deleting tag_scanning: persistence_id=[{}]", persistenceId)
+    }
+    deleteTagScanning.flatMap { ps =>
+      executeWrite(ps.bind(persistenceId))
+    }
+  }
+
+  private def executeWrite[T <: Statement[T]](statement: Statement[T]): Future[Done] = {
+    require(!settings.dryRun, s"Write query [$statement] is not allowed in dry-run mode")
+    session.executeWrite(statement.setExecutionProfileName(settings.journal.writeProfile))
+  }
+
+}

--- a/rollback-tool-cassandra/src/test/resources/application.conf
+++ b/rollback-tool-cassandra/src/test/resources/application.conf
@@ -1,3 +1,8 @@
+akka {
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+  loglevel = "DEBUG"
+  logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+}
 akka.actor.serialize-messages = on
 akka.actor.serialization-bindings {
   "lerna.akka.entityreplication.rollback.JsonSerializable" = jackson-json

--- a/rollback-tool-cassandra/src/test/scala/lerna/akka/entityreplication/rollback/cassandra/CassandraEventsByTagSettingsSpec.scala
+++ b/rollback-tool-cassandra/src/test/scala/lerna/akka/entityreplication/rollback/cassandra/CassandraEventsByTagSettingsSpec.scala
@@ -1,0 +1,67 @@
+package lerna.akka.entityreplication.rollback.cassandra
+
+import com.typesafe.config.{ Config, ConfigFactory }
+import org.scalatest.{ Matchers, WordSpec }
+
+final class CassandraEventsByTagSettingsSpec extends WordSpec with Matchers {
+
+  private val defaultPluginConfig: Config =
+    ConfigFactory.load().getConfig("akka.persistence.cassandra")
+
+  private val customPluginConfig: Config = ConfigFactory.parseString("""
+      |journal {
+      |  keyspace = "custom_akka"
+      |}
+      |events-by-tag {
+      |  table = "custom_tag_views"
+      |}
+      |""".stripMargin)
+
+  "CassandraEventsByTagSettings" should {
+
+    "load the default config" in {
+      val settings = CassandraEventsByTagSettings(defaultPluginConfig)
+      settings.keyspace should be("akka")
+      settings.table should be("tag_views")
+    }
+
+    "load the given custom config" in {
+      val settings = CassandraEventsByTagSettings(customPluginConfig)
+      settings.keyspace should be("custom_akka")
+      settings.table should be("custom_tag_views")
+    }
+
+  }
+
+  "CassandraEventsByTagSettings.tagViewsTableName" should {
+
+    "return the tag_views table name qualified with the keyspace name" in {
+      val settings = CassandraEventsByTagSettings(customPluginConfig)
+      settings.keyspace should be("custom_akka")
+      settings.table should be("custom_tag_views")
+      settings.tagViewsTableName should be("custom_akka.custom_tag_views")
+    }
+
+  }
+
+  "CassandraEventsByTagSettings.tagWriteProgressTableName" should {
+
+    "return the tag_write_progress table name qualified with the keyspace name" in {
+      val settings = CassandraEventsByTagSettings(customPluginConfig)
+      settings.keyspace should be("custom_akka")
+      settings.tagWriteProgressTableName should be("custom_akka.tag_write_progress")
+    }
+
+  }
+
+  "CassandraEventsByTagSettings.tagScanningTableName" should {
+
+    "return the tag_scanning table name qualified with the keyspace name" in {
+      val settings = CassandraEventsByTagSettings(customPluginConfig)
+      settings.keyspace should be("custom_akka")
+      settings.tagScanningTableName should be("custom_akka.tag_scanning")
+    }
+
+  }
+
+}

--- a/rollback-tool-cassandra/src/test/scala/lerna/akka/entityreplication/rollback/cassandra/CassandraPersistentActorRollbackSettingsSpec.scala
+++ b/rollback-tool-cassandra/src/test/scala/lerna/akka/entityreplication/rollback/cassandra/CassandraPersistentActorRollbackSettingsSpec.scala
@@ -17,6 +17,9 @@ final class CassandraPersistentActorRollbackSettingsSpec extends TestKitBase wit
       |    table = "custom_messages"
       |    target-partition-size = 1000000
       |  }
+      |  events-by-tag {
+      |    table = "custom_tag_views"
+      |  }
       |  query {
       |    read-profile = "custom_akka-persistence-cassandra-query-profile"
       |    max-buffer-size = 1000
@@ -56,6 +59,10 @@ final class CassandraPersistentActorRollbackSettingsSpec extends TestKitBase wit
       settings.query.readProfile should be("custom_akka-persistence-cassandra-query-profile")
       settings.query.maxBufferSize should be(1000)
       settings.query.deserializationParallelism should be(2)
+
+      // EventsByTag Settings
+      settings.eventsByTag.keyspace should be("custom_akka")
+      settings.eventsByTag.table should be("custom_tag_views")
 
       // Snapshot settings
       settings.snapshot.writeProfile should be("custom_akka-persistence-cassandra-snapshot-write-profile")


### PR DESCRIPTION
Closes #202 

The new rollback deletes only tagged events after the given sequence number. Since the new rollback doesn't execute the full rebuild of `tag_views`, which requires all old events, it can support the deletion of old events.

## Related components of Akka Persistence Cassandra

The related classes are the following:
* `CassandraJournal`: https://github.com/akka/akka-persistence-cassandra/blob/v1.0.5/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
* `TagWriters`: https://github.com/akka/akka-persistence-cassandra/blob/v1.0.5/core/src/main/scala/akka/persistence/cassandra/journal/TagWriters.scala
* `TagWriter`: https://github.com/akka/akka-persistence-cassandra/blob/v1.0.5/core/src/main/scala/akka/persistence/cassandra/journal/TagWriter.scala
* `CassandraTagRecovery`: https://github.com/akka/akka-persistence-cassandra/blob/v1.0.5/core/src/main/scala/akka/persistence/cassandra/journal/CassandraTagRecovery.scala

There are two tables (`tag_write_progress`, `tag_scanning`) that track metadata for `tag_views` table.

`tag_write_progress` tracks the last tagged events information that a tag writer successfully wrote into `tag_view`. `tag_write_progress` tracks the progress per the combination of persistence ID and tag.

`tag_scanning` tracks the first event info that the actor should scan at its start, which is not used for an event replay but used for a tag recovery. The tag recovery scans events and then writes events (if the event has a tag) to `tag_views` via a tag writer. The tag recovery is needed if tagged event writing is behind the event replay.