### PR TITLE
Enable MiMa binary compatibility check of rollback-tool-cassandra

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -136,8 +136,7 @@ lazy val rollbackToolCassandra = (project in file("rollback-tool-cassandra"))
       ),
     ),
     // MiMa
-    mimaFailOnNoPrevious := false,      // TODO enable after the first stable version release
-    mimaPreviousArtifacts := Set.empty, // TODO set non empty after the first stable version release
+    mimaPreviousArtifacts := previousStableVersion.value.map(organization.value %% moduleName.value % _).toSet,
     mimaReportSignatureProblems := true,
   )
 

--- a/rollback-tool-cassandra/src/main/mima-filters/2.2.0.backwards.excludes/pr-203-rollback-deletes-only-target-tagged-events.excludes
+++ b/rollback-tool-cassandra/src/main/mima-filters/2.2.0.backwards.excludes/pr-203-rollback-deletes-only-target-tagged-events.excludes
@@ -1,0 +1,2 @@
+# CassandraPersistentActorRollback is a private class.
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.akka.entityreplication.rollback.cassandra.CassandraPersistentActorRollback.deleteTagView")


### PR DESCRIPTION
Enable MiMa binary compatibiltiy check of `akka-entity-replication-rollback-tool-cassandra`.

There is one potential problem, which is from https://github.com/lerna-stack/akka-entity-replication/pull/203 :

> https://github.com/lerna-stack/akka-entity-replication/actions/runs/4829005367/jobs/8603518330?pr=205
> ```
> Error:  akka-entity-replication-rollback-tool-cassandra: Failed binary compatibility check against com.lerna-stack:akka-entity-replication-rollback-tool-cassandra_2.13:2.2.0! Found 1 potential problems
> Error:   * method deleteTagView(java.lang.String)scala.concurrent.Future in class lerna.akka.entityreplication.rollback.cassandra.CassandraPersistentActorRollback does not have a correspondent in current version
> Error:     filter with: ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.akka.entityreplication.rollback.cassandra.CassandraPersistentActorRollback.deleteTagView")
> Error:  java.lang.RuntimeException: Failed binary compatibility check against com.lerna-stack:akka-entity-replication-rollback-tool-cassandra_2.13:2.2.0! Found 1 potential problems
> ```

It can be filtered since class `CassandraPersistentActorRollback` is private: