### PR TITLE
Support deleting old events and snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 [Unreleased]: https://github.com/lerna-stack/akka-entity-replication/compare/v2.2.0...master
 
+### Added
+- Support deleting old events and snapshots
+  [#201](https://github.com/lerna-stack/akka-entity-replication/issues/201),
+  [PR#204](https://github.com/lerna-stack/akka-entity-replication/pull/204)
+
 ### Changed
-* Rollback deletes only tagged events after the given sequence number
+- Rollback deletes only tagged events after the given sequence number
   [#202](https://github.com/lerna-stack/akka-entity-replication/issues/202),
   [PR#203](https://github.com/lerna-stack/akka-entity-replication/pull/203)
 

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -60,6 +60,9 @@ lerna.akka.entityreplication {
     // save a snapshot on which its Raft log has more entries than the `compaction.log-size-threshold`, which triggers
     // compaction. Using values much higher than the threshold, a Raft actor can read at least one snapshot with a high
     // probability.
+    //
+    // A rollback is possible unless required events (and a snapshot) are not deleted. With a higher relative sequence
+    // number, a rollback can use an older timestamp. If a rollback is planned, use a higher value based on requirements.
     delete-before-relative-sequence-nr = 100000
 
     // log compaction settings
@@ -128,6 +131,9 @@ lerna.akka.entityreplication {
       // snapshot (not the entity's) at a constant interval. Instead, it saves a snapshot after it completes eitnty
       // snapshot synchronization. Since entity snapshot synchronization seldom happends, the snapshot read query almost
       // always reads the latest snapshot.
+      //
+      // A rollback is possible unless required events (and a snapshot) are not deleted. With a higher relative sequence
+      // number, a rollback can use an older timestamp. If a rollback is planned, use a higher value based on requirements.
       delete-before-relative-sequence-nr = 1000
     }
 
@@ -163,6 +169,9 @@ lerna.akka.entityreplication {
       // Using values higher than or equal to `snapshot-every` is a good starting point. It's because snapshot read and
       // write queries can have different consistency levels, resulting in the read query not reading the latest
       // snapshot in some cases. Using 0 is possible if the snapshot read query always reads the latest snapshot.
+      //
+      // A rollback is possible unless required events (and a snapshot) are not deleted. With a higher relative sequence
+      // number, a rollback can use an older timestamp. If a rollback is planned, use a higher value based on requirements.
       delete-before-relative-sequence-nr = 1
     }
 
@@ -276,6 +285,9 @@ lerna.akka.entityreplication {
       // Using values higher than or equal to `snapshot-every` is a good starting point. It's because snapshot read and
       // write queries can have different consistency levels, resulting in the read query not reading the latestsnapshot
       // in some cases. Using 0 is possible if the snapshot read query always reads the latest snapshot.
+      //
+      // A rollback is possible unless required events (and a snapshot) are not deleted. With a higher relative sequence
+      // number, a rollback can use an older timestamp. If a rollback is planned, use a higher value based on requirements.
       delete-before-relative-sequence-nr = 1000
     }
   }

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -156,6 +156,37 @@ lerna.akka.entityreplication {
 
       // Snapshot after this number of events.
       snapshot-every = 1000
+
+      // Enables event deletion of event-sourcing stores (a.k.a CommitLogStore)
+      //
+      // An event-sourcing store deletes old events when it successfully saves a snapshot if this setting is on.
+      //
+      // WARNING:
+      //   akka-entity-replication only supports Akka Persistence Cassandra since the deletion relies on a tagged-event
+      //   table (`akka.tag_views`) being split from an event table (`akka.messages`). Don't use a persistence plugin
+      //   that shares such tables if this setting is on since it would result in that journal queries cannot subscribe
+      //   to tagged events via the event-sourcing feature.
+      //
+      // WARNING:
+      //   Don't use the optional snapshots feature (`snapshot-is-optional = true`) of a snapshot plugin if this setting
+      //   is on since it would make an event-sourcing store an inconsistent sate if a snapshot load fails.
+      delete-old-events = off
+
+      // Enables snapshot deletion of event-sourcing stores (a.k.a CommitLogStore)
+      //
+      // An event-sourcing store deletes old snapshots when it successfully saves a snapshot if this setting is on.
+      delete-old-snapshots = off
+
+      // The relative sequence number for determining old events and snapshots to be deleted.
+      //
+      // Event-sourcing stores delete old events and/or snapshots that have the following sequence numbers:
+      //   * For events: `SaveSnapshotSuccess.meta.sequenceNr - delete-before-relative-sequence-nr`
+      //   * For snapshots: `SaveSnapshotSuccess.meta.sequenceNr - 1 - delete-before-relative-sequence-nr`
+      //
+      // Using values higher than or equal to `snapshot-every` is a good starting point. It's because snapshot read and
+      // write queries can have different consistency levels, resulting in the read query not reading the latestsnapshot
+      // in some cases. Using 0 is possible if the snapshot read query always reads the latest snapshot.
+      delete-before-relative-sequence-nr = 1000
     }
   }
 }

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -29,6 +29,39 @@ lerna.akka.entityreplication {
     // The maximum number of AppendEnteis that will be sent at once at every heartbeat-interval.
     max-append-entries-batch-size = 10
 
+    // Enables event deletion of Raft actors
+    //
+    // A Raft actor deletes old events when it successfully saves a snapshot if this setting is on.
+    //
+    // WARNING:
+    //   akka-entity-replication only supports Akka Persistence Cassandra since the deletion relies on a tagged-event
+    //   table (`akka.tag_views`) being split from an event table (`akka.messages`). Don't use a persistence plugin
+    //   that shares such tables if this setting is on since it would result in that internal journal queries cannot
+    //   subscribe to tagged events.
+    //
+    // WARNING:
+    //   Don't use the optional snapshots feature (`snapshot-is-optional = true`) of a snapshot plugin if this setting
+    //   is on since it would make a Raft actor an inconsistent sate if a snapshot load fails.
+    delete-old-events = off
+
+    // Enables snapshot deletion of Raft actors
+    //
+    // A Raft actor deletes old snapshots when it successfully saves a snapshot if this setting is on.
+    delete-old-snapshots = off
+
+    // The relative sequence number for determining old events and snapshots to be deleted.
+    //
+    // Raft actors delete old events and/or snapshots that have the following sequence numbers:
+    //   * For events: `SaveSnapshotSuccess.meta.sequenceNr - delete-before-relative-sequence-nr`
+    //   * For snapshots: `SaveSnapshotSuccess.meta.sequenceNr - 1 - delete-before-relative-sequence-nr`
+    //
+    // Using values much higher than `compaction.log-size-threshold` is a good starting point. A Raft actor doesn't save
+    // a snapshot at a constant interval. Instead, it saves a snapshot after it completes compaction. A Raft actor will
+    // save a snapshot on which its Raft log has more entries than the `compaction.log-size-threshold`, which triggers
+    // compaction. Using values much higher than the threshold, a Raft actor can read at least one snapshot with a high
+    // probability.
+    delete-before-relative-sequence-nr = 100000
+
     // log compaction settings
     compaction {
 

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -97,6 +97,38 @@ lerna.akka.entityreplication {
       // only the snapshots the single event indicates will be copied over this limit.
       // Copying snapshot should be executed atomically per event.
       max-snapshot-batch-size = 1000
+
+      // Enables event deletion of SnapshotSyncManagers, which manages entity snapshot synchronization
+      //
+      // A SnapshotSyncManager deletes old events when it successfully saves a snapshot if this setting is on.
+      //
+      // WARNING:
+      //   akka-entity-replication only supports Akka Persistence Cassandra since the deletion relies on a tagged-event
+      //   table (`akka.tag_views`) being split from an event table (`akka.messages`). Don't use a persistence plugin
+      //   that shares such tables if this setting is on since it would result in that internal journal queries cannot
+      //   subscribe to tagged events.
+      //
+      // WARNING:
+      //   Don't use the optional snapshots feature (`snapshot-is-optional = true`) of a snapshot plugin if this setting
+      //   is on since it would make a SnapshotSyncManager an inconsistent sate if a snapshot load fails.
+      delete-old-events = off
+
+      // Enables snapshot deletion of SnapshotSyncManager, which manages entity snapshot synchronization
+      //
+      // A SnapshotSyncManager deletes old snapshots when it successfully saves a snapshot if this setting is on.
+      delete-old-snapshots = off
+
+      // The relative sequence number for determining old events and snapshots to be deleted.
+      //
+      // SnapshotSyncManagers delete old events and/or snapshots that have the following sequence numbers:
+      //   * For events: `SaveSnapshotSuccess.meta.sequenceNr - delete-before-relative-sequence-nr`
+      //   * For snapshots: `SaveSnapshotSuccess.meta.sequenceNr - 1 - delete-before-relative-sequence-nr`
+      //
+      // Using a higher value is a good starting point, while it could be 0. A SnapshotSyncManager doesn't save a
+      // snapshot (not the entity's) at a constant interval. Instead, it saves a snapshot after it completes eitnty
+      // snapshot synchronization. Since entity snapshot synchronization seldom happends, the snapshot read query almost
+      // always reads the latest snapshot.
+      delete-before-relative-sequence-nr = 1000
     }
 
     // Entity snapshot store settings

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -107,6 +107,31 @@ lerna.akka.entityreplication {
       // By taking snapshot, optimizing recovery times of an Entity.
       // Increasing this value increases snapshot writing, decreasing it increases recovery times.
       snapshot-every = 1
+
+      // Enables event deletion of EntitySnapshotStores
+      //
+      // An EntitySnapshotStore deletes old events when it successfully saves a snapshot if this setting is on.
+      //
+      // WARNING:
+      //   Don't use the optional snapshots feature (`snapshot-is-optional = true`) of a snapshot plugin if this setting
+      //   is on since it would make an EntitySnapshotStore an inconsistent sate if a snapshot load fails.
+      delete-old-events = off
+
+      // Enables snapshot deletion of EntitySnapshotStores
+      //
+      // An EntitySnapshotStore deletes old snapshots when it successfully saves a snapshot if this setting is on.
+      delete-old-snapshots = off
+
+      // The relative sequence number for determining old events and snapshots to be deleted.
+      //
+      // EntitySnapshotStores delete old events and/or snapshots that have the following sequence numbers:
+      //   * For events: `SaveSnapshotSuccess.meta.sequenceNr - delete-before-relative-sequence-nr`
+      //   * For snapshots: `SaveSnapshotSuccess.meta.sequenceNr - 1 - delete-before-relative-sequence-nr`
+      //
+      // Using values higher than or equal to `snapshot-every` is a good starting point. It's because snapshot read and
+      // write queries can have different consistency levels, resulting in the read query not reading the latest
+      // snapshot in some cases. Using 0 is possible if the snapshot read query always reads the latest snapshot.
+      delete-before-relative-sequence-nr = 1
     }
 
     sharding = ${akka.cluster.sharding} {

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -63,7 +63,7 @@ lerna.akka.entityreplication {
     //
     // A rollback is possible unless required events (and a snapshot) are not deleted. With a higher relative sequence
     // number, a rollback can use an older timestamp. If a rollback is planned, use a higher value based on requirements.
-    delete-before-relative-sequence-nr = 100000
+    delete-before-relative-sequence-nr = 250000
 
     // log compaction settings
     compaction {
@@ -134,7 +134,7 @@ lerna.akka.entityreplication {
       //
       // A rollback is possible unless required events (and a snapshot) are not deleted. With a higher relative sequence
       // number, a rollback can use an older timestamp. If a rollback is planned, use a higher value based on requirements.
-      delete-before-relative-sequence-nr = 1000
+      delete-before-relative-sequence-nr = 250000
     }
 
     // Entity snapshot store settings
@@ -172,7 +172,7 @@ lerna.akka.entityreplication {
       //
       // A rollback is possible unless required events (and a snapshot) are not deleted. With a higher relative sequence
       // number, a rollback can use an older timestamp. If a rollback is planned, use a higher value based on requirements.
-      delete-before-relative-sequence-nr = 1
+      delete-before-relative-sequence-nr = 5
     }
 
     sharding = ${akka.cluster.sharding} {
@@ -288,7 +288,7 @@ lerna.akka.entityreplication {
       //
       // A rollback is possible unless required events (and a snapshot) are not deleted. With a higher relative sequence
       // number, a rollback can use an older timestamp. If a rollback is planned, use a higher value based on requirements.
-      delete-before-relative-sequence-nr = 1000
+      delete-before-relative-sequence-nr = 5000
     }
   }
 }

--- a/core/src/main/scala/lerna/akka/entityreplication/raft/Candidate.scala
+++ b/core/src/main/scala/lerna/akka/entityreplication/raft/Candidate.scala
@@ -32,8 +32,14 @@ private[raft] trait Candidate { this: RaftActor =>
     case SnapshotTick                                    => handleSnapshotTick()
     case response: Snapshot                              => receiveEntitySnapshotResponse(response)
     case response: SnapshotProtocol.SaveSnapshotResponse => receiveSaveSnapshotResponse(response)
-    case _: akka.persistence.SaveSnapshotSuccess         => // ignore
-    case _: akka.persistence.SaveSnapshotFailure         => // ignore: no problem because events exist even if snapshot saving failed
+
+    // Akka Persistence protocol
+    case success: akka.persistence.SaveSnapshotSuccess    => handleSaveSnapshotSuccess(success)
+    case failure: akka.persistence.SaveSnapshotFailure    => handleSaveSnapshotFailure(failure)
+    case success: akka.persistence.DeleteMessagesSuccess  => handleDeleteMessagesSuccess(success)
+    case failure: akka.persistence.DeleteMessagesFailure  => handleDeleteMessagesFailure(failure)
+    case success: akka.persistence.DeleteSnapshotsSuccess => handleDeleteSnapshotsSuccess(success)
+    case failure: akka.persistence.DeleteSnapshotsFailure => handleDeleteSnapshotsFailure(failure)
 
     // Event sourcing protocol
     case response: CommitLogStoreActor.AppendCommittedEntriesResponse =>

--- a/core/src/main/scala/lerna/akka/entityreplication/raft/Follower.scala
+++ b/core/src/main/scala/lerna/akka/entityreplication/raft/Follower.scala
@@ -31,8 +31,14 @@ private[raft] trait Follower { this: RaftActor =>
     case SnapshotTick                                    => handleSnapshotTick()
     case response: Snapshot                              => receiveEntitySnapshotResponse(response)
     case response: SnapshotProtocol.SaveSnapshotResponse => receiveSaveSnapshotResponse(response)
-    case _: akka.persistence.SaveSnapshotSuccess         => // ignore
-    case _: akka.persistence.SaveSnapshotFailure         => // ignore: no problem because events exist even if snapshot saving failed
+
+    // Akka Persistence protocol
+    case success: akka.persistence.SaveSnapshotSuccess    => handleSaveSnapshotSuccess(success)
+    case failure: akka.persistence.SaveSnapshotFailure    => handleSaveSnapshotFailure(failure)
+    case success: akka.persistence.DeleteMessagesSuccess  => handleDeleteMessagesSuccess(success)
+    case failure: akka.persistence.DeleteMessagesFailure  => handleDeleteMessagesFailure(failure)
+    case success: akka.persistence.DeleteSnapshotsSuccess => handleDeleteSnapshotsSuccess(success)
+    case failure: akka.persistence.DeleteSnapshotsFailure => handleDeleteSnapshotsFailure(failure)
 
     // Event sourcing protocol
     case response: CommitLogStoreActor.AppendCommittedEntriesResponse =>

--- a/core/src/main/scala/lerna/akka/entityreplication/raft/Leader.scala
+++ b/core/src/main/scala/lerna/akka/entityreplication/raft/Leader.scala
@@ -40,8 +40,14 @@ private[raft] trait Leader { this: RaftActor =>
     case SnapshotTick                                         => handleSnapshotTick()
     case response: Snapshot                                   => receiveEntitySnapshotResponse(response)
     case response: SnapshotProtocol.SaveSnapshotResponse      => receiveSaveSnapshotResponse(response)
-    case _: akka.persistence.SaveSnapshotSuccess              => // ignore
-    case _: akka.persistence.SaveSnapshotFailure              => // ignore: no problem because events exist even if snapshot saving failed
+
+    // Akka Persistence protocol
+    case success: akka.persistence.SaveSnapshotSuccess    => handleSaveSnapshotSuccess(success)
+    case failure: akka.persistence.SaveSnapshotFailure    => handleSaveSnapshotFailure(failure)
+    case success: akka.persistence.DeleteMessagesSuccess  => handleDeleteMessagesSuccess(success)
+    case failure: akka.persistence.DeleteMessagesFailure  => handleDeleteMessagesFailure(failure)
+    case success: akka.persistence.DeleteSnapshotsSuccess => handleDeleteSnapshotsSuccess(success)
+    case failure: akka.persistence.DeleteSnapshotsFailure => handleDeleteSnapshotsFailure(failure)
 
     // Event sourcing protocol
     case EventSourcingTick =>

--- a/core/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
+++ b/core/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
@@ -1,7 +1,7 @@
 package lerna.akka.entityreplication.raft
 
 import akka.actor.{ ActorRef, Cancellable, Props, Stash }
-import akka.persistence.{ Recovery, RuntimePluginConfig }
+import akka.persistence.{ Recovery, RuntimePluginConfig, SnapshotSelectionCriteria }
 import com.typesafe.config.{ Config, ConfigFactory }
 import lerna.akka.entityreplication.ClusterReplication.EntityPropsProvider
 import lerna.akka.entityreplication.ReplicationRegion.Msg
@@ -978,4 +978,81 @@ private[raft] class RaftActor(
     cancelEventSourcingTickTimer()
     super.postStop()
   }
+
+  protected def handleSaveSnapshotSuccess(success: akka.persistence.SaveSnapshotSuccess): Unit = {
+    if (log.isInfoEnabled) {
+      log.info("[{}] Succeeded to saveSnapshot given metadata [{}]", currentState, success.metadata)
+    }
+    val deleteBeforeRelativeSequenceNr = settings.deleteBeforeRelativeSequenceNr
+    if (settings.deleteOldEvents) {
+      val deleteEventsToSequenceNr =
+        math.max(0, success.metadata.sequenceNr - deleteBeforeRelativeSequenceNr)
+      if (log.isInfoEnabled) {
+        log.info("[{}] Deleting events up to sequenceNr [{}]", currentState, deleteEventsToSequenceNr)
+      }
+      deleteMessages(deleteEventsToSequenceNr)
+    }
+    if (settings.deleteOldSnapshots) {
+      val deletionCriteria = {
+        // Since this actor will use the snapshot with sequence number `metadata.sequenceNr` for recovery, it can delete
+        // snapshots with sequence numbers less than `metadata.sequenceNr`.
+        val deleteSnapshotsToSequenceNr =
+          math.max(0, success.metadata.sequenceNr - 1 - deleteBeforeRelativeSequenceNr)
+        SnapshotSelectionCriteria(minSequenceNr = 0, maxSequenceNr = deleteSnapshotsToSequenceNr)
+      }
+      if (log.isInfoEnabled) {
+        log.info("[{}] Deleting snapshots matching criteria [{}]", currentState, deletionCriteria)
+      }
+      deleteSnapshots(deletionCriteria)
+    }
+  }
+
+  protected def handleSaveSnapshotFailure(failure: akka.persistence.SaveSnapshotFailure): Unit = {
+    if (log.isWarningEnabled) {
+      log.warning(
+        "[{}] Failed to saveSnapshot given metadata [{}] due to: [{}: {}]",
+        currentState,
+        failure.metadata,
+        failure.cause.getClass.getCanonicalName,
+        failure.cause.getMessage,
+      )
+    }
+  }
+
+  protected def handleDeleteMessagesSuccess(success: akka.persistence.DeleteMessagesSuccess): Unit = {
+    if (log.isInfoEnabled) {
+      log.info("[{}] Succeeded to deleteMessages up to sequenceNr [{}]", currentState, success.toSequenceNr)
+    }
+  }
+
+  protected def handleDeleteMessagesFailure(failure: akka.persistence.DeleteMessagesFailure): Unit = {
+    if (log.isWarningEnabled) {
+      log.warning(
+        "[{}] Failed to deleteMessages given toSequenceNr [{}] due to: [{}: {}]",
+        currentState,
+        failure.toSequenceNr,
+        failure.cause.getClass.getCanonicalName,
+        failure.cause.getMessage,
+      )
+    }
+  }
+
+  protected def handleDeleteSnapshotsSuccess(success: akka.persistence.DeleteSnapshotsSuccess): Unit = {
+    if (log.isInfoEnabled) {
+      log.info("[{}] Succeeded to deleteSnapshots given criteria [{}]", currentState, success.criteria)
+    }
+  }
+
+  protected def handleDeleteSnapshotsFailure(failure: akka.persistence.DeleteSnapshotsFailure): Unit = {
+    if (log.isWarningEnabled) {
+      log.warning(
+        "[{}] Failed to deleteSnapshots given criteria [{}] due to: [{}: {}]",
+        currentState,
+        failure.criteria,
+        failure.cause.getClass.getCanonicalName,
+        failure.cause.getMessage,
+      )
+    }
+  }
+
 }

--- a/core/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
+++ b/core/src/main/scala/lerna/akka/entityreplication/raft/RaftActor.scala
@@ -987,8 +987,8 @@ private[raft] class RaftActor(
     if (settings.deleteOldEvents) {
       val deleteEventsToSequenceNr =
         math.max(0, success.metadata.sequenceNr - deleteBeforeRelativeSequenceNr)
-      if (log.isInfoEnabled) {
-        log.info("[{}] Deleting events up to sequenceNr [{}]", currentState, deleteEventsToSequenceNr)
+      if (log.isDebugEnabled) {
+        log.debug("[{}] Deleting events up to sequenceNr [{}]", currentState, deleteEventsToSequenceNr)
       }
       deleteMessages(deleteEventsToSequenceNr)
     }
@@ -1000,8 +1000,8 @@ private[raft] class RaftActor(
           math.max(0, success.metadata.sequenceNr - 1 - deleteBeforeRelativeSequenceNr)
         SnapshotSelectionCriteria(minSequenceNr = 0, maxSequenceNr = deleteSnapshotsToSequenceNr)
       }
-      if (log.isInfoEnabled) {
-        log.info("[{}] Deleting snapshots matching criteria [{}]", currentState, deletionCriteria)
+      if (log.isDebugEnabled) {
+        log.debug("[{}] Deleting snapshots matching criteria [{}]", currentState, deletionCriteria)
       }
       deleteSnapshots(deletionCriteria)
     }

--- a/core/src/main/scala/lerna/akka/entityreplication/raft/RaftSettings.scala
+++ b/core/src/main/scala/lerna/akka/entityreplication/raft/RaftSettings.scala
@@ -41,6 +41,22 @@ trait RaftSettings {
 
   def maxAppendEntriesBatchSize: Int
 
+  /** Returns `true` if a Raft actor (`RaftActor`) deletes old events when it successfully saves a
+    * snapshot, `false` otherwise.
+    */
+  def deleteOldEvents: Boolean
+
+  /** Returns `true` if a Raft actor (`RaftActor`) deletes old snapshots when it successfully saves
+    * a snapshot, `false` otherwise.
+    */
+  def deleteOldSnapshots: Boolean
+
+  /** Returns the relative sequence number for determining old events and snapshots to be deleted.
+    *
+    * For more details, see the setting `lerna.akka.entityreplication.raft.delete-before-relative-sequence-nr`.
+    */
+  def deleteBeforeRelativeSequenceNr: Long
+
   def compactionSnapshotCacheTimeToLive: FiniteDuration
 
   def compactionLogSizeThreshold: Int

--- a/core/src/main/scala/lerna/akka/entityreplication/raft/RaftSettings.scala
+++ b/core/src/main/scala/lerna/akka/entityreplication/raft/RaftSettings.scala
@@ -73,6 +73,22 @@ trait RaftSettings {
 
   def snapshotSyncMaxSnapshotBatchSize: Int
 
+  /** Returns `true` if a `SnapshotSyncManager` deletes old events when it successfully saves a
+    * snapshot, `false` otherwise.
+    */
+  def snapshotSyncDeleteOldEvents: Boolean
+
+  /** Returns `true` if a `SnapshotSyncManager` deletes old snapshots when it successfully saves
+    * a snapshot, `false` otherwise.
+    */
+  def snapshotSyncDeleteOldSnapshots: Boolean
+
+  /** Returns the relative sequence number for determining old events and snapshots to be deleted.
+    *
+    * For more details, see the setting `lerna.akka.entityreplication.raft.snapshot-sync.delete-before-relative-sequence-nr`.
+    */
+  def snapshotSyncDeleteBeforeRelativeSequenceNr: Long
+
   def snapshotStoreSnapshotEvery: Int
 
   /** Returns `true` if an EntitySnapshotStore (`raft.snapshot.SnapshotStore`) deletes old events when it successfully

--- a/core/src/main/scala/lerna/akka/entityreplication/raft/RaftSettings.scala
+++ b/core/src/main/scala/lerna/akka/entityreplication/raft/RaftSettings.scala
@@ -87,6 +87,22 @@ trait RaftSettings {
 
   def eventSourcedSnapshotEvery: Int
 
+  /** Returns `true` if an event-sourcing store (`CommitLogStoreActor`) deletes old events when it successfully saves a
+    * snapshot, `false` otherwise.
+    */
+  def eventSourcedDeleteOldEvents: Boolean
+
+  /** Returns `true` if an event-sourcing store (`CommitLogStoreActor`) deletes old snapshots when it successfully saves
+    * a snapshot, `false` otherwise.
+    */
+  def eventSourcedDeleteOldSnapshots: Boolean
+
+  /** Returns the relative sequence number for determining old events and snapshots to be deleted.
+    *
+    * For more details, see the setting `lerna.akka.entityreplication.raft.eventsourced.persistence.delete-before-relative-sequence-nr`.
+    */
+  def eventSourcedDeleteBeforeRelativeSequenceNr: Long
+
   private[entityreplication] def withDisabledShards(disabledShards: Set[String]): RaftSettings
 
   private[entityreplication] def withStickyLeaders(stickyLeaders: Map[String, String]): RaftSettings

--- a/core/src/main/scala/lerna/akka/entityreplication/raft/RaftSettings.scala
+++ b/core/src/main/scala/lerna/akka/entityreplication/raft/RaftSettings.scala
@@ -75,6 +75,22 @@ trait RaftSettings {
 
   def snapshotStoreSnapshotEvery: Int
 
+  /** Returns `true` if an EntitySnapshotStore (`raft.snapshot.SnapshotStore`) deletes old events when it successfully
+    * saves a snapshot, `false` otherwise.
+    */
+  def snapshotStoreDeleteOldEvents: Boolean
+
+  /** Returns `true` if an EntitySnapshotStore (`raft.snapshot.SnapshotStore`) deletes old snapshots when it successfully
+    * saves a snapshot, `false` otherwise.
+    */
+  def snapshotStoreDeleteOldSnapshots: Boolean
+
+  /** Returns the relative sequence number for determining old events and snapshots to be deleted.
+    *
+    * For more details, see the setting `lerna.akka.entityreplication.raft.entity-snapshot-store.delete-before-relative-sequence-nr`.
+    */
+  def snapshotStoreDeleteBeforeRelativeSequenceNr: Long
+
   def clusterShardingConfig: Config
 
   def raftActorAutoStartFrequency: FiniteDuration

--- a/core/src/main/scala/lerna/akka/entityreplication/raft/RaftSettingsImpl.scala
+++ b/core/src/main/scala/lerna/akka/entityreplication/raft/RaftSettingsImpl.scala
@@ -31,6 +31,9 @@ private[entityreplication] final case class RaftSettingsImpl(
     snapshotSyncCopyingParallelism: Int,
     snapshotSyncPersistenceOperationTimeout: FiniteDuration,
     snapshotSyncMaxSnapshotBatchSize: Int,
+    snapshotSyncDeleteOldEvents: Boolean,
+    snapshotSyncDeleteOldSnapshots: Boolean,
+    snapshotSyncDeleteBeforeRelativeSequenceNr: Long,
     snapshotStoreSnapshotEvery: Int,
     snapshotStoreDeleteOldEvents: Boolean,
     snapshotStoreDeleteOldSnapshots: Boolean,
@@ -188,6 +191,17 @@ private[entityreplication] object RaftSettingsImpl {
       s"snapshot-sync.max-snapshot-batch-size (${snapshotSyncMaxSnapshotBatchSize}) should be larger than 0",
     )
 
+    val snapshotSyncDeleteOldEvents: Boolean =
+      config.getBoolean("snapshot-sync.delete-old-events")
+    val snapshotSyncDeleteOldSnapshots: Boolean =
+      config.getBoolean("snapshot-sync.delete-old-snapshots")
+    val snapshotSyncDeleteBeforeRelativeSequenceNr: Long =
+      config.getLong("snapshot-sync.delete-before-relative-sequence-nr")
+    require(
+      snapshotSyncDeleteBeforeRelativeSequenceNr >= 0,
+      s"snapshot-sync.delete-before-relative-sequence-nr ($snapshotSyncDeleteBeforeRelativeSequenceNr) should be greater than or equal to 0.",
+    )
+
     val snapshotStoreSnapshotEvery: Int = config.getInt("entity-snapshot-store.snapshot-every")
     require(
       snapshotStoreSnapshotEvery > 0,
@@ -299,6 +313,9 @@ private[entityreplication] object RaftSettingsImpl {
       snapshotSyncCopyingParallelism = snapshotSyncCopyingParallelism,
       snapshotSyncPersistenceOperationTimeout = snapshotSyncPersistenceOperationTimeout,
       snapshotSyncMaxSnapshotBatchSize = snapshotSyncMaxSnapshotBatchSize,
+      snapshotSyncDeleteOldEvents = snapshotSyncDeleteOldEvents,
+      snapshotSyncDeleteOldSnapshots = snapshotSyncDeleteOldSnapshots,
+      snapshotSyncDeleteBeforeRelativeSequenceNr = snapshotSyncDeleteBeforeRelativeSequenceNr,
       snapshotStoreSnapshotEvery = snapshotStoreSnapshotEvery,
       snapshotStoreDeleteOldEvents = snapshotStoreDeleteOldEvents,
       snapshotStoreDeleteOldSnapshots = snapshotStoreDeleteOldSnapshots,

--- a/core/src/main/scala/lerna/akka/entityreplication/raft/RaftSettingsImpl.scala
+++ b/core/src/main/scala/lerna/akka/entityreplication/raft/RaftSettingsImpl.scala
@@ -21,6 +21,9 @@ private[entityreplication] final case class RaftSettingsImpl(
     disabledShards: Set[String],
     maxAppendEntriesSize: Int,
     maxAppendEntriesBatchSize: Int,
+    deleteOldEvents: Boolean,
+    deleteOldSnapshots: Boolean,
+    deleteBeforeRelativeSequenceNr: Long,
     compactionSnapshotCacheTimeToLive: FiniteDuration,
     compactionLogSizeThreshold: Int,
     compactionPreserveLogSize: Int,
@@ -133,6 +136,17 @@ private[entityreplication] object RaftSettingsImpl {
     require(
       maxAppendEntriesBatchSize > 0,
       s"max-append-entries-batch-size ($maxAppendEntriesBatchSize) should be greater than 0",
+    )
+
+    val deleteOldEvents: Boolean =
+      config.getBoolean("delete-old-events")
+    val deleteOldSnapshots: Boolean =
+      config.getBoolean("delete-old-snapshots")
+    val deleteBeforeRelativeSequenceNr: Long =
+      config.getLong("delete-before-relative-sequence-nr")
+    require(
+      deleteBeforeRelativeSequenceNr >= 0,
+      s"delete-before-relative-sequence-nr ($deleteBeforeRelativeSequenceNr) should be greater than or equal to 0.",
     )
 
     val compactionSnapshotCacheTimeToLive: FiniteDuration =
@@ -261,6 +275,9 @@ private[entityreplication] object RaftSettingsImpl {
       disabledShards = disabledShards,
       maxAppendEntriesSize = maxAppendEntriesSize,
       maxAppendEntriesBatchSize = maxAppendEntriesBatchSize,
+      deleteOldEvents = deleteOldEvents,
+      deleteOldSnapshots = deleteOldSnapshots,
+      deleteBeforeRelativeSequenceNr = deleteBeforeRelativeSequenceNr,
       compactionSnapshotCacheTimeToLive = compactionSnapshotCacheTimeToLive,
       compactionLogSizeThreshold = compactionLogSizeThreshold,
       compactionPreserveLogSize = compactionPreserveLogSize,

--- a/core/src/main/scala/lerna/akka/entityreplication/raft/RaftSettingsImpl.scala
+++ b/core/src/main/scala/lerna/akka/entityreplication/raft/RaftSettingsImpl.scala
@@ -32,6 +32,9 @@ private[entityreplication] final case class RaftSettingsImpl(
     snapshotSyncPersistenceOperationTimeout: FiniteDuration,
     snapshotSyncMaxSnapshotBatchSize: Int,
     snapshotStoreSnapshotEvery: Int,
+    snapshotStoreDeleteOldEvents: Boolean,
+    snapshotStoreDeleteOldSnapshots: Boolean,
+    snapshotStoreDeleteBeforeRelativeSequenceNr: Long,
     clusterShardingConfig: Config,
     raftActorAutoStartFrequency: FiniteDuration,
     raftActorAutoStartNumberOfActors: Int,
@@ -191,6 +194,17 @@ private[entityreplication] object RaftSettingsImpl {
       s"entity-snapshot-store.snapshot-every ($snapshotStoreSnapshotEvery) should be larger than 0",
     )
 
+    val snapshotStoreDeleteOldEvents: Boolean =
+      config.getBoolean("entity-snapshot-store.delete-old-events")
+    val snapshotStoreDeleteOldSnapshots: Boolean =
+      config.getBoolean("entity-snapshot-store.delete-old-snapshots")
+    val snapshotStoreDeleteBeforeRelativeSequenceNr: Long =
+      config.getLong("entity-snapshot-store.delete-before-relative-sequence-nr")
+    require(
+      snapshotStoreDeleteBeforeRelativeSequenceNr >= 0,
+      s"entity-snapshot-store.delete-before-relative-sequence-nr ($snapshotStoreDeleteBeforeRelativeSequenceNr) should be greater than or equal to 0.",
+    )
+
     val clusterShardingConfig: Config = config.getConfig("sharding")
 
     val raftActorAutoStartFrequency: FiniteDuration =
@@ -286,6 +300,9 @@ private[entityreplication] object RaftSettingsImpl {
       snapshotSyncPersistenceOperationTimeout = snapshotSyncPersistenceOperationTimeout,
       snapshotSyncMaxSnapshotBatchSize = snapshotSyncMaxSnapshotBatchSize,
       snapshotStoreSnapshotEvery = snapshotStoreSnapshotEvery,
+      snapshotStoreDeleteOldEvents = snapshotStoreDeleteOldEvents,
+      snapshotStoreDeleteOldSnapshots = snapshotStoreDeleteOldSnapshots,
+      snapshotStoreDeleteBeforeRelativeSequenceNr = snapshotStoreDeleteBeforeRelativeSequenceNr,
       clusterShardingConfig = clusterShardingConfig,
       raftActorAutoStartFrequency = raftActorAutoStartFrequency,
       raftActorAutoStartNumberOfActors = raftActorAutoStartNumberOfActors,

--- a/core/src/main/scala/lerna/akka/entityreplication/raft/RaftSettingsImpl.scala
+++ b/core/src/main/scala/lerna/akka/entityreplication/raft/RaftSettingsImpl.scala
@@ -42,6 +42,9 @@ private[entityreplication] final case class RaftSettingsImpl(
     eventSourcedJournalPluginId: String,
     eventSourcedSnapshotStorePluginId: String,
     eventSourcedSnapshotEvery: Int,
+    eventSourcedDeleteOldEvents: Boolean,
+    eventSourcedDeleteOldSnapshots: Boolean,
+    eventSourcedDeleteBeforeRelativeSequenceNr: Long,
 ) extends RaftSettings {
 
   override private[raft] def randomizedElectionTimeout(): FiniteDuration =
@@ -234,6 +237,17 @@ private[entityreplication] object RaftSettingsImpl {
       s"snapshot-every ($eventSourcedSnapshotEvery) should be greater than 0.",
     )
 
+    val eventSourcedDeleteOldEvents: Boolean =
+      config.getBoolean("eventsourced.persistence.delete-old-events")
+    val eventSourcedDeleteOldSnapshots: Boolean =
+      config.getBoolean("eventsourced.persistence.delete-old-snapshots")
+    val eventSourcedDeleteBeforeRelativeSequenceNr: Long =
+      config.getLong("eventsourced.persistence.delete-before-relative-sequence-nr")
+    require(
+      eventSourcedDeleteBeforeRelativeSequenceNr >= 0,
+      s"eventsourced.persistence.delete-before-relative-sequence-nr ($eventSourcedDeleteBeforeRelativeSequenceNr) should be greater than or equal to 0.",
+    )
+
     RaftSettingsImpl(
       config = config,
       electionTimeout = electionTimeout,
@@ -268,6 +282,9 @@ private[entityreplication] object RaftSettingsImpl {
       eventSourcedJournalPluginId = eventSourcedJournalPluginId,
       eventSourcedSnapshotStorePluginId = eventSourcedSnapshotStorePluginId,
       eventSourcedSnapshotEvery = eventSourcedSnapshotEvery,
+      eventSourcedDeleteOldEvents = eventSourcedDeleteOldEvents,
+      eventSourcedDeleteOldSnapshots = eventSourcedDeleteOldSnapshots,
+      eventSourcedDeleteBeforeRelativeSequenceNr = eventSourcedDeleteBeforeRelativeSequenceNr,
     )
   }
 

--- a/core/src/main/scala/lerna/akka/entityreplication/raft/eventsourced/CommitLogStoreActor.scala
+++ b/core/src/main/scala/lerna/akka/entityreplication/raft/eventsourced/CommitLogStoreActor.scala
@@ -332,8 +332,8 @@ private[entityreplication] class CommitLogStoreActor(typeName: TypeName, setting
     if (settings.raftSettings.eventSourcedDeleteOldEvents) {
       val deleteEventsToSequenceNr =
         math.max(0, success.metadata.sequenceNr - deleteBeforeRelativeSequenceNr)
-      if (log.isInfoEnabled) {
-        log.info("Deleting events up to sequenceNr [{}]", deleteEventsToSequenceNr)
+      if (log.isDebugEnabled) {
+        log.debug("Deleting events up to sequenceNr [{}]", deleteEventsToSequenceNr)
       }
       deleteMessages(deleteEventsToSequenceNr)
     }
@@ -348,8 +348,8 @@ private[entityreplication] class CommitLogStoreActor(typeName: TypeName, setting
           )
         SnapshotSelectionCriteria(minSequenceNr = 0, maxSequenceNr = deleteSnapshotsToSequenceNr)
       }
-      if (log.isInfoEnabled) {
-        log.info("Deleting snapshots matching criteria [{}]", deletionCriteria)
+      if (log.isDebugEnabled) {
+        log.debug("Deleting snapshots matching criteria [{}]", deletionCriteria)
       }
       deleteSnapshots(deletionCriteria)
     }

--- a/core/src/main/scala/lerna/akka/entityreplication/raft/eventsourced/CommitLogStoreActor.scala
+++ b/core/src/main/scala/lerna/akka/entityreplication/raft/eventsourced/CommitLogStoreActor.scala
@@ -332,26 +332,26 @@ private[entityreplication] class CommitLogStoreActor(typeName: TypeName, setting
     if (settings.raftSettings.eventSourcedDeleteOldEvents) {
       val deleteEventsToSequenceNr =
         math.max(0, success.metadata.sequenceNr - deleteBeforeRelativeSequenceNr)
-      if (log.isDebugEnabled) {
-        log.debug("Deleting events up to sequenceNr [{}]", deleteEventsToSequenceNr)
+      if (deleteEventsToSequenceNr > 0) {
+        if (log.isDebugEnabled) {
+          log.debug("Deleting events up to sequenceNr [{}]", deleteEventsToSequenceNr)
+        }
+        deleteMessages(deleteEventsToSequenceNr)
       }
-      deleteMessages(deleteEventsToSequenceNr)
     }
     if (settings.raftSettings.eventSourcedDeleteOldSnapshots) {
-      val deletionCriteria = {
-        // Since this actor will use the snapshot with sequence number `metadata.sequenceNr` for recovery, it can delete
-        // snapshots with sequence numbers less than `metadata.sequenceNr`.
-        val deleteSnapshotsToSequenceNr =
-          math.max(
-            0,
-            success.metadata.sequenceNr - 1 - deleteBeforeRelativeSequenceNr,
-          )
-        SnapshotSelectionCriteria(minSequenceNr = 0, maxSequenceNr = deleteSnapshotsToSequenceNr)
+      // Since this actor will use the snapshot with sequence number `metadata.sequenceNr` for recovery, it can delete
+      // snapshots with sequence numbers less than `metadata.sequenceNr`.
+      val deleteSnapshotsToSequenceNr =
+        math.max(0, success.metadata.sequenceNr - 1 - deleteBeforeRelativeSequenceNr)
+      if (deleteSnapshotsToSequenceNr > 0) {
+        val deletionCriteria =
+          SnapshotSelectionCriteria(minSequenceNr = 0, maxSequenceNr = deleteSnapshotsToSequenceNr)
+        if (log.isDebugEnabled) {
+          log.debug("Deleting snapshots matching criteria [{}]", deletionCriteria)
+        }
+        deleteSnapshots(deletionCriteria)
       }
-      if (log.isDebugEnabled) {
-        log.debug("Deleting snapshots matching criteria [{}]", deletionCriteria)
-      }
-      deleteSnapshots(deletionCriteria)
     }
   }
 

--- a/core/src/main/scala/lerna/akka/entityreplication/raft/snapshot/sync/SnapshotSyncManager.scala
+++ b/core/src/main/scala/lerna/akka/entityreplication/raft/snapshot/sync/SnapshotSyncManager.scala
@@ -706,8 +706,8 @@ private[entityreplication] class SnapshotSyncManager(
   private def deleteOldEvents(upperSequenceNr: Long): Unit = {
     assert(shouldDeleteOldEvents, s"Old event deletion should be enabled but is disabled.")
     val deleteEventsToSequenceNr = math.max(0, upperSequenceNr)
-    if (log.isInfoEnabled) {
-      log.info("Deleting events up to sequenceNr [{}]", deleteEventsToSequenceNr)
+    if (log.isDebugEnabled) {
+      log.debug("Deleting events up to sequenceNr [{}]", deleteEventsToSequenceNr)
     }
     deleteMessages(deleteEventsToSequenceNr)
   }
@@ -720,8 +720,8 @@ private[entityreplication] class SnapshotSyncManager(
       val deleteSnapshotsToSequenceNr = math.max(0, upperSequenceNr - 1)
       SnapshotSelectionCriteria(minSequenceNr = 0, maxSequenceNr = deleteSnapshotsToSequenceNr)
     }
-    if (log.isInfoEnabled) {
-      log.info("Deleting snapshots matching criteria [{}]", deletionCriteria)
+    if (log.isDebugEnabled) {
+      log.debug("Deleting snapshots matching criteria [{}]", deletionCriteria)
     }
     deleteSnapshots(deletionCriteria)
   }

--- a/core/src/test/scala/lerna/akka/entityreplication/raft/RaftActorPersistenceDeletionSpec.scala
+++ b/core/src/test/scala/lerna/akka/entityreplication/raft/RaftActorPersistenceDeletionSpec.scala
@@ -447,7 +447,13 @@ final class RaftActorPersistenceDeletionSpec
       val newEntries = Seq.tabulate(20) { i =>
         LogEntry(LogEntryIndex(6 + i), EntityEvent(Option(entityId), s"event-${6 + i}"), Term(1))
       }
-      appendNewEntriesEachTo(raftActor, currentTerm = Term(1), prevLogTerm = Term(1), newEntries.head, newEntries.tail: _*)
+      appendNewEntriesEachTo(
+        raftActor,
+        currentTerm = Term(1),
+        prevLogTerm = Term(1),
+        newEntries.head,
+        newEntries.tail: _*,
+      )
 
       promoteBeforeDelete(this, raftActor)
 

--- a/core/src/test/scala/lerna/akka/entityreplication/raft/RaftActorPersistenceDeletionSpec.scala
+++ b/core/src/test/scala/lerna/akka/entityreplication/raft/RaftActorPersistenceDeletionSpec.scala
@@ -1,0 +1,526 @@
+package lerna.akka.entityreplication.raft
+
+import akka.actor.testkit.typed.scaladsl.LoggingTestKit
+import akka.actor.typed.scaladsl.adapter.ClassicActorSystemOps
+import akka.actor.{ typed, ActorRef, ActorSystem }
+import akka.persistence.testkit.scaladsl.{ PersistenceTestKit, SnapshotTestKit }
+import akka.testkit.{ TestKit, TestProbe }
+import com.typesafe.config.{ Config, ConfigFactory }
+import lerna.akka.entityreplication.ReplicationRegion
+import lerna.akka.entityreplication.model._
+import lerna.akka.entityreplication.raft.RaftActor._
+import lerna.akka.entityreplication.raft.RaftProtocol._
+import lerna.akka.entityreplication.raft.eventsourced.CommitLogStoreActor
+import lerna.akka.entityreplication.raft.model._
+import lerna.akka.entityreplication.raft.protocol.RaftCommands._
+import lerna.akka.entityreplication.raft.routing.MemberIndex
+import lerna.akka.entityreplication.raft.snapshot.SnapshotProtocol._
+import org.scalactic.TypeCheckedTripleEquals
+
+final class RaftActorPersistenceDeletionSpec
+    extends TestKit(
+      ActorSystem("RaftActorPersistenceDeletionSpec", RaftActorSpecBase.configWithPersistenceTestKits),
+    )
+    with RaftActorSpecBase
+    with TypeCheckedTripleEquals {
+
+  private implicit val typedSystem: typed.ActorSystem[Nothing] = system.toTyped
+  private val persistenceTestKit                               = PersistenceTestKit(system)
+  private val snapshotTestKit                                  = SnapshotTestKit(system)
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    persistenceTestKit.clearAll()
+    persistenceTestKit.resetPolicy()
+    snapshotTestKit.clearAll()
+    snapshotTestKit.resetPolicy()
+  }
+
+  private def configFor(
+      deleteBeforeRelativeSequenceNr: Long,
+      deleteOldEvents: Boolean = false,
+      deleteOldSnapshots: Boolean = false,
+  ): Config = {
+    ConfigFactory
+      .parseString(
+        s"""
+           |lerna.akka.entityreplication.raft {
+           |  election-timeout = 99999s
+           |  compaction.log-size-threshold = 3
+           |  compaction.preserve-log-size = 1
+           |  compaction.log-size-check-interval = 99999s
+           |  delete-old-events = $deleteOldEvents
+           |  delete-old-snapshots = $deleteOldSnapshots
+           |  delete-before-relative-sequence-nr = $deleteBeforeRelativeSequenceNr
+           |}
+           |""".stripMargin,
+      ).withFallback(system.settings.config)
+  }
+
+  private trait Fixture {
+    val shardId: NormalizedShardId     = createUniqueShardId()
+    val selfIndex: MemberIndex         = createUniqueMemberIndex()
+    val otherIndexA: MemberIndex       = createUniqueMemberIndex()
+    val otherIndexB: MemberIndex       = createUniqueMemberIndex()
+    val otherIndices: Set[MemberIndex] = Set(otherIndexA, otherIndexB)
+
+    val persistenceId: String =
+      raftActorPersistenceId(defaultTypeName, shardId, selfIndex)
+    val entityId: NormalizedEntityId =
+      NormalizedEntityId.from("entity")
+
+    val otherRaftActor: TestProbe = TestProbe()
+
+    val replicationRegion: TestProbe = TestProbe()
+    val replicationActor: TestProbe  = TestProbe()
+    val snapshotStore: TestProbe     = TestProbe()
+    val commitLogStore: TestProbe    = TestProbe()
+
+    // The following actors ignore all messages by default since they can receive messages periodically in the background.
+    // Disable ignore when it has to verify incoming messages.
+    replicationRegion.ignoreMsg { case _ => true }
+    replicationActor.ignoreMsg { case _ => true }
+    snapshotStore.ignoreMsg { case _ => true }
+    commitLogStore.ignoreMsg { case _ => true }
+
+    def createFollower(config: Config): ActorRef = {
+      val settings = RaftSettings(config)
+      val followerData = {
+        val initialEntries = Seq(
+          LogEntry(LogEntryIndex(1), EntityEvent(None, NoOp), Term(1)),
+        )
+        val replicatedLog = ReplicatedLog().truncateAndAppend(initialEntries)
+        RaftMemberData(
+          currentTerm = Term(1),
+          replicatedLog = replicatedLog,
+          commitIndex = LogEntryIndex(1),
+          lastApplied = LogEntryIndex(1),
+          eventSourcingIndex = Option(LogEntryIndex(1)),
+        ).initializeFollowerData()
+      }
+      val raftActor = createRaftActor(
+        shardId = shardId,
+        shardSnapshotStore = snapshotStore.ref,
+        region = replicationRegion.ref,
+        selfMemberIndex = selfIndex,
+        otherMemberIndexes = otherIndices,
+        settings = settings,
+        replicationActor = replicationActor.ref,
+        entityId = entityId,
+        commitLogStore = commitLogStore.ref,
+      )
+      setState(raftActor, Follower, followerData)
+      raftActor
+    }
+
+    def advanceCompaction(raftActor: ActorRef, newEventSourcingIndex: LogEntryIndex): Unit = {
+      commitLogStore.ignoreNoMsg()
+      replicationActor.ignoreNoMsg()
+      snapshotStore.ignoreNoMsg()
+
+      // Trigger compaction
+      raftActor ! SnapshotTick
+
+      // Advance EventSourcingIndex
+      commitLogStore.fishForSpecificMessage() {
+        case _: CommitLogStoreActor.AppendCommittedEntries =>
+          commitLogStore.reply(CommitLogStoreActor.AppendCommittedEntriesResponse(newEventSourcingIndex))
+      }
+
+      // Advance EntitySnapshot taking
+      replicationActor.fishForSpecificMessage() {
+        case msg: TakeSnapshot =>
+          replicationActor.reply(Snapshot(msg.metadata, EntityState("state")))
+      }
+
+      // Advance EntitySnapshot saving
+      snapshotStore.fishForSpecificMessage() {
+        case msg: SaveSnapshot =>
+          snapshotStore.reply(SaveSnapshotSuccess(msg.snapshot.metadata))
+      }
+
+      commitLogStore.ignoreMsg { case _ => true }
+      replicationActor.ignoreMsg { case _ => true }
+      snapshotStore.ignoreMsg { case _ => true }
+    }
+
+    def appendNewEntriesTo(
+        follower: ActorRef,
+        currentTerm: Term,
+        prevLogTerm: Term,
+        firstEntry: LogEntry,
+        entries: LogEntry*,
+    ): Unit = {
+      val newEntries   = firstEntry +: entries
+      val prevLogIndex = firstEntry.index.prev()
+      val lastLogIndex = entries.lastOption.getOrElse(firstEntry).index
+      otherRaftActor.send(
+        follower,
+        AppendEntries(shardId, currentTerm, otherIndexA, prevLogIndex, prevLogTerm, newEntries, lastLogIndex),
+      )
+      otherRaftActor.expectMsg(AppendEntriesSucceeded(currentTerm, lastLogIndex, selfIndex))
+    }
+
+    def appendNewEntriesEachTo(
+        follower: ActorRef,
+        currentTerm: Term,
+        prevLogTerm: Term,
+        firstEntry: LogEntry,
+        entries: LogEntry*,
+    ): Unit = {
+      appendNewEntriesTo(follower, currentTerm, prevLogTerm, firstEntry)
+      for ((entry, prevEntry) <- entries.zip(firstEntry +: entries)) {
+        appendNewEntriesTo(follower, currentTerm, prevEntry.term, entry)
+      }
+    }
+
+    def assertRaftActorHandlesNewMessage(raftActor: ActorRef): Unit = {
+      // Use RequestVote since all RaftActor states can handle RequestVote.
+      otherRaftActor.send(
+        raftActor,
+        RequestVote(shardId, Term(1), otherIndexA, LogEntryIndex(1), Term(1)),
+      )
+      otherRaftActor.expectMsgType[RequestVoteDenied]
+    }
+
+  }
+
+  "Follower" should {
+    def promoteToFollower(fixture: Fixture, follower: ActorRef): Unit = { /* Do nothing */ }
+
+    behave like eventDeletionSupport(promoteBeforeDelete = promoteToFollower)
+    behave like snapshotDeletionSupport(promoteBeforeDelete = promoteToFollower)
+  }
+
+  "Candidate" should {
+    def promoteToCandidate(fixture: Fixture, follower: ActorRef): Unit = {
+      follower ! ElectionTimeout
+      awaitAssert {
+        assert(getState(follower).stateName === Candidate)
+      }
+    }
+
+    behave like eventDeletionSupport(promoteBeforeDelete = promoteToCandidate)
+    behave like snapshotDeletionSupport(promoteBeforeDelete = promoteToCandidate)
+  }
+
+  "Leader" should {
+    def promoteToLeader(fixture: Fixture, follower: ActorRef): Unit = {
+      import fixture._
+      replicationRegion.ignoreNoMsg()
+      follower ! ElectionTimeout
+      replicationRegion.fishForSpecificMessage() {
+        case ReplicationRegion.Broadcast(requestVote: RequestVote) =>
+          replicationRegion.forward(replicationRegion.lastSender, requestVote)
+          replicationRegion.reply(RequestVoteAccepted(requestVote.term, otherIndexA))
+          replicationRegion.reply(RequestVoteAccepted(requestVote.term, otherIndexB))
+      }
+      replicationRegion.ignoreMsg { case _ => true }
+      awaitAssert {
+        assert(getState(follower).stateName === Leader)
+      }
+    }
+
+    behave like eventDeletionSupport(promoteBeforeDelete = promoteToLeader)
+    behave like snapshotDeletionSupport(promoteBeforeDelete = promoteToLeader)
+  }
+
+  def eventDeletionSupport(promoteBeforeDelete: (Fixture, ActorRef) => Unit): Unit = {
+
+    "not delete events if event deletion is disabled" in new Fixture {
+      val raftActor = createFollower(
+        configFor(
+          deleteBeforeRelativeSequenceNr = 0,
+          deleteOldEvents = false,
+        ),
+      )
+
+      // Arrange: append new entries, which will trigger compaction.
+      appendNewEntriesTo(
+        raftActor,
+        currentTerm = Term(1),
+        prevLogTerm = Term(1),
+        LogEntry(LogEntryIndex(2), EntityEvent(Option(entityId), "event-1"), Term(1)),
+        LogEntry(LogEntryIndex(3), EntityEvent(Option(entityId), "event-2"), Term(1)),
+        LogEntry(LogEntryIndex(4), EntityEvent(Option(entityId), "event-3"), Term(1)),
+      )
+
+      promoteBeforeDelete(this, raftActor)
+
+      // Arrange: store the number of events to verify event deletion.
+      val numOfEventsBeforeDelete =
+        persistenceTestKit.persistedInStorage(persistenceId).size
+
+      // Act: complete compaction, which will trigger a snapshot save and event deletion.
+      advanceCompaction(raftActor, newEventSourcingIndex = LogEntryIndex(4))
+
+      // Assert:
+      snapshotTestKit.expectNextPersistedType[PersistentStateData.PersistentState](persistenceId)
+      assertForDuration(
+        {
+          assert(persistenceTestKit.persistedInStorage(persistenceId).size >= numOfEventsBeforeDelete)
+        },
+        max = remainingOrDefault,
+      )
+    }
+
+    "delete events matching the criteria if it successfully saves a snapshot" in new Fixture {
+      val raftActor = createFollower(
+        configFor(
+          deleteBeforeRelativeSequenceNr = 1,
+          deleteOldEvents = true,
+        ),
+      )
+
+      // Arrange: append new entries, which will trigger compaction.
+      appendNewEntriesEachTo(
+        raftActor,
+        currentTerm = Term(1),
+        prevLogTerm = Term(1),
+        LogEntry(LogEntryIndex(2), EntityEvent(Option(entityId), "event-1"), Term(1)),
+        LogEntry(LogEntryIndex(3), EntityEvent(Option(entityId), "event-2"), Term(1)),
+        LogEntry(LogEntryIndex(4), EntityEvent(Option(entityId), "event-3"), Term(1)),
+      )
+
+      promoteBeforeDelete(this, raftActor)
+
+      // Arrange: store the number of events to verify event deletion.
+      val numOfEventsBeforeDelete =
+        persistenceTestKit.persistedInStorage(persistenceId).size
+
+      // Act: complete compaction, which will trigger a snapshot save and event deletion.
+      advanceCompaction(raftActor, newEventSourcingIndex = LogEntryIndex(4))
+
+      // Assert:
+      snapshotTestKit.expectNextPersistedType[PersistentStateData.PersistentState](persistenceId)
+      awaitAssert {
+        assert(persistenceTestKit.persistedInStorage(persistenceId).size < numOfEventsBeforeDelete)
+        assert(persistenceTestKit.persistedInStorage(persistenceId).size === 1)
+      }
+    }
+
+    "not delete events if it successfully saves a snapshot, but no events match the criteria" in new Fixture {
+      val raftActor = createFollower(
+        configFor(
+          deleteBeforeRelativeSequenceNr = 1000,
+          deleteOldEvents = true,
+        ),
+      )
+
+      // Arrange: append new entries, which will trigger compaction.
+      appendNewEntriesTo(
+        raftActor,
+        currentTerm = Term(1),
+        prevLogTerm = Term(1),
+        LogEntry(LogEntryIndex(2), EntityEvent(Option(entityId), "event-1"), Term(1)),
+        LogEntry(LogEntryIndex(3), EntityEvent(Option(entityId), "event-2"), Term(1)),
+        LogEntry(LogEntryIndex(4), EntityEvent(Option(entityId), "event-3"), Term(1)),
+      )
+
+      promoteBeforeDelete(this, raftActor)
+
+      // Arrange: store the number of events to verify event deletion.
+      val numOfEventsBeforeDelete =
+        persistenceTestKit.persistedInStorage(persistenceId).size
+
+      // Act: complete compaction, which will trigger a snapshot save and event deletion.
+      advanceCompaction(raftActor, newEventSourcingIndex = LogEntryIndex(4))
+
+      // Assert:
+      snapshotTestKit.expectNextPersistedType[PersistentStateData.PersistentState](persistenceId)
+      assertForDuration(
+        {
+          assert(persistenceTestKit.persistedInStorage(persistenceId).size >= numOfEventsBeforeDelete)
+        },
+        max = remainingOrDefault,
+      )
+    }
+
+    "continue its behavior if an event deletion fails" in new Fixture {
+      val raftActor = createFollower(
+        configFor(
+          deleteBeforeRelativeSequenceNr = 1,
+          deleteOldEvents = true,
+        ),
+      )
+
+      // Arrange: append new entries, which will trigger compaction.
+      appendNewEntriesEachTo(
+        raftActor,
+        currentTerm = Term(1),
+        prevLogTerm = Term(1),
+        LogEntry(LogEntryIndex(2), EntityEvent(Option(entityId), "event-1"), Term(1)),
+        LogEntry(LogEntryIndex(3), EntityEvent(Option(entityId), "event-2"), Term(1)),
+        LogEntry(LogEntryIndex(4), EntityEvent(Option(entityId), "event-3"), Term(1)),
+      )
+
+      promoteBeforeDelete(this, raftActor)
+
+      // Arrange: store the number of events to verify event deletion.
+      val numOfEventsBeforeDelete =
+        persistenceTestKit.persistedInStorage(persistenceId).size
+
+      // Act: complete compaction, which will trigger a snapshot save and event deletion.
+      LoggingTestKit.warn("Failed to deleteMessages").expect {
+        persistenceTestKit.failNextDelete(persistenceId)
+        advanceCompaction(raftActor, newEventSourcingIndex = LogEntryIndex(4))
+        snapshotTestKit.expectNextPersistedType[PersistentStateData.PersistentState](persistenceId)
+      }
+
+      // Assert:
+      awaitAssert {
+        assert(persistenceTestKit.persistedInStorage(persistenceId).size >= numOfEventsBeforeDelete)
+        assert(persistenceTestKit.persistedInStorage(persistenceId).size > 1)
+      }
+
+      // Assert: RaftActor should handle the next message.
+      assertRaftActorHandlesNewMessage(raftActor)
+    }
+  }
+
+  def snapshotDeletionSupport(promoteBeforeDelete: (Fixture, ActorRef) => Unit): Unit = {
+
+    "not delete snapshots if snapshot deletion is disabled" in new Fixture {
+      val raftActor = createFollower(
+        configFor(
+          deleteBeforeRelativeSequenceNr = 0,
+          deleteOldSnapshots = false,
+        ),
+      )
+
+      // Arrange: complete the first compaction, which will trigger a snapshot save.
+      appendNewEntriesTo(
+        raftActor,
+        currentTerm = Term(1),
+        prevLogTerm = Term(1),
+        LogEntry(LogEntryIndex(2), EntityEvent(Option(entityId), "event-1"), Term(1)),
+        LogEntry(LogEntryIndex(3), EntityEvent(Option(entityId), "event-2"), Term(1)),
+      )
+      advanceCompaction(raftActor, newEventSourcingIndex = LogEntryIndex(3))
+      snapshotTestKit.expectNextPersistedType[PersistentStateData.PersistentState](persistenceId)
+
+      // Arrange: append new entries, which will trigger the second compaction.
+      appendNewEntriesTo(
+        raftActor,
+        currentTerm = Term(1),
+        prevLogTerm = Term(1),
+        LogEntry(LogEntryIndex(4), EntityEvent(Option(entityId), "event-3"), Term(1)),
+        LogEntry(LogEntryIndex(5), EntityEvent(Option(entityId), "event-4"), Term(1)),
+        LogEntry(LogEntryIndex(6), EntityEvent(Option(entityId), "event-5"), Term(1)),
+      )
+
+      promoteBeforeDelete(this, raftActor)
+
+      // Act: complete the second compaction, which will trigger a snapshot save and deletion.
+      advanceCompaction(raftActor, newEventSourcingIndex = LogEntryIndex(6))
+
+      // Assert:
+      snapshotTestKit.expectNextPersistedType[PersistentStateData.PersistentState](persistenceId)
+      assertForDuration(
+        {
+          assert(snapshotTestKit.persistedInStorage(persistenceId).size === 2)
+        },
+        max = remainingOrDefault,
+      )
+    }
+
+    "delete snapshots matching the criteria if it successfully saves a snapshot" in new Fixture {
+      val raftActor = createFollower(
+        configFor(
+          deleteBeforeRelativeSequenceNr = 0,
+          deleteOldSnapshots = true,
+        ),
+      )
+
+      // Arrange: complete the first compaction, which will trigger a snapshot save.
+      appendNewEntriesTo(
+        raftActor,
+        currentTerm = Term(1),
+        prevLogTerm = Term(1),
+        LogEntry(LogEntryIndex(2), EntityEvent(Option(entityId), "event-1"), Term(1)),
+        LogEntry(LogEntryIndex(3), EntityEvent(Option(entityId), "event-2"), Term(1)),
+      )
+      advanceCompaction(raftActor, newEventSourcingIndex = LogEntryIndex(3))
+      snapshotTestKit.expectNextPersistedType[PersistentStateData.PersistentState](persistenceId)
+
+      // Arrange: append new entries, which will trigger the second compaction.
+      appendNewEntriesTo(
+        raftActor,
+        currentTerm = Term(1),
+        prevLogTerm = Term(1),
+        LogEntry(LogEntryIndex(4), EntityEvent(Option(entityId), "event-b-3"), Term(1)),
+        LogEntry(LogEntryIndex(5), EntityEvent(Option(entityId), "event-b-4"), Term(1)),
+        LogEntry(LogEntryIndex(6), EntityEvent(Option(entityId), "event-b-5"), Term(1)),
+      )
+
+      promoteBeforeDelete(this, raftActor)
+
+      // NOTE:
+      //   Assert that a new snapshot is saved successfully by inspecting an info log since
+      //   snapshotTestKit.expectNextPersistedType[PersistentStateData.PersistentState](persistenceId) might not work
+      //   in this case.
+      LoggingTestKit.info("Succeeded to saveSnapshot").expect {
+        // Act: completes the second compaction, which will trigger a snapshot save and deletion.
+        advanceCompaction(raftActor, newEventSourcingIndex = LogEntryIndex(6))
+      }
+
+      // Assert:
+      awaitAssert {
+        assert(snapshotTestKit.persistedInStorage(persistenceId).size === 1)
+      }
+    }
+
+    "not delete snapshots if it successfully saves a snapshot, but no snapshots match the criteria" in new Fixture {
+      val raftActor = createFollower(
+        configFor(
+          deleteBeforeRelativeSequenceNr = 1000,
+          deleteOldSnapshots = true,
+        ),
+      )
+
+      // Arrange: complete the first compaction, which will trigger a snapshot save.
+      appendNewEntriesTo(
+        raftActor,
+        currentTerm = Term(1),
+        prevLogTerm = Term(1),
+        LogEntry(LogEntryIndex(2), EntityEvent(Option(entityId), "event-1"), Term(1)),
+        LogEntry(LogEntryIndex(3), EntityEvent(Option(entityId), "event-2"), Term(1)),
+      )
+      advanceCompaction(raftActor, newEventSourcingIndex = LogEntryIndex(3))
+      snapshotTestKit.expectNextPersistedType[PersistentStateData.PersistentState](persistenceId)
+
+      // Arrange: append new entries, which will trigger the second compaction.
+      appendNewEntriesTo(
+        raftActor,
+        currentTerm = Term(1),
+        prevLogTerm = Term(1),
+        LogEntry(LogEntryIndex(4), EntityEvent(Option(entityId), "event-3"), Term(1)),
+        LogEntry(LogEntryIndex(5), EntityEvent(Option(entityId), "event-4"), Term(1)),
+        LogEntry(LogEntryIndex(6), EntityEvent(Option(entityId), "event-5"), Term(1)),
+      )
+
+      promoteBeforeDelete(this, raftActor)
+
+      // Act: complete the second compaction, which will trigger a snapshot save and deletion.
+      advanceCompaction(raftActor, newEventSourcingIndex = LogEntryIndex(6))
+
+      // Assert:
+      snapshotTestKit.expectNextPersistedType[PersistentStateData.PersistentState](persistenceId)
+      assertForDuration(
+        {
+          assert(snapshotTestKit.persistedInStorage(persistenceId).size === 2)
+        },
+        max = remainingOrDefault,
+      )
+    }
+
+    "continue its behavior if a snapshot deletion fails" ignore {
+      // TODO: Write this test after `SnapshotTestKit.failNextDelete` comes to trigger a snapshot deletion failure.
+      //   `SnapshotTestKit.failNextDelete` doesn't trigger a snapshot deletion failure at the time of writing.
+      //   While underlying implementation `PersistenceTestKitSnapshotPlugin.deleteAsync` is supposed to return a failed
+      //   Future, it always returns a successful Future.
+    }
+
+  }
+
+}

--- a/core/src/test/scala/lerna/akka/entityreplication/raft/RaftSettingsSpec.scala
+++ b/core/src/test/scala/lerna/akka/entityreplication/raft/RaftSettingsSpec.scala
@@ -31,7 +31,7 @@ final class RaftSettingsSpec extends TestKit(ActorSystem("RaftSettingsSpec")) wi
       settings.maxAppendEntriesBatchSize shouldBe 10
       settings.deleteOldEvents shouldBe false
       settings.deleteOldSnapshots shouldBe false
-      settings.deleteBeforeRelativeSequenceNr shouldBe 100_000
+      settings.deleteBeforeRelativeSequenceNr shouldBe 250_000
       settings.compactionSnapshotCacheTimeToLive shouldBe 10.seconds
       settings.compactionLogSizeThreshold shouldBe 50_000
       settings.compactionPreserveLogSize shouldBe 10_000
@@ -41,11 +41,11 @@ final class RaftSettingsSpec extends TestKit(ActorSystem("RaftSettingsSpec")) wi
       settings.snapshotSyncMaxSnapshotBatchSize shouldBe 1_000
       settings.snapshotSyncDeleteOldEvents shouldBe false
       settings.snapshotSyncDeleteOldSnapshots shouldBe false
-      settings.snapshotSyncDeleteBeforeRelativeSequenceNr shouldBe 1_000
+      settings.snapshotSyncDeleteBeforeRelativeSequenceNr shouldBe 250_000
       settings.snapshotStoreSnapshotEvery shouldBe 1
       settings.snapshotStoreDeleteOldEvents shouldBe false
       settings.snapshotStoreDeleteOldSnapshots shouldBe false
-      settings.snapshotStoreDeleteBeforeRelativeSequenceNr shouldBe 1
+      settings.snapshotStoreDeleteBeforeRelativeSequenceNr shouldBe 5
       settings.clusterShardingConfig shouldBe defaultConfig.getConfig("lerna.akka.entityreplication.raft.sharding")
       settings.raftActorAutoStartFrequency shouldBe 3.seconds
       settings.raftActorAutoStartNumberOfActors shouldBe 5
@@ -61,7 +61,7 @@ final class RaftSettingsSpec extends TestKit(ActorSystem("RaftSettingsSpec")) wi
       settings.eventSourcedSnapshotEvery shouldBe 1_000
       settings.eventSourcedDeleteOldEvents shouldBe false
       settings.eventSourcedDeleteOldSnapshots shouldBe false
-      settings.eventSourcedDeleteBeforeRelativeSequenceNr shouldBe 1_000
+      settings.eventSourcedDeleteBeforeRelativeSequenceNr shouldBe 5_000
     }
 
     "load the default journalPluginAdditionalConfig with non-empty journalPluginId" in {

--- a/core/src/test/scala/lerna/akka/entityreplication/raft/RaftSettingsSpec.scala
+++ b/core/src/test/scala/lerna/akka/entityreplication/raft/RaftSettingsSpec.scala
@@ -39,6 +39,9 @@ final class RaftSettingsSpec extends TestKit(ActorSystem("RaftSettingsSpec")) wi
       settings.snapshotSyncCopyingParallelism shouldBe 10
       settings.snapshotSyncPersistenceOperationTimeout shouldBe 10.seconds
       settings.snapshotSyncMaxSnapshotBatchSize shouldBe 1_000
+      settings.snapshotSyncDeleteOldEvents shouldBe false
+      settings.snapshotSyncDeleteOldSnapshots shouldBe false
+      settings.snapshotSyncDeleteBeforeRelativeSequenceNr shouldBe 1_000
       settings.snapshotStoreSnapshotEvery shouldBe 1
       settings.snapshotStoreDeleteOldEvents shouldBe false
       settings.snapshotStoreDeleteOldSnapshots shouldBe false
@@ -209,6 +212,27 @@ final class RaftSettingsSpec extends TestKit(ActorSystem("RaftSettingsSpec")) wi
           RaftSettings(config)
         }
       }
+    }
+
+    "not throw an IllegalArgumentException if the given snapshot-sync.delete-before-relative-sequence-nr is 0" in {
+      val config = ConfigFactory
+        .parseString("""
+            |lerna.akka.entityreplication.raft.snapshot-sync.delete-before-relative-sequence-nr = 0
+            |""".stripMargin)
+        .withFallback(defaultConfig)
+      RaftSettings(config).snapshotSyncDeleteBeforeRelativeSequenceNr shouldBe 0
+    }
+
+    "throw an IllegalArgumentException if the given snapshot-sync.delete-before-relative-sequence-nr is -1" in {
+      val config = ConfigFactory
+        .parseString("""
+            |lerna.akka.entityreplication.raft.snapshot-sync.delete-before-relative-sequence-nr = -1
+            |""".stripMargin)
+        .withFallback(defaultConfig)
+      val exception = intercept[IllegalArgumentException] {
+        RaftSettings(config)
+      }
+      exception.getMessage shouldBe "requirement failed: snapshot-sync.delete-before-relative-sequence-nr (-1) should be greater than or equal to 0."
     }
 
     "throw an IllegalArgumentException if the given entity-snapshot-store.snapshot-every is less than or equal to 0" in {

--- a/core/src/test/scala/lerna/akka/entityreplication/raft/eventsourced/CommitLogStoreActorSpec.scala
+++ b/core/src/test/scala/lerna/akka/entityreplication/raft/eventsourced/CommitLogStoreActorSpec.scala
@@ -657,7 +657,7 @@ final class CommitLogStoreActorSpec
       snapshotTestKit.expectNextPersisted(persistenceId, CommitLogStoreActor.State(LogEntryIndex(3)))
       assertForDuration(
         {
-          assert(persistenceTestKit.persistedInStorage(persistenceId).size === 3)
+          assert(persistenceTestKit.persistedInStorage(persistenceId) === Seq("event-1", "event-2", "event-3"))
         },
         max = remainingOrDefault,
       )
@@ -708,7 +708,7 @@ final class CommitLogStoreActorSpec
       snapshotTestKit.expectNextPersisted(persistenceId, CommitLogStoreActor.State(LogEntryIndex(3)))
       assertForDuration(
         {
-          assert(persistenceTestKit.persistedInStorage(persistenceId).size === 3)
+          assert(persistenceTestKit.persistedInStorage(persistenceId) === Seq("event-1", "event-2", "event-3"))
         },
         max = remainingOrDefault,
       )
@@ -768,7 +768,12 @@ final class CommitLogStoreActorSpec
       snapshotTestKit.expectNextPersisted(persistenceId, CommitLogStoreActor.State(LogEntryIndex(6)))
       assertForDuration(
         {
-          assert(snapshotTestKit.persistedInStorage(persistenceId).size === 3)
+          val allSnapshots = Seq(
+            CommitLogStoreActor.State(LogEntryIndex(2)),
+            CommitLogStoreActor.State(LogEntryIndex(4)),
+            CommitLogStoreActor.State(LogEntryIndex(6)),
+          )
+          assert(snapshotTestKit.persistedInStorage(persistenceId).map(_._2) === allSnapshots)
         },
         max = remainingOrDefault,
       )
@@ -827,7 +832,11 @@ final class CommitLogStoreActorSpec
       snapshotTestKit.expectNextPersisted(persistenceId, CommitLogStoreActor.State(LogEntryIndex(4)))
       assertForDuration(
         {
-          assert(snapshotTestKit.persistedInStorage(persistenceId).size === 2)
+          val allSnapshots = Seq(
+            CommitLogStoreActor.State(LogEntryIndex(2)),
+            CommitLogStoreActor.State(LogEntryIndex(4)),
+          )
+          assert(snapshotTestKit.persistedInStorage(persistenceId).map(_._2) === allSnapshots)
         },
         max = remainingOrDefault,
       )

--- a/core/src/test/scala/lerna/akka/entityreplication/raft/snapshot/ShardSnapshotStoreFailureSpec.scala
+++ b/core/src/test/scala/lerna/akka/entityreplication/raft/snapshot/ShardSnapshotStoreFailureSpec.scala
@@ -103,7 +103,7 @@ class ShardSnapshotStoreFailureSpec
       snapshotTestKit.failNextPersisted(snapshotStorePersistenceId)
 
       // Test:
-      LoggingTestKit.warn("Saving EntitySnapshot as a snapshot failed.").expect {
+      LoggingTestKit.warn("Failed to saveSnapshot").expect {
         shardSnapshotStore ! SaveSnapshot(snapshot, replyTo = testActor)
         persistenceTestKit.expectNextPersisted(snapshotStorePersistenceId, snapshot)
         expectMsg(SaveSnapshotSuccess(metadata))

--- a/core/src/test/scala/lerna/akka/entityreplication/raft/snapshot/ShardSnapshotStoreSuccessSpec.scala
+++ b/core/src/test/scala/lerna/akka/entityreplication/raft/snapshot/ShardSnapshotStoreSuccessSpec.scala
@@ -135,7 +135,7 @@ class ShardSnapshotStoreSuccessSpec
       val metadata                   = EntitySnapshotMetadata(entityId, LogEntryIndex.initial())
       val snapshot                   = EntitySnapshot(metadata, dummyEntityState)
 
-      LoggingTestKit.debug("Saving EntitySnapshot as a snapshot succeeded.").expect {
+      LoggingTestKit.debug("Succeeded to saveSnapshot").expect {
         shardSnapshotStore ! SaveSnapshot(snapshot, replyTo = testActor)
         persistenceTestKit.expectNextPersisted(snapshotStorePersistenceId, snapshot)
         expectMsg(SaveSnapshotSuccess(metadata))

--- a/core/src/test/scala/lerna/akka/entityreplication/raft/snapshot/SnapshotStorePersistenceDeletionSpec.scala
+++ b/core/src/test/scala/lerna/akka/entityreplication/raft/snapshot/SnapshotStorePersistenceDeletionSpec.scala
@@ -134,12 +134,11 @@ final class SnapshotStorePersistenceDeletionSpec
     // Act: save the second event, which will trigger a snapshot save and event deletion.
     val entityState2 = createEntitySnapshotData(LogEntryIndex(2))
     saveEntitySnapshot(snapshotStore, entityState2)
-    persistenceTestKit.expectNextPersisted(persistenceId, entityState2)
 
     // Assert:
     snapshotTestKit.expectNextPersisted(persistenceId, entityState2)
     awaitAssert {
-      assert(persistenceTestKit.persistedInStorage(persistenceId).size === 1)
+      assert(persistenceTestKit.persistedInStorage(persistenceId) === Seq(entityState2))
     }
   }
 
@@ -187,17 +186,14 @@ final class SnapshotStorePersistenceDeletionSpec
     locally {
       val entityState1 = createEntitySnapshotData(LogEntryIndex(1))
       saveEntitySnapshot(snapshotStore, entityState1)
-      persistenceTestKit.expectNextPersisted(persistenceId, entityState1)
     }
 
     // Act & Assert:
-    val entityState2 = createEntitySnapshotData(LogEntryIndex(2))
     LoggingTestKit.warn("Failed to deleteMessages").expect {
       persistenceTestKit.failNextDelete(persistenceId)
       // Act: save the second event, which will trigger a snapshot save and event deletion.
+      val entityState2 = createEntitySnapshotData(LogEntryIndex(2))
       saveEntitySnapshot(snapshotStore, entityState2)
-      persistenceTestKit.expectNextPersisted(persistenceId, entityState2)
-      snapshotTestKit.expectNextPersisted(persistenceId, entityState2)
     }
   }
 
@@ -210,26 +206,23 @@ final class SnapshotStorePersistenceDeletionSpec
       ),
     )
 
-    // Arrange: save the first event and snapshot.
+    // Arrange: save the first snapshot.
     locally {
       val entityState1 = createEntitySnapshotData(LogEntryIndex(1))
       saveEntitySnapshot(snapshotStore, entityState1)
-      persistenceTestKit.expectNextPersisted(persistenceId, entityState1)
       snapshotTestKit.expectNextPersisted(persistenceId, entityState1)
     }
 
-    // Arrange: save the second event and snapshot.
+    // Arrange: save the second snapshot.
     locally {
       val entityState2 = createEntitySnapshotData(LogEntryIndex(2))
       saveEntitySnapshot(snapshotStore, entityState2)
-      persistenceTestKit.expectNextPersisted(persistenceId, entityState2)
       snapshotTestKit.expectNextPersisted(persistenceId, entityState2)
     }
 
-    // Act: save the third event and snapshot, which will not trigger a snapshot deletion.
+    // Act: save the third snapshot, which will not trigger a snapshot deletion.
     val entityState3 = createEntitySnapshotData(LogEntryIndex(3))
     saveEntitySnapshot(snapshotStore, entityState3)
-    persistenceTestKit.expectNextPersisted(persistenceId, entityState3)
 
     // Assert:
     snapshotTestKit.expectNextPersisted(persistenceId, entityState3)
@@ -250,31 +243,25 @@ final class SnapshotStorePersistenceDeletionSpec
       ),
     )
 
-    // Arrange: save the first event and snapshot.
+    // Arrange: save the first snapshot.
     locally {
       val entityState1 = createEntitySnapshotData(LogEntryIndex(1))
       saveEntitySnapshot(snapshotStore, entityState1)
-      persistenceTestKit.expectNextPersisted(persistenceId, entityState1)
       snapshotTestKit.expectNextPersisted(persistenceId, entityState1)
     }
 
-    // Arrange: save the second event and snapshot.
-    locally {
-      val entityState2 = createEntitySnapshotData(LogEntryIndex(2))
-      saveEntitySnapshot(snapshotStore, entityState2)
-      persistenceTestKit.expectNextPersisted(persistenceId, entityState2)
-      snapshotTestKit.expectNextPersisted(persistenceId, entityState2)
-    }
+    // Arrange: save the second snapshot.
+    val entityState2 = createEntitySnapshotData(LogEntryIndex(2))
+    saveEntitySnapshot(snapshotStore, entityState2)
+    snapshotTestKit.expectNextPersisted(persistenceId, entityState2)
 
-    // Act: save the third event and snapshot, which will trigger a snapshot deletion.
+    // Act: save the third snapshot, which will trigger a snapshot deletion.
     val entityState3 = createEntitySnapshotData(LogEntryIndex(3))
     saveEntitySnapshot(snapshotStore, entityState3)
-    persistenceTestKit.expectNextPersisted(persistenceId, entityState3)
 
     // Assert:
-    snapshotTestKit.expectNextPersisted(persistenceId, entityState3)
     awaitAssert {
-      assert(snapshotTestKit.persistedInStorage(persistenceId).size === 2)
+      assert(snapshotTestKit.persistedInStorage(persistenceId).map(_._2) === Seq(entityState2, entityState3))
     }
   }
 
@@ -287,26 +274,23 @@ final class SnapshotStorePersistenceDeletionSpec
       ),
     )
 
-    // Arrange: save the first event and snapshot.
+    // Arrange: save the first snapshot.
     locally {
       val entityState1 = createEntitySnapshotData(LogEntryIndex(1))
       saveEntitySnapshot(snapshotStore, entityState1)
-      persistenceTestKit.expectNextPersisted(persistenceId, entityState1)
       snapshotTestKit.expectNextPersisted(persistenceId, entityState1)
     }
 
-    // Arrange: save the second event and snapshot.
+    // Arrange: save the second snapshot.
     locally {
       val entityState2 = createEntitySnapshotData(LogEntryIndex(2))
       saveEntitySnapshot(snapshotStore, entityState2)
-      persistenceTestKit.expectNextPersisted(persistenceId, entityState2)
       snapshotTestKit.expectNextPersisted(persistenceId, entityState2)
     }
 
-    // Act: save the third event and snapshot, which will trigger a snapshot deletion.
+    // Act: save the third snapshot, which will trigger a snapshot deletion.
     val entityState3 = createEntitySnapshotData(LogEntryIndex(3))
     saveEntitySnapshot(snapshotStore, entityState3)
-    persistenceTestKit.expectNextPersisted(persistenceId, entityState3)
 
     // Assert:
     snapshotTestKit.expectNextPersisted(persistenceId, entityState3)

--- a/core/src/test/scala/lerna/akka/entityreplication/raft/snapshot/SnapshotStorePersistenceDeletionSpec.scala
+++ b/core/src/test/scala/lerna/akka/entityreplication/raft/snapshot/SnapshotStorePersistenceDeletionSpec.scala
@@ -94,11 +94,9 @@ final class SnapshotStorePersistenceDeletionSpec
     )
 
     // Arrange: save the first event.
-    locally {
-      val entityState1 = createEntitySnapshotData(LogEntryIndex(1))
-      saveEntitySnapshot(snapshotStore, entityState1)
-      persistenceTestKit.expectNextPersisted(persistenceId, entityState1)
-    }
+    val entityState1 = createEntitySnapshotData(LogEntryIndex(1))
+    saveEntitySnapshot(snapshotStore, entityState1)
+    persistenceTestKit.expectNextPersisted(persistenceId, entityState1)
 
     // Act: save the second event, which will trigger a snapshot save but not event deletion.
     val entityState2 = createEntitySnapshotData(LogEntryIndex(2))
@@ -109,7 +107,7 @@ final class SnapshotStorePersistenceDeletionSpec
     snapshotTestKit.expectNextPersisted(persistenceId, entityState2)
     assertForDuration(
       {
-        assert(persistenceTestKit.persistedInStorage(persistenceId).size === 2)
+        assert(persistenceTestKit.persistedInStorage(persistenceId) === Seq(entityState1, entityState2))
       },
       max = remainingOrDefault,
     )
@@ -152,11 +150,9 @@ final class SnapshotStorePersistenceDeletionSpec
     )
 
     // Arrange: save the first event.
-    locally {
-      val entityState1 = createEntitySnapshotData(LogEntryIndex(1))
-      saveEntitySnapshot(snapshotStore, entityState1)
-      persistenceTestKit.expectNextPersisted(persistenceId, entityState1)
-    }
+    val entityState1 = createEntitySnapshotData(LogEntryIndex(1))
+    saveEntitySnapshot(snapshotStore, entityState1)
+    persistenceTestKit.expectNextPersisted(persistenceId, entityState1)
 
     // Act: save the second event, which will trigger a snapshot save and event deletion.
     val entityState2 = createEntitySnapshotData(LogEntryIndex(2))
@@ -167,7 +163,7 @@ final class SnapshotStorePersistenceDeletionSpec
     snapshotTestKit.expectNextPersisted(persistenceId, entityState2)
     assertForDuration(
       {
-        assert(persistenceTestKit.persistedInStorage(persistenceId).size === 2)
+        assert(persistenceTestKit.persistedInStorage(persistenceId) === Seq(entityState1, entityState2))
       },
       max = remainingOrDefault,
     )
@@ -207,18 +203,14 @@ final class SnapshotStorePersistenceDeletionSpec
     )
 
     // Arrange: save the first snapshot.
-    locally {
-      val entityState1 = createEntitySnapshotData(LogEntryIndex(1))
-      saveEntitySnapshot(snapshotStore, entityState1)
-      snapshotTestKit.expectNextPersisted(persistenceId, entityState1)
-    }
+    val entityState1 = createEntitySnapshotData(LogEntryIndex(1))
+    saveEntitySnapshot(snapshotStore, entityState1)
+    snapshotTestKit.expectNextPersisted(persistenceId, entityState1)
 
     // Arrange: save the second snapshot.
-    locally {
-      val entityState2 = createEntitySnapshotData(LogEntryIndex(2))
-      saveEntitySnapshot(snapshotStore, entityState2)
-      snapshotTestKit.expectNextPersisted(persistenceId, entityState2)
-    }
+    val entityState2 = createEntitySnapshotData(LogEntryIndex(2))
+    saveEntitySnapshot(snapshotStore, entityState2)
+    snapshotTestKit.expectNextPersisted(persistenceId, entityState2)
 
     // Act: save the third snapshot, which will not trigger a snapshot deletion.
     val entityState3 = createEntitySnapshotData(LogEntryIndex(3))
@@ -228,7 +220,8 @@ final class SnapshotStorePersistenceDeletionSpec
     snapshotTestKit.expectNextPersisted(persistenceId, entityState3)
     assertForDuration(
       {
-        assert(snapshotTestKit.persistedInStorage(persistenceId).size === 3)
+        val allSnapshots = Seq(entityState1, entityState2, entityState3)
+        assert(snapshotTestKit.persistedInStorage(persistenceId).map(_._2) === allSnapshots)
       },
       max = remainingOrDefault,
     )
@@ -275,18 +268,14 @@ final class SnapshotStorePersistenceDeletionSpec
     )
 
     // Arrange: save the first snapshot.
-    locally {
-      val entityState1 = createEntitySnapshotData(LogEntryIndex(1))
-      saveEntitySnapshot(snapshotStore, entityState1)
-      snapshotTestKit.expectNextPersisted(persistenceId, entityState1)
-    }
+    val entityState1 = createEntitySnapshotData(LogEntryIndex(1))
+    saveEntitySnapshot(snapshotStore, entityState1)
+    snapshotTestKit.expectNextPersisted(persistenceId, entityState1)
 
     // Arrange: save the second snapshot.
-    locally {
-      val entityState2 = createEntitySnapshotData(LogEntryIndex(2))
-      saveEntitySnapshot(snapshotStore, entityState2)
-      snapshotTestKit.expectNextPersisted(persistenceId, entityState2)
-    }
+    val entityState2 = createEntitySnapshotData(LogEntryIndex(2))
+    saveEntitySnapshot(snapshotStore, entityState2)
+    snapshotTestKit.expectNextPersisted(persistenceId, entityState2)
 
     // Act: save the third snapshot, which will trigger a snapshot deletion.
     val entityState3 = createEntitySnapshotData(LogEntryIndex(3))
@@ -296,7 +285,8 @@ final class SnapshotStorePersistenceDeletionSpec
     snapshotTestKit.expectNextPersisted(persistenceId, entityState3)
     assertForDuration(
       {
-        assert(snapshotTestKit.persistedInStorage(persistenceId).size === 3)
+        val allSnapshots = Seq(entityState1, entityState2, entityState3)
+        assert(snapshotTestKit.persistedInStorage(persistenceId).map(_._2) === allSnapshots)
       },
       max = remainingOrDefault,
     )

--- a/core/src/test/scala/lerna/akka/entityreplication/raft/snapshot/SnapshotStorePersistenceDeletionSpec.scala
+++ b/core/src/test/scala/lerna/akka/entityreplication/raft/snapshot/SnapshotStorePersistenceDeletionSpec.scala
@@ -1,0 +1,328 @@
+package lerna.akka.entityreplication.raft.snapshot
+
+import akka.actor.testkit.typed.scaladsl.LoggingTestKit
+import akka.actor.typed.scaladsl.adapter.ClassicActorSystemOps
+import akka.actor.{ typed, ActorRef, ActorSystem }
+import akka.persistence.testkit.scaladsl.{ PersistenceTestKit, SnapshotTestKit }
+import akka.testkit.{ TestKit, TestProbe }
+import com.typesafe.config.{ Config, ConfigFactory }
+import lerna.akka.entityreplication.model.{ NormalizedEntityId, TypeName }
+import lerna.akka.entityreplication.raft.model.LogEntryIndex
+import lerna.akka.entityreplication.raft.{ ActorSpec, RaftSettings }
+import lerna.akka.entityreplication.raft.routing.MemberIndex
+import org.scalactic.TypeCheckedTripleEquals
+
+import java.util.UUID
+
+final class SnapshotStorePersistenceDeletionSpec
+    extends TestKit(
+      ActorSystem("SnapshotStorePersistenceDeletionSpec", ShardSnapshotStoreSpecBase.configWithPersistenceTestKits),
+    )
+    with ActorSpec
+    with TypeCheckedTripleEquals {
+
+  import lerna.akka.entityreplication.raft.snapshot.SnapshotProtocol._
+
+  private implicit val typedSystem: typed.ActorSystem[Nothing] = system.toTyped
+  private val persistenceTestKit                               = PersistenceTestKit(system)
+  private val snapshotTestKit                                  = SnapshotTestKit(system)
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    persistenceTestKit.clearAll()
+    persistenceTestKit.resetPolicy()
+    snapshotTestKit.clearAll()
+    snapshotTestKit.resetPolicy()
+  }
+
+  private def configFor(
+      snapshotEvery: Int,
+      deleteBeforeRelativeSequenceNr: Long,
+      deleteOldEvents: Boolean = false,
+      deleteOldSnapshots: Boolean = false,
+  ): Config = {
+    ConfigFactory
+      .parseString(s"""
+          |lerna.akka.entityreplication.raft.entity-snapshot-store {
+          |  snapshot-every = ${snapshotEvery}
+          |  delete-old-events = ${deleteOldEvents}
+          |  delete-old-snapshots = ${deleteOldSnapshots}
+          |  delete-before-relative-sequence-nr = ${deleteBeforeRelativeSequenceNr}
+          |}
+          |""".stripMargin)
+      .withFallback(system.settings.config)
+  }
+
+  private trait Fixture {
+    val typeName: TypeName           = TypeName.from("test")
+    val memberIndex: MemberIndex     = MemberIndex("test-role")
+    val entityId: NormalizedEntityId = NormalizedEntityId.from(s"entity-${UUID.randomUUID().toString}")
+
+    val persistenceId: String =
+      SnapshotStore.persistenceId(typeName, entityId, memberIndex)
+
+    val probe: TestProbe = TestProbe()
+
+    def spawnSnapshotStore(config: Config): ActorRef =
+      planAutoKill {
+        childActorOf(
+          SnapshotStore.props(
+            typeName,
+            entityId,
+            RaftSettings(config),
+            memberIndex,
+          ),
+        )
+      }
+
+    def createEntitySnapshotData(index: LogEntryIndex): EntitySnapshot =
+      EntitySnapshot(EntitySnapshotMetadata(entityId, index), EntityState(s"state-${entityId.raw}-${index}"))
+
+    def saveEntitySnapshot(snapshotStore: ActorRef, entitySnapshot: EntitySnapshot): Unit = {
+      probe.send(snapshotStore, SaveSnapshot(entitySnapshot, replyTo = probe.ref))
+      probe.expectMsg(SaveSnapshotSuccess(entitySnapshot.metadata))
+    }
+  }
+
+  "not delete events if event deletion is disabled" in new Fixture {
+    val snapshotStore = spawnSnapshotStore(
+      configFor(
+        snapshotEvery = 2,
+        deleteBeforeRelativeSequenceNr = 1,
+        deleteOldEvents = false,
+      ),
+    )
+
+    // Arrange: save the first event.
+    locally {
+      val entityState1 = createEntitySnapshotData(LogEntryIndex(1))
+      saveEntitySnapshot(snapshotStore, entityState1)
+      persistenceTestKit.expectNextPersisted(persistenceId, entityState1)
+    }
+
+    // Act: save the second event, which will trigger a snapshot save but not event deletion.
+    val entityState2 = createEntitySnapshotData(LogEntryIndex(2))
+    saveEntitySnapshot(snapshotStore, entityState2)
+    persistenceTestKit.expectNextPersisted(persistenceId, entityState2)
+
+    // Assert:
+    snapshotTestKit.expectNextPersisted(persistenceId, entityState2)
+    assertForDuration(
+      {
+        assert(persistenceTestKit.persistedInStorage(persistenceId).size === 2)
+      },
+      max = remainingOrDefault,
+    )
+  }
+
+  "delete events matching the criteria if it successfully saves a snapshot" in new Fixture {
+    val snapshotStore = spawnSnapshotStore(
+      configFor(
+        snapshotEvery = 2,
+        deleteBeforeRelativeSequenceNr = 1,
+        deleteOldEvents = true,
+      ),
+    )
+
+    // Arrange: save the first event.
+    locally {
+      val entityState1 = createEntitySnapshotData(LogEntryIndex(1))
+      saveEntitySnapshot(snapshotStore, entityState1)
+      persistenceTestKit.expectNextPersisted(persistenceId, entityState1)
+    }
+
+    // Act: save the second event, which will trigger a snapshot save and event deletion.
+    val entityState2 = createEntitySnapshotData(LogEntryIndex(2))
+    saveEntitySnapshot(snapshotStore, entityState2)
+    persistenceTestKit.expectNextPersisted(persistenceId, entityState2)
+
+    // Assert:
+    snapshotTestKit.expectNextPersisted(persistenceId, entityState2)
+    awaitAssert {
+      assert(persistenceTestKit.persistedInStorage(persistenceId).size === 1)
+    }
+  }
+
+  "not delete events if it successfully saves a snapshot, but no events match the criteria" in new Fixture {
+    val snapshotStore = spawnSnapshotStore(
+      configFor(
+        snapshotEvery = 2,
+        deleteBeforeRelativeSequenceNr = 10,
+        deleteOldEvents = true,
+      ),
+    )
+
+    // Arrange: save the first event.
+    locally {
+      val entityState1 = createEntitySnapshotData(LogEntryIndex(1))
+      saveEntitySnapshot(snapshotStore, entityState1)
+      persistenceTestKit.expectNextPersisted(persistenceId, entityState1)
+    }
+
+    // Act: save the second event, which will trigger a snapshot save and event deletion.
+    val entityState2 = createEntitySnapshotData(LogEntryIndex(2))
+    saveEntitySnapshot(snapshotStore, entityState2)
+    persistenceTestKit.expectNextPersisted(persistenceId, entityState2)
+
+    // Assert:
+    snapshotTestKit.expectNextPersisted(persistenceId, entityState2)
+    assertForDuration(
+      {
+        assert(persistenceTestKit.persistedInStorage(persistenceId).size === 2)
+      },
+      max = remainingOrDefault,
+    )
+  }
+
+  "log a warning message if an event deletion fails" in new Fixture {
+    val snapshotStore = spawnSnapshotStore(
+      configFor(
+        snapshotEvery = 2,
+        deleteBeforeRelativeSequenceNr = 1,
+        deleteOldEvents = true,
+      ),
+    )
+
+    // Arrange: save the first event.
+    locally {
+      val entityState1 = createEntitySnapshotData(LogEntryIndex(1))
+      saveEntitySnapshot(snapshotStore, entityState1)
+      persistenceTestKit.expectNextPersisted(persistenceId, entityState1)
+    }
+
+    // Act & Assert:
+    val entityState2 = createEntitySnapshotData(LogEntryIndex(2))
+    LoggingTestKit.warn("Failed to deleteMessages").expect {
+      persistenceTestKit.failNextDelete(persistenceId)
+      // Act: save the second event, which will trigger a snapshot save and event deletion.
+      saveEntitySnapshot(snapshotStore, entityState2)
+      persistenceTestKit.expectNextPersisted(persistenceId, entityState2)
+      snapshotTestKit.expectNextPersisted(persistenceId, entityState2)
+    }
+  }
+
+  "not delete snapshots if snapshot deletion is disabled" in new Fixture {
+    val snapshotStore = spawnSnapshotStore(
+      configFor(
+        snapshotEvery = 1,
+        deleteBeforeRelativeSequenceNr = 1,
+        deleteOldSnapshots = false,
+      ),
+    )
+
+    // Arrange: save the first event and snapshot.
+    locally {
+      val entityState1 = createEntitySnapshotData(LogEntryIndex(1))
+      saveEntitySnapshot(snapshotStore, entityState1)
+      persistenceTestKit.expectNextPersisted(persistenceId, entityState1)
+      snapshotTestKit.expectNextPersisted(persistenceId, entityState1)
+    }
+
+    // Arrange: save the second event and snapshot.
+    locally {
+      val entityState2 = createEntitySnapshotData(LogEntryIndex(2))
+      saveEntitySnapshot(snapshotStore, entityState2)
+      persistenceTestKit.expectNextPersisted(persistenceId, entityState2)
+      snapshotTestKit.expectNextPersisted(persistenceId, entityState2)
+    }
+
+    // Act: save the third event and snapshot, which will not trigger a snapshot deletion.
+    val entityState3 = createEntitySnapshotData(LogEntryIndex(3))
+    saveEntitySnapshot(snapshotStore, entityState3)
+    persistenceTestKit.expectNextPersisted(persistenceId, entityState3)
+
+    // Assert:
+    snapshotTestKit.expectNextPersisted(persistenceId, entityState3)
+    assertForDuration(
+      {
+        assert(snapshotTestKit.persistedInStorage(persistenceId).size === 3)
+      },
+      max = remainingOrDefault,
+    )
+  }
+
+  "delete snapshots matching the criteria if it successfully saves a snapshot" in new Fixture {
+    val snapshotStore = spawnSnapshotStore(
+      configFor(
+        snapshotEvery = 1,
+        deleteBeforeRelativeSequenceNr = 1,
+        deleteOldSnapshots = true,
+      ),
+    )
+
+    // Arrange: save the first event and snapshot.
+    locally {
+      val entityState1 = createEntitySnapshotData(LogEntryIndex(1))
+      saveEntitySnapshot(snapshotStore, entityState1)
+      persistenceTestKit.expectNextPersisted(persistenceId, entityState1)
+      snapshotTestKit.expectNextPersisted(persistenceId, entityState1)
+    }
+
+    // Arrange: save the second event and snapshot.
+    locally {
+      val entityState2 = createEntitySnapshotData(LogEntryIndex(2))
+      saveEntitySnapshot(snapshotStore, entityState2)
+      persistenceTestKit.expectNextPersisted(persistenceId, entityState2)
+      snapshotTestKit.expectNextPersisted(persistenceId, entityState2)
+    }
+
+    // Act: save the third event and snapshot, which will trigger a snapshot deletion.
+    val entityState3 = createEntitySnapshotData(LogEntryIndex(3))
+    saveEntitySnapshot(snapshotStore, entityState3)
+    persistenceTestKit.expectNextPersisted(persistenceId, entityState3)
+
+    // Assert:
+    snapshotTestKit.expectNextPersisted(persistenceId, entityState3)
+    awaitAssert {
+      assert(snapshotTestKit.persistedInStorage(persistenceId).size === 2)
+    }
+  }
+
+  "not delete snapshots if it successfully saves a snapshot, but no snapshots match the criteria" in new Fixture {
+    val snapshotStore = spawnSnapshotStore(
+      configFor(
+        snapshotEvery = 1,
+        deleteBeforeRelativeSequenceNr = 10,
+        deleteOldSnapshots = true,
+      ),
+    )
+
+    // Arrange: save the first event and snapshot.
+    locally {
+      val entityState1 = createEntitySnapshotData(LogEntryIndex(1))
+      saveEntitySnapshot(snapshotStore, entityState1)
+      persistenceTestKit.expectNextPersisted(persistenceId, entityState1)
+      snapshotTestKit.expectNextPersisted(persistenceId, entityState1)
+    }
+
+    // Arrange: save the second event and snapshot.
+    locally {
+      val entityState2 = createEntitySnapshotData(LogEntryIndex(2))
+      saveEntitySnapshot(snapshotStore, entityState2)
+      persistenceTestKit.expectNextPersisted(persistenceId, entityState2)
+      snapshotTestKit.expectNextPersisted(persistenceId, entityState2)
+    }
+
+    // Act: save the third event and snapshot, which will trigger a snapshot deletion.
+    val entityState3 = createEntitySnapshotData(LogEntryIndex(3))
+    saveEntitySnapshot(snapshotStore, entityState3)
+    persistenceTestKit.expectNextPersisted(persistenceId, entityState3)
+
+    // Assert:
+    snapshotTestKit.expectNextPersisted(persistenceId, entityState3)
+    assertForDuration(
+      {
+        assert(snapshotTestKit.persistedInStorage(persistenceId).size === 3)
+      },
+      max = remainingOrDefault,
+    )
+  }
+
+  "log a warning message if a snapshot deletion fails" ignore {
+    // TODO: Write this test after `SnapshotTestKit.failNextDelete` comes to trigger a snapshot deletion failure.
+    //   `SnapshotTestKit.failNextDelete` doesn't trigger a snapshot deletion failure at the time of writing.
+    //   While underlying implementation `PersistenceTestKitSnapshotPlugin.deleteAsync` is supposed to return a failed
+    //   Future, it always returns a successful Future.
+  }
+
+}

--- a/core/src/test/scala/lerna/akka/entityreplication/raft/snapshot/sync/SnapshotSyncManagerPersistenceDeletionSpec.scala
+++ b/core/src/test/scala/lerna/akka/entityreplication/raft/snapshot/sync/SnapshotSyncManagerPersistenceDeletionSpec.scala
@@ -1,0 +1,597 @@
+package lerna.akka.entityreplication.raft.snapshot.sync
+
+import akka.actor.testkit.typed.scaladsl.LoggingTestKit
+import akka.actor.typed.scaladsl.adapter.ClassicActorSystemOps
+import akka.actor.{ typed, ActorRef, ActorSystem }
+import akka.persistence.journal.Tagged
+import akka.persistence.query.Offset
+import akka.persistence.testkit.query.scaladsl.PersistenceTestKitReadJournal
+import akka.persistence.testkit.scaladsl.{ PersistenceTestKit, SnapshotTestKit }
+import akka.persistence.testkit.{ PersistenceTestKitPlugin, PersistenceTestKitSnapshotPlugin, SnapshotMeta }
+import akka.testkit.{ TestKit, TestProbe }
+import com.typesafe.config.{ Config, ConfigFactory }
+import lerna.akka.entityreplication.model.{ NormalizedEntityId, NormalizedShardId, TypeName }
+import lerna.akka.entityreplication.raft.RaftActor.CompactionCompleted
+import lerna.akka.entityreplication.raft.model._
+import lerna.akka.entityreplication.raft.persistence.EntitySnapshotsUpdatedTag
+import lerna.akka.entityreplication.raft.routing.MemberIndex
+import lerna.akka.entityreplication.raft.snapshot.SnapshotProtocol._
+import lerna.akka.entityreplication.raft.snapshot.sync.SnapshotSyncManager._
+import lerna.akka.entityreplication.raft.snapshot.{ ShardSnapshotStore, SnapshotStore }
+import lerna.akka.entityreplication.raft.{ ActorSpec, RaftSettings }
+import org.scalactic.TypeCheckedTripleEquals
+import org.scalatest.Inside
+
+import java.util.UUID
+
+object SnapshotSyncManagerPersistenceDeletionSpec {
+
+  def config: Config = {
+    PersistenceTestKitPlugin.config
+      .withFallback(PersistenceTestKitSnapshotPlugin.config)
+      .withFallback(raftPersistenceConfig)
+      .withFallback(ConfigFactory.load())
+  }
+
+  private val raftPersistenceConfig: Config = ConfigFactory.parseString(
+    s"""
+       |lerna.akka.entityreplication.raft.persistence {
+       |  journal.plugin = ${PersistenceTestKitPlugin.PluginId}
+       |  snapshot-store.plugin = ${PersistenceTestKitSnapshotPlugin.PluginId}
+       |  query.plugin = ${PersistenceTestKitReadJournal.Identifier}
+       |}
+       |""".stripMargin,
+  )
+
+}
+
+final class SnapshotSyncManagerPersistenceDeletionSpec
+    extends TestKit(
+      ActorSystem(
+        "SnapshotSyncManagerPersistenceDeletionSpec",
+        SnapshotSyncManagerPersistenceDeletionSpec.config,
+      ),
+    )
+    with ActorSpec
+    with Inside
+    with TypeCheckedTripleEquals {
+
+  private implicit val typedSystem: typed.ActorSystem[Nothing] = system.toTyped
+  private val persistenceTestKit                               = PersistenceTestKit(system)
+  private val snapshotTestKit                                  = SnapshotTestKit(system)
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    persistenceTestKit.clearAll()
+    persistenceTestKit.resetPolicy()
+    snapshotTestKit.clearAll()
+    snapshotTestKit.resetPolicy()
+  }
+
+  private def configFor(
+      deleteBeforeRelativeSequenceNumber: Long,
+      deleteOldEvents: Boolean = false,
+      deleteOldSnapshots: Boolean = false,
+  ): Config = {
+    ConfigFactory
+      .parseString(
+        s"""
+         |lerna.akka.entityreplication.raft.snapshot-sync {
+         |  snapshot-copying-parallelism = 1
+         |  delete-old-events = $deleteOldEvents
+         |  delete-old-snapshots = $deleteOldSnapshots
+         |  delete-before-relative-sequence-nr = $deleteBeforeRelativeSequenceNumber
+         |}
+         |""".stripMargin,
+      ).withFallback(system.settings.config)
+  }
+
+  private trait Fixture {
+    val shardId: NormalizedShardId  = NormalizedShardId.from(s"shard:${UUID.randomUUID().toString}")
+    val typeName: TypeName          = TypeName.from(s"type-name:${UUID.randomUUID().toString}")
+    val srcMemberIndex: MemberIndex = MemberIndex(s"member-index:${UUID.randomUUID().toString}")
+    val dstMemberIndex: MemberIndex = MemberIndex(s"member-index:${UUID.randomUUID().toString}")
+
+    val persistenceId: String =
+      SnapshotSyncManager.persistenceId(typeName, srcMemberIndex, dstMemberIndex, shardId)
+    val destinationShardSnapshotStorePersistenceId: String =
+      s"shard-snapshot-store:${UUID.randomUUID().toString}"
+    val raftActorPersistenceId: String =
+      s"raft-???:${UUID.randomUUID().toString}"
+
+    val probe: TestProbe = TestProbe()
+
+    def spawnSnapshotSyncManager(config: Config): ActorRef =
+      spawnSnapshotSyncManager(RaftSettings(config))
+
+    def spawnSnapshotSyncManager(settings: RaftSettings): ActorRef = {
+      val dstSnapshotStore = planAutoKill {
+        system.actorOf(
+          ShardSnapshotStore.props(typeName, settings, dstMemberIndex),
+          destinationShardSnapshotStorePersistenceId,
+        )
+      }
+      planAutoKill {
+        system.actorOf(
+          SnapshotSyncManager.props(
+            typeName,
+            srcMemberIndex,
+            dstMemberIndex,
+            dstSnapshotStore,
+            shardId,
+            settings,
+          ),
+        )
+      }
+    }
+
+    /** The number of new events `runEntitySnapshotSynchronization` saves
+      *
+      * For clarification of test cases. This value should be updated if the implementation of
+      * `runEntitySnapshotSynchronization` changes. This value change doesn't affect `runEntitySnapshotSynchronization` behavior.
+      */
+    val NumOfNewEventsSynchronizationSaves: Int = 2
+
+    /** The number of new snapshots `runEntitySnapshotSynchronization` saves
+      *
+      * For clarification of test cases. This value should be updated if the implementation of
+      * `runEntitySnapshotSynchronization` changes. This value change doesn't affect `runEntitySnapshotSynchronization` behavior.
+      */
+    val NumOfNewSnapshotsSynchronizationSaves: Int = 1
+
+    /** The offset of entity snapshot synchronization progress after `runEntitySnapshotSynchronization` runs
+      *
+      * For clarification of test cases. This value should be updated if the implementation of
+      * `runEntitySnapshotSynchronization` changes. This value change doesn't affect `runEntitySnapshotSynchronization` behavior.
+      */
+    val OffsetAfterSynchronizationCompletes: Offset = Offset.sequence(1)
+
+    def runEntitySnapshotSynchronization(snapshotSyncManager: ActorRef): Unit = {
+      // Require: events and snapshots of the SnapshotSyncManager should have no offset.
+      // PersistenceTestKitReadJournal.currentEventsByTag that the SnapshotSyncManager runs has yet to support offsets.
+      persistenceTestKit.persistedInStorage(persistenceId).foreach { event =>
+        inside(event) {
+          case SyncCompleted(offset) =>
+            require(
+              offset === Offset.noOffset,
+              "SyncCompleted.offset should be NoOffset since PersistenceTestKitReadJournal has yet to support offsets.",
+            )
+        }
+      }
+      snapshotTestKit.persistedInStorage(persistenceId).foreach {
+        case (_, snapshot) =>
+          inside(snapshot) {
+            case SyncProgress(offset) =>
+              require(
+                offset === Offset.noOffset,
+                "SyncProgress.offset should be NoOffset since PersistenceTestKitReadJournal has yet to support offsets.",
+              )
+          }
+      }
+
+      // Prepare: source entity snapshots
+      val entityId =
+        NormalizedEntityId.from(s"entity:${UUID.randomUUID().toString}")
+      persistenceTestKit.persistForRecovery(
+        SnapshotStore.persistenceId(typeName, entityId, srcMemberIndex),
+        Seq(EntitySnapshot(EntitySnapshotMetadata(entityId, LogEntryIndex(2)), EntityState("entity-1-state"))),
+      )
+      // Prepare: tagged events the SnapshotSyncManager subscribes
+      persistenceTestKit.persistForRecovery(
+        raftActorPersistenceId,
+        Seq(
+          Tagged(
+            CompactionCompleted(srcMemberIndex, shardId, Term(1), LogEntryIndex(2), Set(entityId)),
+            Set(EntitySnapshotsUpdatedTag(srcMemberIndex, shardId).toString),
+          ),
+        ),
+      )
+
+      // Trigger entity snapshot synchronization.
+      snapshotSyncManager ! SnapshotSyncManager.SyncSnapshot(
+        srcLatestSnapshotLastLogTerm = Term(1),
+        srcLatestSnapshotLastLogIndex = LogEntryIndex(2),
+        dstLatestSnapshotLastLogTerm = Term(1),
+        dstLatestSnapshotLastLogIndex = LogEntryIndex(1),
+        replyTo = probe.ref,
+      )
+      // Ensure the entity snapshot synchronization completes.
+      probe.expectMsg(
+        SnapshotSyncManager.SyncSnapshotSucceeded(Term(1), LogEntryIndex(2), srcMemberIndex),
+      )
+
+      // The entity snapshot synchronization result in two event saves:
+      persistenceTestKit.expectNextPersisted(
+        persistenceId,
+        SnapshotCopied(Offset.sequence(1), dstMemberIndex, shardId, Term(1), LogEntryIndex(2), Set(entityId)),
+      )
+      persistenceTestKit.expectNextPersisted(
+        persistenceId,
+        SyncCompleted(Offset.sequence(1)),
+      )
+      // The caller will assert the saved snapshot `SyncProgress(Offset.sequence(1))` (not the entity's),
+      // this method doesn't assert that.
+    }
+
+  }
+
+  "SnapshotSyncManager" should {
+
+    "not delete events if event deletion is disabled" in new Fixture {
+      val config = configFor(
+        deleteBeforeRelativeSequenceNumber = 1,
+        deleteOldEvents = false,
+      )
+
+      // Arrange: save events and snapshots of SnapshotSyncManager.
+      persistenceTestKit.persistForRecovery(
+        persistenceId,
+        Seq(
+          SyncCompleted(Offset.noOffset),
+          SyncCompleted(Offset.noOffset),
+        ),
+      )
+      snapshotTestKit.persistForRecovery(
+        persistenceId,
+        SnapshotMeta(sequenceNr = 2) -> SyncProgress(Offset.noOffset),
+      )
+      snapshotTestKit.expectNextPersisted(persistenceId, SyncProgress(Offset.noOffset))
+
+      // Act: run entity snapshot synchronization, which will trigger a snapshot save but not event deletion.
+      val snapshotSyncManager = spawnSnapshotSyncManager(config)
+      runEntitySnapshotSynchronization(snapshotSyncManager)
+
+      // Assert:
+      snapshotTestKit.expectNextPersisted(persistenceId, SyncProgress(OffsetAfterSynchronizationCompletes))
+      assertForDuration(
+        {
+          assert(persistenceTestKit.persistedInStorage(persistenceId).size === 2 + NumOfNewEventsSynchronizationSaves)
+        },
+        max = remainingOrDefault,
+      )
+    }
+
+    "delete events matching the criteria if it successfully saves a snapshot" in new Fixture {
+      val config = configFor(
+        deleteBeforeRelativeSequenceNumber = 1,
+        deleteOldEvents = true,
+      )
+
+      // Arrange: save events and snapshots of SnapshotSyncManager.
+      persistenceTestKit.persistForRecovery(
+        persistenceId,
+        Seq(
+          SyncCompleted(Offset.noOffset),
+          SyncCompleted(Offset.noOffset),
+        ),
+      )
+      snapshotTestKit.persistForRecovery(
+        persistenceId,
+        SnapshotMeta(sequenceNr = 2) -> SyncProgress(Offset.noOffset),
+      )
+      snapshotTestKit.expectNextPersisted(persistenceId, SyncProgress(Offset.noOffset))
+
+      // Act: run entity snapshot synchronization, which will trigger a snapshot save and event deletion.
+      val snapshotSyncManager = spawnSnapshotSyncManager(config)
+      runEntitySnapshotSynchronization(snapshotSyncManager)
+
+      // Assert:
+      snapshotTestKit.expectNextPersisted(persistenceId, SyncProgress(OffsetAfterSynchronizationCompletes))
+      awaitAssert {
+        assert(persistenceTestKit.persistedInStorage(persistenceId).size === 1)
+      }
+    }
+
+    "not delete events if it successfully saves a snapshot, but no events match the criteria" in new Fixture {
+      val config = configFor(
+        deleteBeforeRelativeSequenceNumber = 10,
+        deleteOldEvents = true,
+      )
+
+      // Arrange: save events and snapshots of SnapshotSyncManager.
+      persistenceTestKit.persistForRecovery(
+        persistenceId,
+        Seq(
+          SyncCompleted(Offset.noOffset),
+          SyncCompleted(Offset.noOffset),
+        ),
+      )
+      snapshotTestKit.persistForRecovery(
+        persistenceId,
+        SnapshotMeta(sequenceNr = 2) -> SyncProgress(Offset.noOffset),
+      )
+      snapshotTestKit.expectNextPersisted(persistenceId, SyncProgress(Offset.noOffset))
+
+      // Act: run entity snapshot synchronization, which will trigger a snapshot save and event deletion.
+      val snapshotSyncManager = spawnSnapshotSyncManager(config)
+      runEntitySnapshotSynchronization(snapshotSyncManager)
+
+      // Assert:
+      snapshotTestKit.expectNextPersisted(persistenceId, SyncProgress(OffsetAfterSynchronizationCompletes))
+      assertForDuration(
+        {
+          assert(persistenceTestKit.persistedInStorage(persistenceId).size === 2 + NumOfNewEventsSynchronizationSaves)
+        },
+        max = remainingOrDefault,
+      )
+    }
+
+    "log a warning message if an event deletion fails" in new Fixture {
+      val config = configFor(
+        deleteBeforeRelativeSequenceNumber = 1,
+        deleteOldEvents = true,
+      )
+
+      // Arrange: save events and snapshots of SnapshotSyncManager.
+      persistenceTestKit.persistForRecovery(
+        persistenceId,
+        Seq(
+          SyncCompleted(Offset.noOffset),
+          SyncCompleted(Offset.noOffset),
+        ),
+      )
+      snapshotTestKit.persistForRecovery(
+        persistenceId,
+        SnapshotMeta(sequenceNr = 2) -> SyncProgress(Offset.noOffset),
+      )
+      snapshotTestKit.expectNextPersisted(persistenceId, SyncProgress(Offset.noOffset))
+
+      // Act & Assert:
+      val snapshotSyncManager = spawnSnapshotSyncManager(config)
+      LoggingTestKit.warn("Failed to deleteMessages").expect {
+        persistenceTestKit.failNextDelete(persistenceId)
+        // Act: run entity snapshot synchronization, which will trigger a snapshot save and event deletion.
+        runEntitySnapshotSynchronization(snapshotSyncManager)
+        snapshotTestKit.expectNextPersisted(persistenceId, SyncProgress(OffsetAfterSynchronizationCompletes))
+      }
+    }
+
+    "not delete snapshots if snapshot deletion is disabled" in new Fixture {
+      val config = configFor(
+        deleteBeforeRelativeSequenceNumber = 1,
+        deleteOldSnapshots = false,
+      )
+
+      // Arrange: save events and snapshots of SnapshotSyncManager.
+      persistenceTestKit.persistForRecovery(
+        persistenceId,
+        Seq(
+          SyncCompleted(Offset.noOffset),
+          SyncCompleted(Offset.noOffset),
+          SyncCompleted(Offset.noOffset),
+          SyncCompleted(Offset.noOffset),
+        ),
+      )
+      snapshotTestKit.persistForRecovery(
+        persistenceId,
+        Seq(
+          SnapshotMeta(sequenceNr = 2) -> SyncProgress(Offset.noOffset),
+          SnapshotMeta(sequenceNr = 4) -> SyncProgress(Offset.noOffset),
+        ),
+      )
+      snapshotTestKit.expectNextPersisted(persistenceId, SyncProgress(Offset.noOffset))
+      snapshotTestKit.expectNextPersisted(persistenceId, SyncProgress(Offset.noOffset))
+
+      // Act: run entity snapshot synchronization, which will trigger a snapshot save but not deletion.
+      val snapshotSyncManager = spawnSnapshotSyncManager(config)
+      runEntitySnapshotSynchronization(snapshotSyncManager)
+
+      // Assert:
+      snapshotTestKit.expectNextPersisted(persistenceId, SyncProgress(OffsetAfterSynchronizationCompletes))
+      assertForDuration(
+        {
+          assert(snapshotTestKit.persistedInStorage(persistenceId).size === 2 + NumOfNewSnapshotsSynchronizationSaves)
+        },
+        max = remainingOrDefault,
+      )
+    }
+
+    "delete snapshots matching the criteria if it successfully saves a snapshot" in new Fixture {
+      val settings = RaftSettings(
+        configFor(
+          deleteBeforeRelativeSequenceNumber = 2,
+          deleteOldSnapshots = true,
+        ),
+      )
+
+      // Arrange: save events and snapshots of SnapshotSyncManager.
+      persistenceTestKit.persistForRecovery(
+        persistenceId,
+        Seq(
+          SyncCompleted(Offset.noOffset),
+          SyncCompleted(Offset.noOffset),
+          SyncCompleted(Offset.noOffset),
+          SyncCompleted(Offset.noOffset),
+        ),
+      )
+      snapshotTestKit.persistForRecovery(
+        persistenceId,
+        Seq(
+          SnapshotMeta(sequenceNr = 2) -> SyncProgress(Offset.noOffset),
+          SnapshotMeta(sequenceNr = 4) -> SyncProgress(Offset.noOffset),
+        ),
+      )
+      snapshotTestKit.expectNextPersisted(persistenceId, SyncProgress(Offset.noOffset))
+      snapshotTestKit.expectNextPersisted(persistenceId, SyncProgress(Offset.noOffset))
+
+      // Act: run entity snapshot synchronization, which will trigger a snapshot save and deletion.
+      val snapshotSyncManager = spawnSnapshotSyncManager(settings)
+      runEntitySnapshotSynchronization(snapshotSyncManager)
+
+      // Assert:
+      snapshotTestKit.expectNextPersisted(persistenceId, SyncProgress(OffsetAfterSynchronizationCompletes))
+      awaitAssert {
+        assume(settings.snapshotSyncDeleteBeforeRelativeSequenceNr === NumOfNewEventsSynchronizationSaves.toLong)
+        assert(snapshotTestKit.persistedInStorage(persistenceId).size === 1 + NumOfNewSnapshotsSynchronizationSaves)
+      }
+    }
+
+    "not delete snapshots if it successfully saves a snapshot, but no snapshots match the criteria" in new Fixture {
+      val config = configFor(
+        deleteBeforeRelativeSequenceNumber = 10,
+        deleteOldSnapshots = true,
+      )
+
+      // Arrange: save events and snapshots of SnapshotSyncManager.
+      persistenceTestKit.persistForRecovery(
+        persistenceId,
+        Seq(
+          SyncCompleted(Offset.noOffset),
+          SyncCompleted(Offset.noOffset),
+          SyncCompleted(Offset.noOffset),
+          SyncCompleted(Offset.noOffset),
+        ),
+      )
+      snapshotTestKit.persistForRecovery(
+        persistenceId,
+        Seq(
+          SnapshotMeta(sequenceNr = 2) -> SyncProgress(Offset.noOffset),
+          SnapshotMeta(sequenceNr = 4) -> SyncProgress(Offset.noOffset),
+        ),
+      )
+      snapshotTestKit.expectNextPersisted(persistenceId, SyncProgress(Offset.noOffset))
+      snapshotTestKit.expectNextPersisted(persistenceId, SyncProgress(Offset.noOffset))
+
+      // Act: run entity snapshot synchronization, which will trigger a snapshot and deletion.
+      val snapshotSyncManager = spawnSnapshotSyncManager(config)
+      runEntitySnapshotSynchronization(snapshotSyncManager)
+
+      // Assert:
+      snapshotTestKit.expectNextPersisted(persistenceId, SyncProgress(OffsetAfterSynchronizationCompletes))
+      assertForDuration(
+        {
+          assert(snapshotTestKit.persistedInStorage(persistenceId).size === 2 + NumOfNewSnapshotsSynchronizationSaves)
+        },
+        max = remainingOrDefault,
+      )
+    }
+
+    "log a warning message if a snapshot deletion fails" ignore {
+      // TODO: Write this test after `SnapshotTestKit.failNextDelete` comes to trigger a snapshot deletion failure.
+      //   `SnapshotTestKit.failNextDelete` doesn't trigger a snapshot deletion failure at the time of writing.
+      //   While underlying implementation `PersistenceTestKitSnapshotPlugin.deleteAsync` is supposed to return a failed
+      //   Future, it always returns a successful Future.
+    }
+
+    "stop after the synchronization completes if no deletions are enabled." in new Fixture {
+      val config = configFor(
+        deleteBeforeRelativeSequenceNumber = 0,
+        deleteOldEvents = false,
+        deleteOldSnapshots = false,
+      )
+
+      // Act:
+      val snapshotSyncManager = spawnSnapshotSyncManager(config)
+      runEntitySnapshotSynchronization(snapshotSyncManager)
+
+      // Assert:
+      probe.watch(snapshotSyncManager)
+      probe.expectTerminated(snapshotSyncManager)
+    }
+
+    "stop after the event deletion succeeds if only event deletion is enabled." in new Fixture {
+      val config = configFor(
+        deleteBeforeRelativeSequenceNumber = 0,
+        deleteOldEvents = true,
+        deleteOldSnapshots = false,
+      )
+
+      // Act: run entity snapshot synchronization, which will trigger an event deletion.
+      val snapshotSyncManager = spawnSnapshotSyncManager(config)
+      runEntitySnapshotSynchronization(snapshotSyncManager)
+
+      // Assert:
+      probe.watch(snapshotSyncManager)
+      probe.expectTerminated(snapshotSyncManager)
+    }
+
+    "stop after the event deletion fails if only event deletion is enabled." in new Fixture {
+      val config = configFor(
+        deleteBeforeRelativeSequenceNumber = 0,
+        deleteOldEvents = true,
+        deleteOldSnapshots = false,
+      )
+
+      // Act: run entity snapshot synchronization, which will trigger en event deletion.
+      val snapshotSyncManager = spawnSnapshotSyncManager(config)
+      persistenceTestKit.failNextDelete(persistenceId)
+      runEntitySnapshotSynchronization(snapshotSyncManager)
+
+      // Assert:
+      probe.watch(snapshotSyncManager)
+      probe.expectTerminated(snapshotSyncManager)
+    }
+
+    "stop after the snapshot deletion succeeds if only snapshot deletion is enabled." in new Fixture {
+      val config = configFor(
+        deleteBeforeRelativeSequenceNumber = 0,
+        deleteOldEvents = false,
+        deleteOldSnapshots = true,
+      )
+
+      // Act: run entity snapshot synchronization, which will trigger a snapshot deletion.
+      val snapshotSyncManager = spawnSnapshotSyncManager(config)
+      runEntitySnapshotSynchronization(snapshotSyncManager)
+
+      // Assert:
+      probe.watch(snapshotSyncManager)
+      probe.expectTerminated(snapshotSyncManager)
+    }
+
+    "stop after the snapshot deletion fails if only snapshot deletion is enabled." ignore {
+      // TODO: Write this test after `SnapshotTestKit.failNextDelete` comes to trigger a snapshot deletion failure.
+      //   `SnapshotTestKit.failNextDelete` doesn't trigger a snapshot deletion failure at the time of writing.
+      //   While underlying implementation `PersistenceTestKitSnapshotPlugin.deleteAsync` is supposed to return a failed
+      //   Future, it always returns a successful Future.
+    }
+
+    "stop after both deletions succeed if both deletions are enabled." in new Fixture {
+      val config = configFor(
+        deleteBeforeRelativeSequenceNumber = 0,
+        deleteOldEvents = true,
+        deleteOldSnapshots = true,
+      )
+
+      // Act: run entity snapshot synchronization, which will trigger both deletions.
+      val snapshotSyncManager = spawnSnapshotSyncManager(config)
+      runEntitySnapshotSynchronization(snapshotSyncManager)
+
+      // Assert:
+      probe.watch(snapshotSyncManager)
+      probe.expectTerminated(snapshotSyncManager)
+    }
+
+    "stop after only the event deletion fails if both deletions are enabled." in new Fixture {
+      val config = configFor(
+        deleteBeforeRelativeSequenceNumber = 0,
+        deleteOldEvents = true,
+        deleteOldSnapshots = true,
+      )
+
+      // Act: run entity snapshot synchronization, which will trigger both deletions.
+      val snapshotSyncManager = spawnSnapshotSyncManager(config)
+      persistenceTestKit.failNextDelete(persistenceId)
+      runEntitySnapshotSynchronization(snapshotSyncManager)
+
+      // Assert:
+      probe.watch(snapshotSyncManager)
+      probe.expectTerminated(snapshotSyncManager)
+    }
+
+    "stop after only the snapshot deletion fails if both deletions are enabled." ignore {
+      // TODO: Write this test after `SnapshotTestKit.failNextDelete` comes to trigger a snapshot deletion failure.
+      //   `SnapshotTestKit.failNextDelete` doesn't trigger a snapshot deletion failure at the time of writing.
+      //   While underlying implementation `PersistenceTestKitSnapshotPlugin.deleteAsync` is supposed to return a failed
+      //   Future, it always returns a successful Future.
+    }
+
+    "stop after both deletions fail if both deletions are enabled." ignore {
+      // TODO: Write this test after `SnapshotTestKit.failNextDelete` comes to trigger a snapshot deletion failure.
+      //   `SnapshotTestKit.failNextDelete` doesn't trigger a snapshot deletion failure at the time of writing.
+      //   While underlying implementation `PersistenceTestKitSnapshotPlugin.deleteAsync` is supposed to return a failed
+      //   Future, it always returns a successful Future.
+    }
+
+  }
+
+}

--- a/docs/rollback_guide.md
+++ b/docs/rollback_guide.md
@@ -14,6 +14,15 @@ All clock synchronization gaps among all nodes should be less than a certain per
 less than 10 seconds. To configure this period, see [Configure the rollback tool](#configure-the-rollback-tool) for
 details.
 
+## WARNING
+
+`akka-entity-replication` (v.2.3.0 or later) supports deleting old events and snapshots. Once events or snapshots
+are deleted, a rollback to a timestamp that requires such deleted events or snapshots is impossible. At the time of
+writing, the rollback tool can't detect such deletions yet. If such a timestamp is specified, the rollback tool will
+delete all events and snapshots of the target Raft shard, or persistent actors of the target Raft shard will be
+inconsistent state. Please ensure that a rollback is possible by inspecting data stores if either event or snapshot
+deletion is enabled.
+
 ## Rollback Procedures
 
 ### 1. Disable the target Raft shard


### PR DESCRIPTION
Closes: https://github.com/lerna-stack/akka-entity-replication/issues/201

`akka-entity-replication` supports deleting old events and snapshots. This deletion feature is an opt-in feature (disabled is the default) since it only supports the Akka Persistence Cassandra. The deletion criteria is based on sequence number.

There are four related persistent actors:
* `lerna.akka.entityreplication.raft.RaftActor`
* `lerna.akka.entityreplication.raft.snapshot.sync.SnapshotSyncManager`
* `lerna.akka.entityreplication.raft.snapshot.SnapshotStore`
* `lerna.akka.entityreplication.raft.eventsourced.CommitLogStoreActor`

They delete old events and snapshots automatically when they save a snapshot. If a deletion fails, they will log a warning message.

The newly introduced settings are:
* `lerna.akka.entityreplication.raft.delete-old-events`
* `lerna.akka.entityreplication.raft.delete-old-snapshots`
* `lerna.akka.entityreplication.raft.delete-before-relative-sequence-nr`
* `lerna.akka.entityreplication.raft.snapshot-sync.delete-old-events`
* `lerna.akka.entityreplication.raft.snapshot-sync.delete-old-snapshots`
* `lerna.akka.entityreplication.raft.snapshot-sync.delete-before-relative-sequence-nr`
* `lerna.akka.entityreplication.raft.entity-snapshot-store.delete-old-events`
* `lerna.akka.entityreplication.raft.entity-snapshot-store.delete-old-snapshots`
* `lerna.akka.entityreplication.raft.entity-snapshot-store.delete-before-relative-sequence-nr`
* `lerna.akka.entityreplication.raft.eventsourced.persistence.delete-old-events`
* `lerna.akka.entityreplication.raft.eventsourced.persistence.delete-old-snapshots`
* `lerna.akka.entityreplication.raft.eventsourced.persistence.delete-before-relative-sequence-nr`

