### PR TITLE
`CassandraPersistenceQueries` handles deleted partitions

### DIFF
--- a/rollback-tool-cassandra/src/main/scala/lerna/akka/entityreplication/rollback/cassandra/CassandraJournalSettings.scala
+++ b/rollback-tool-cassandra/src/main/scala/lerna/akka/entityreplication/rollback/cassandra/CassandraJournalSettings.scala
@@ -20,6 +20,8 @@ private object CassandraJournalSettings {
       pluginConfig.getString("journal.keyspace")
     val table =
       pluginConfig.getString("journal.table")
+    val metadataTable =
+      pluginConfig.getString("journal.metadata-table")
     val targetPartitionSize =
       pluginConfig.getLong("journal.target-partition-size")
     new CassandraJournalSettings(
@@ -27,6 +29,7 @@ private object CassandraJournalSettings {
       writeProfile,
       keyspace,
       table,
+      metadataTable,
       targetPartitionSize,
     )
   }
@@ -38,6 +41,7 @@ private final class CassandraJournalSettings private (
     val writeProfile: String,
     val keyspace: String,
     val table: String,
+    val metadataTable: String,
     val targetPartitionSize: Long,
 ) {
   require(
@@ -47,5 +51,8 @@ private final class CassandraJournalSettings private (
 
   /** The table name qualified with the keyspace name */
   def tableName: String = s"${keyspace}.${table}"
+
+  /** The metadata table name qualified with the keyspace name */
+  def metadataTableName: String = s"${keyspace}.${metadataTable}"
 
 }

--- a/rollback-tool-cassandra/src/main/scala/lerna/akka/entityreplication/rollback/cassandra/CassandraPersistenceQueries.scala
+++ b/rollback-tool-cassandra/src/main/scala/lerna/akka/entityreplication/rollback/cassandra/CassandraPersistenceQueries.scala
@@ -38,6 +38,8 @@ private final class CassandraPersistenceQueries(
     session.prepare(statements.selectMessagesFromAsc)
   private lazy val selectMessagesFromDescPreparedStatement: Future[PreparedStatement] =
     session.prepare(statements.selectMessagesFromDesc)
+  private lazy val selectDeletedToPreparedStatement: Future[PreparedStatement] =
+    session.prepare(statements.selectDeletedTo)
 
   import system.dispatcher
 
@@ -89,7 +91,18 @@ private final class CassandraPersistenceQueries(
             }
         }
     }
-    find(from, None, 0)
+    selectDeletedToSequenceNr(persistenceId).flatMap {
+      case Some(deletedToSequenceNr) =>
+        val possibleFromPartitionNr =
+          PartitionNr.fromSequenceNr(deletedToSequenceNr + 1, journalSettings.targetPartitionSize)
+        if (from <= possibleFromPartitionNr) {
+          find(possibleFromPartitionNr, Some(deletedToSequenceNr), 0)
+        } else {
+          find(from, None, 0)
+        }
+      case None =>
+        find(from, None, 0)
+    }
   }
 
   /** Returns the highest sequence number of the given partition
@@ -202,6 +215,29 @@ private final class CassandraPersistenceQueries(
       source(bs)
     }
     Source.futureSource(futureSource).mapMaterializedValue(_ => NotUsed)
+  }
+
+  /** Returns the highest deleted sequence number (called `deleted_to`)
+    *
+    * All events with sequence sequence numbers less than or equal to `deleted_to` have been deleted.
+    *
+    * If no events have been deleted, this method returns `Future.successful(None)`.
+    */
+  def selectDeletedToSequenceNr(persistenceId: String): Future[Option[SequenceNr]] = {
+    selectDeletedToPreparedStatement.flatMap { ps =>
+      val bs = ps.bind(persistenceId)
+      selectOne(bs)
+        .map { rowOption =>
+          rowOption
+            .map(_.getLong("deleted_to"))
+        }.flatMap {
+          case None | Some(0) =>
+            Future.successful(None)
+          case Some(deletedToSequenceNr) =>
+            assert(deletedToSequenceNr > 0)
+            Future.successful(Some(SequenceNr(deletedToSequenceNr)))
+        }
+    }
   }
 
   private def selectOne[T <: Statement[T]](statement: Statement[T]): Future[Option[Row]] = {

--- a/rollback-tool-cassandra/src/main/scala/lerna/akka/entityreplication/rollback/cassandra/CassandraPersistenceQueriesStatements.scala
+++ b/rollback-tool-cassandra/src/main/scala/lerna/akka/entityreplication/rollback/cassandra/CassandraPersistenceQueriesStatements.scala
@@ -40,4 +40,11 @@ private final class CassandraPersistenceQueriesStatements(
        ORDER BY sequence_nr DESC
        """
 
+  val selectDeletedTo: String =
+    s"""
+       SELECT deleted_to FROM ${journalSettings.metadataTableName}
+       WHERE
+         persistence_id = ?
+     """
+
 }

--- a/rollback-tool-cassandra/src/test/scala/lerna/akka/entityreplication/rollback/cassandra/CassandraJournalSettingsSpec.scala
+++ b/rollback-tool-cassandra/src/test/scala/lerna/akka/entityreplication/rollback/cassandra/CassandraJournalSettingsSpec.scala
@@ -14,6 +14,7 @@ final class CassandraJournalSettingsSpec extends WordSpec with Matchers {
       |journal {
       |  keyspace = "custom_akka"
       |  table = "custom_messages"
+      |  metadata-table = "custom_metadata"
       |  target-partition-size = 1000000
       |}
       |""".stripMargin)
@@ -26,6 +27,7 @@ final class CassandraJournalSettingsSpec extends WordSpec with Matchers {
       settings.writeProfile should be("akka-persistence-cassandra-profile")
       settings.keyspace should be("akka")
       settings.table should be("messages")
+      settings.metadataTable should be("metadata")
       settings.targetPartitionSize should be(500_000)
     }
 
@@ -35,6 +37,7 @@ final class CassandraJournalSettingsSpec extends WordSpec with Matchers {
       settings.writeProfile should be("custom_akka-persistence-cassandra-write-profile")
       settings.keyspace should be("custom_akka")
       settings.table should be("custom_messages")
+      settings.metadataTable should be("custom_metadata")
       settings.targetPartitionSize should be(1_000_000)
     }
 
@@ -77,6 +80,17 @@ final class CassandraJournalSettingsSpec extends WordSpec with Matchers {
       settings.keyspace should be("custom_akka")
       settings.table should be("custom_messages")
       settings.tableName should be("custom_akka.custom_messages")
+    }
+
+  }
+
+  "CassandraJournalSettings.metadataTableName" should {
+
+    "return the metadata table name qualified with the keyspace name" in {
+      val settings = CassandraJournalSettings(customPluginConfig)
+      settings.keyspace should be("custom_akka")
+      settings.metadataTable should be("custom_metadata")
+      settings.metadataTableName should be("custom_akka.custom_metadata")
     }
 
   }

--- a/rollback-tool-cassandra/src/test/scala/lerna/akka/entityreplication/rollback/cassandra/CassandraPersistenceQueriesSpec.scala
+++ b/rollback-tool-cassandra/src/test/scala/lerna/akka/entityreplication/rollback/cassandra/CassandraPersistenceQueriesSpec.scala
@@ -88,6 +88,114 @@ final class CassandraPersistenceQueriesSpec
       queries.findHighestSequenceNrAfter(persistenceId, SequenceNr(22)).futureValue should be(None)
     }
 
+    "find the highest sequence number after the given sequence number if all events are deleted" in {
+      val queries       = new CassandraPersistenceQueries(system, defaultSettings)
+      val probe         = TestProbe()
+      val persistenceId = nextPersistenceId()
+
+      // Prepare:
+      val actor: ActorRef = system.actorOf(TestPersistentActor.props(persistenceId))
+      for (sequenceNr <- 1 to 15) {
+        actor ! TestPersistentActor.PersistEvent(probe.ref)
+        probe.expectMsg(TestPersistentActor.Ack(sequenceNr))
+      }
+      actor ! TestPersistentActor.SaveSnapshot(probe.ref)
+      probe.expectMsg(TestPersistentActor.Ack(15))
+      actor ! TestPersistentActor.DeleteEventsTo(15, probe.ref)
+      probe.expectMsg(TestPersistentActor.Ack(15))
+
+      // Test prerequisites:
+      queries.selectDeletedToSequenceNr(persistenceId).futureValue should be(Some(SequenceNr(15)))
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(0)).futureValue should be(None)
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(1)).futureValue should be(None)
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(2)).futureValue should be(None)
+
+      // Test:
+      queries.findHighestSequenceNrAfter(persistenceId, SequenceNr(1)).futureValue should be(Some(SequenceNr(15)))
+      queries.findHighestSequenceNrAfter(persistenceId, SequenceNr(10)).futureValue should be(Some(SequenceNr(15)))
+      queries.findHighestSequenceNrAfter(persistenceId, SequenceNr(11)).futureValue should be(Some(SequenceNr(15)))
+      queries.findHighestSequenceNrAfter(persistenceId, SequenceNr(14)).futureValue should be(Some(SequenceNr(15)))
+      queries.findHighestSequenceNrAfter(persistenceId, SequenceNr(15)).futureValue should be(Some(SequenceNr(15)))
+      queries.findHighestSequenceNrAfter(persistenceId, SequenceNr(16)).futureValue should be(None)
+    }
+
+    "find the highest sequence number after the given sequence number if old events are deleted" in {
+      val queries       = new CassandraPersistenceQueries(system, defaultSettings)
+      val probe         = TestProbe()
+      val persistenceId = nextPersistenceId()
+
+      // Prepare:
+      val actor: ActorRef = system.actorOf(TestPersistentActor.props(persistenceId))
+      for (sequenceNr <- 1 to 25) {
+        actor ! TestPersistentActor.PersistEvent(probe.ref)
+        probe.expectMsg(TestPersistentActor.Ack(sequenceNr))
+      }
+      actor ! TestPersistentActor.SaveSnapshot(probe.ref)
+      probe.expectMsg(TestPersistentActor.Ack(25))
+      actor ! TestPersistentActor.DeleteEventsTo(22, probe.ref)
+      probe.expectMsg(TestPersistentActor.Ack(22))
+
+      // Test prerequisites:
+      queries.selectDeletedToSequenceNr(persistenceId).futureValue should be(Some(SequenceNr(22)))
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(0)).futureValue should be(None)
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(1)).futureValue should be(None)
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(2)).futureValue should be(Some(SequenceNr(25)))
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(3)).futureValue should be(None)
+
+      // Test:
+      queries.findHighestSequenceNrAfter(persistenceId, SequenceNr(1)).futureValue should be(Some(SequenceNr(25)))
+      queries.findHighestSequenceNrAfter(persistenceId, SequenceNr(10)).futureValue should be(Some(SequenceNr(25)))
+      queries.findHighestSequenceNrAfter(persistenceId, SequenceNr(11)).futureValue should be(Some(SequenceNr(25)))
+      queries.findHighestSequenceNrAfter(persistenceId, SequenceNr(20)).futureValue should be(Some(SequenceNr(25)))
+      queries.findHighestSequenceNrAfter(persistenceId, SequenceNr(21)).futureValue should be(Some(SequenceNr(25)))
+      queries.findHighestSequenceNrAfter(persistenceId, SequenceNr(22)).futureValue should be(Some(SequenceNr(25)))
+      queries.findHighestSequenceNrAfter(persistenceId, SequenceNr(23)).futureValue should be(Some(SequenceNr(25)))
+      queries.findHighestSequenceNrAfter(persistenceId, SequenceNr(24)).futureValue should be(Some(SequenceNr(25)))
+      queries.findHighestSequenceNrAfter(persistenceId, SequenceNr(25)).futureValue should be(Some(SequenceNr(25)))
+      queries.findHighestSequenceNrAfter(persistenceId, SequenceNr(26)).futureValue should be(None)
+    }
+
+    "find the highest sequence number after the given sequence number " +
+    "if old events are deleted, and an empty partition exists" in {
+      val queries       = new CassandraPersistenceQueries(system, defaultSettings)
+      val probe         = TestProbe()
+      val persistenceId = nextPersistenceId()
+
+      // Prepare:
+      val actor: ActorRef = system.actorOf(TestPersistentActor.props(persistenceId))
+      for (sequenceNr <- 1 to 30) {
+        actor ! TestPersistentActor.PersistEvent(probe.ref)
+        probe.expectMsg(TestPersistentActor.Ack(sequenceNr))
+      }
+      actor ! TestPersistentActor.SaveSnapshot(probe.ref)
+      probe.expectMsg(TestPersistentActor.Ack(30))
+      actor ! TestPersistentActor.DeleteEventsTo(30, probe.ref)
+      probe.expectMsg(TestPersistentActor.Ack(30))
+      actor ! TestPersistentActor.PersistEventsAtomically(numOfEvents = 11, replyTo = probe.ref)
+      probe.expectMsg(TestPersistentActor.Ack(41))
+
+      // Test prerequisites:
+      queries.selectDeletedToSequenceNr(persistenceId).futureValue should be(Some(SequenceNr(30)))
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(0)).futureValue should be(None)
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(1)).futureValue should be(None)
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(2)).futureValue should be(None)
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(3)).futureValue should be(None)
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(4)).futureValue should be(Some(SequenceNr(41)))
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(5)).futureValue should be(None)
+
+      // Test:
+      queries.findHighestSequenceNrAfter(persistenceId, SequenceNr(1)).futureValue should be(Some(SequenceNr(41)))
+      queries.findHighestSequenceNrAfter(persistenceId, SequenceNr(10)).futureValue should be(Some(SequenceNr(41)))
+      queries.findHighestSequenceNrAfter(persistenceId, SequenceNr(11)).futureValue should be(Some(SequenceNr(41)))
+      queries.findHighestSequenceNrAfter(persistenceId, SequenceNr(20)).futureValue should be(Some(SequenceNr(41)))
+      queries.findHighestSequenceNrAfter(persistenceId, SequenceNr(21)).futureValue should be(Some(SequenceNr(41)))
+      queries.findHighestSequenceNrAfter(persistenceId, SequenceNr(30)).futureValue should be(Some(SequenceNr(41)))
+      queries.findHighestSequenceNrAfter(persistenceId, SequenceNr(31)).futureValue should be(Some(SequenceNr(41)))
+      queries.findHighestSequenceNrAfter(persistenceId, SequenceNr(40)).futureValue should be(Some(SequenceNr(41)))
+      queries.findHighestSequenceNrAfter(persistenceId, SequenceNr(41)).futureValue should be(Some(SequenceNr(41)))
+      queries.findHighestSequenceNrAfter(persistenceId, SequenceNr(42)).futureValue should be(None)
+    }
+
   }
 
   "CassandraPersistenceQueries.findHighestSequenceNr" should {
@@ -142,6 +250,101 @@ final class CassandraPersistenceQueriesSpec
       queries.findHighestSequenceNr(persistenceId, PartitionNr(1)).futureValue should be(Some(SequenceNr(21)))
       queries.findHighestSequenceNr(persistenceId, PartitionNr(2)).futureValue should be(Some(SequenceNr(21)))
       queries.findHighestSequenceNr(persistenceId, PartitionNr(3)).futureValue should be(None)
+    }
+
+    "find the highest sequence number from the given partition or above if all events are deleted" in {
+      val queries       = new CassandraPersistenceQueries(system, defaultSettings)
+      val probe         = TestProbe()
+      val persistenceId = nextPersistenceId()
+
+      // Prepare:
+      val actor: ActorRef = system.actorOf(TestPersistentActor.props(persistenceId))
+      for (sequenceNr <- 1 to 15) {
+        actor ! TestPersistentActor.PersistEvent(probe.ref)
+        probe.expectMsg(TestPersistentActor.Ack(sequenceNr))
+      }
+      actor ! TestPersistentActor.SaveSnapshot(probe.ref)
+      probe.expectMsg(TestPersistentActor.Ack(15))
+      actor ! TestPersistentActor.DeleteEventsTo(15, probe.ref)
+      probe.expectMsg(TestPersistentActor.Ack(15))
+
+      // Test prerequisites:
+      queries.selectDeletedToSequenceNr(persistenceId).futureValue should be(Some(SequenceNr(15)))
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(0)).futureValue should be(None)
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(1)).futureValue should be(None)
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(2)).futureValue should be(None)
+
+      // Test:
+      queries.findHighestSequenceNr(persistenceId, PartitionNr(0)).futureValue should be(Some(SequenceNr(15)))
+      queries.findHighestSequenceNr(persistenceId, PartitionNr(1)).futureValue should be(Some(SequenceNr(15)))
+      queries.findHighestSequenceNr(persistenceId, PartitionNr(2)).futureValue should be(None)
+    }
+
+    "find the highest sequence number from the given partition or above if old events are deleted" in {
+      val queries       = new CassandraPersistenceQueries(system, defaultSettings)
+      val probe         = TestProbe()
+      val persistenceId = nextPersistenceId()
+
+      // Prepare:
+      val actor: ActorRef = system.actorOf(TestPersistentActor.props(persistenceId))
+      for (sequenceNr <- 1 to 25) {
+        actor ! TestPersistentActor.PersistEvent(probe.ref)
+        probe.expectMsg(TestPersistentActor.Ack(sequenceNr))
+      }
+      actor ! TestPersistentActor.SaveSnapshot(probe.ref)
+      probe.expectMsg(TestPersistentActor.Ack(25))
+      actor ! TestPersistentActor.DeleteEventsTo(22, probe.ref)
+      probe.expectMsg(TestPersistentActor.Ack(22))
+
+      // Test prerequisites:
+      queries.selectDeletedToSequenceNr(persistenceId).futureValue should be(Some(SequenceNr(22)))
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(0)).futureValue should be(None)
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(1)).futureValue should be(None)
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(2)).futureValue should be(Some(SequenceNr(25)))
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(3)).futureValue should be(None)
+
+      // Test:
+      queries.findHighestSequenceNr(persistenceId, PartitionNr(0)).futureValue should be(Some(SequenceNr(25)))
+      queries.findHighestSequenceNr(persistenceId, PartitionNr(1)).futureValue should be(Some(SequenceNr(25)))
+      queries.findHighestSequenceNr(persistenceId, PartitionNr(2)).futureValue should be(Some(SequenceNr(25)))
+      queries.findHighestSequenceNr(persistenceId, PartitionNr(3)).futureValue should be(None)
+    }
+
+    "find the highest sequence number from the given partition or above " +
+    "if old events are deleted, and an empty partition exists" in {
+      val queries       = new CassandraPersistenceQueries(system, defaultSettings)
+      val probe         = TestProbe()
+      val persistenceId = nextPersistenceId()
+
+      // Prepare:
+      val actor: ActorRef = system.actorOf(TestPersistentActor.props(persistenceId))
+      for (sequenceNr <- 1 to 30) {
+        actor ! TestPersistentActor.PersistEvent(probe.ref)
+        probe.expectMsg(TestPersistentActor.Ack(sequenceNr))
+      }
+      actor ! TestPersistentActor.SaveSnapshot(probe.ref)
+      probe.expectMsg(TestPersistentActor.Ack(30))
+      actor ! TestPersistentActor.DeleteEventsTo(30, probe.ref)
+      probe.expectMsg(TestPersistentActor.Ack(30))
+      actor ! TestPersistentActor.PersistEventsAtomically(numOfEvents = 11, replyTo = probe.ref)
+      probe.expectMsg(TestPersistentActor.Ack(41))
+
+      // Test prerequisites:
+      queries.selectDeletedToSequenceNr(persistenceId).futureValue should be(Some(SequenceNr(30)))
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(0)).futureValue should be(None)
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(1)).futureValue should be(None)
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(2)).futureValue should be(None)
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(3)).futureValue should be(None)
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(4)).futureValue should be(Some(SequenceNr(41)))
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(5)).futureValue should be(None)
+
+      // Test:
+      queries.findHighestSequenceNr(persistenceId, PartitionNr(0)).futureValue should be(Some(SequenceNr(41)))
+      queries.findHighestSequenceNr(persistenceId, PartitionNr(1)).futureValue should be(Some(SequenceNr(41)))
+      queries.findHighestSequenceNr(persistenceId, PartitionNr(2)).futureValue should be(Some(SequenceNr(41)))
+      queries.findHighestSequenceNr(persistenceId, PartitionNr(3)).futureValue should be(Some(SequenceNr(41)))
+      queries.findHighestSequenceNr(persistenceId, PartitionNr(4)).futureValue should be(Some(SequenceNr(41)))
+      queries.findHighestSequenceNr(persistenceId, PartitionNr(5)).futureValue should be(None)
     }
 
   }
@@ -220,6 +423,101 @@ final class CassandraPersistenceQueriesSpec
       queries.findHighestPartitionNr(persistenceId, PartitionNr(3)).futureValue should be(None)
     }
 
+    "find the highest partition number after the given partition if all events are deleted" in {
+      val queries       = new CassandraPersistenceQueries(system, defaultSettings)
+      val probe         = TestProbe()
+      val persistenceId = nextPersistenceId()
+
+      // Prepare:
+      val actor: ActorRef = system.actorOf(TestPersistentActor.props(persistenceId))
+      for (sequenceNr <- 1 to 15) {
+        actor ! TestPersistentActor.PersistEvent(probe.ref)
+        probe.expectMsg(TestPersistentActor.Ack(sequenceNr))
+      }
+      actor ! TestPersistentActor.SaveSnapshot(probe.ref)
+      probe.expectMsg(TestPersistentActor.Ack(15))
+      actor ! TestPersistentActor.DeleteEventsTo(15, probe.ref)
+      probe.expectMsg(TestPersistentActor.Ack(15))
+
+      // Test prerequisites:
+      queries.selectDeletedToSequenceNr(persistenceId).futureValue should be(Some(SequenceNr(15)))
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(0)).futureValue should be(None)
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(1)).futureValue should be(None)
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(2)).futureValue should be(None)
+
+      // Test:
+      queries.findHighestPartitionNr(persistenceId, PartitionNr(0)).futureValue should be(Some(PartitionNr(1)))
+      queries.findHighestPartitionNr(persistenceId, PartitionNr(1)).futureValue should be(Some(PartitionNr(1)))
+      queries.findHighestPartitionNr(persistenceId, PartitionNr(2)).futureValue should be(None)
+    }
+
+    "find the highest partition number after the given partition if old events are deleted" in {
+      val queries       = new CassandraPersistenceQueries(system, defaultSettings)
+      val probe         = TestProbe()
+      val persistenceId = nextPersistenceId()
+
+      // Prepare:
+      val actor: ActorRef = system.actorOf(TestPersistentActor.props(persistenceId))
+      for (sequenceNr <- 1 to 25) {
+        actor ! TestPersistentActor.PersistEvent(probe.ref)
+        probe.expectMsg(TestPersistentActor.Ack(sequenceNr))
+      }
+      actor ! TestPersistentActor.SaveSnapshot(probe.ref)
+      probe.expectMsg(TestPersistentActor.Ack(25))
+      actor ! TestPersistentActor.DeleteEventsTo(22, probe.ref)
+      probe.expectMsg(TestPersistentActor.Ack(22))
+
+      // Test prerequisites:
+      queries.selectDeletedToSequenceNr(persistenceId).futureValue should be(Some(SequenceNr(22)))
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(0)).futureValue should be(None)
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(1)).futureValue should be(None)
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(2)).futureValue should be(Some(SequenceNr(25)))
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(3)).futureValue should be(None)
+
+      // Test:
+      queries.findHighestPartitionNr(persistenceId, PartitionNr(0)).futureValue should be(Some(PartitionNr(2)))
+      queries.findHighestPartitionNr(persistenceId, PartitionNr(1)).futureValue should be(Some(PartitionNr(2)))
+      queries.findHighestPartitionNr(persistenceId, PartitionNr(2)).futureValue should be(Some(PartitionNr(2)))
+      queries.findHighestPartitionNr(persistenceId, PartitionNr(3)).futureValue should be(None)
+    }
+
+    "find the highest partition number after the given partition " +
+    "if old events are deleted, and an empty partition exists" in {
+      val queries       = new CassandraPersistenceQueries(system, defaultSettings)
+      val probe         = TestProbe()
+      val persistenceId = nextPersistenceId()
+
+      // Prepare:
+      val actor: ActorRef = system.actorOf(TestPersistentActor.props(persistenceId))
+      for (sequenceNr <- 1 to 30) {
+        actor ! TestPersistentActor.PersistEvent(probe.ref)
+        probe.expectMsg(TestPersistentActor.Ack(sequenceNr))
+      }
+      actor ! TestPersistentActor.SaveSnapshot(probe.ref)
+      probe.expectMsg(TestPersistentActor.Ack(30))
+      actor ! TestPersistentActor.DeleteEventsTo(30, probe.ref)
+      probe.expectMsg(TestPersistentActor.Ack(30))
+      actor ! TestPersistentActor.PersistEventsAtomically(numOfEvents = 11, replyTo = probe.ref)
+      probe.expectMsg(TestPersistentActor.Ack(41))
+
+      // Test prerequisites:
+      queries.selectDeletedToSequenceNr(persistenceId).futureValue should be(Some(SequenceNr(30)))
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(0)).futureValue should be(None)
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(1)).futureValue should be(None)
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(2)).futureValue should be(None)
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(3)).futureValue should be(None)
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(4)).futureValue should be(Some(SequenceNr(41)))
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(5)).futureValue should be(None)
+
+      // Test:
+      queries.findHighestPartitionNr(persistenceId, PartitionNr(0)).futureValue should be(Some(PartitionNr(4)))
+      queries.findHighestPartitionNr(persistenceId, PartitionNr(1)).futureValue should be(Some(PartitionNr(4)))
+      queries.findHighestPartitionNr(persistenceId, PartitionNr(2)).futureValue should be(Some(PartitionNr(4)))
+      queries.findHighestPartitionNr(persistenceId, PartitionNr(3)).futureValue should be(Some(PartitionNr(4)))
+      queries.findHighestPartitionNr(persistenceId, PartitionNr(4)).futureValue should be(Some(PartitionNr(4)))
+      queries.findHighestPartitionNr(persistenceId, PartitionNr(5)).futureValue should be(None)
+    }
+
   }
 
   "CassandraPersistenceQueries.currentEventsAfter" should {
@@ -285,6 +583,104 @@ final class CassandraPersistenceQueriesSpec
       all(events.map(_.persistenceId)) should be(persistenceId)
       events.map(_.sequenceNr) should be((9 to 21).map(SequenceNr(_)))
       events.map(_.event) should be((9 to 21).map(TestPersistentActor.Event(_)))
+      all(events.map(_.offset)) shouldBe a[TimeBasedUUID]
+      all(events.map(_.tags)) should be(empty)
+    }
+
+    "return an empty source if all events are deleted" in {
+      val queries       = new CassandraPersistenceQueries(system, defaultSettings)
+      val probe         = TestProbe()
+      val persistenceId = nextPersistenceId()
+
+      // Prepare:
+      val actor: ActorRef = system.actorOf(TestPersistentActor.props(persistenceId))
+      for (sequenceNr <- 1 to 15) {
+        actor ! TestPersistentActor.PersistEvent(probe.ref)
+        probe.expectMsg(TestPersistentActor.Ack(sequenceNr))
+      }
+      actor ! TestPersistentActor.SaveSnapshot(probe.ref)
+      probe.expectMsg(TestPersistentActor.Ack(15))
+      actor ! TestPersistentActor.DeleteEventsTo(15, probe.ref)
+      probe.expectMsg(TestPersistentActor.Ack(15))
+
+      // Test prerequisites:
+      queries.selectDeletedToSequenceNr(persistenceId).futureValue should be(Some(SequenceNr(15)))
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(0)).futureValue should be(None)
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(1)).futureValue should be(None)
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(2)).futureValue should be(None)
+
+      // Test:
+      queries.currentEventsAfter(persistenceId, SequenceNr(9)).runWith(Sink.seq).futureValue should be(empty)
+    }
+
+    "return a source that emits current events after th given sequence number inclusive " +
+    "if old events are deleted" in {
+      val queries       = new CassandraPersistenceQueries(system, defaultSettings)
+      val probe         = TestProbe()
+      val persistenceId = nextPersistenceId()
+
+      // Prepare:
+      val actor: ActorRef = system.actorOf(TestPersistentActor.props(persistenceId))
+      for (sequenceNr <- 1 to 25) {
+        actor ! TestPersistentActor.PersistEvent(probe.ref)
+        probe.expectMsg(TestPersistentActor.Ack(sequenceNr))
+      }
+      actor ! TestPersistentActor.SaveSnapshot(probe.ref)
+      probe.expectMsg(TestPersistentActor.Ack(25))
+      actor ! TestPersistentActor.DeleteEventsTo(22, probe.ref)
+      probe.expectMsg(TestPersistentActor.Ack(22))
+
+      // Test prerequisites:
+      queries.selectDeletedToSequenceNr(persistenceId).futureValue should be(Some(SequenceNr(22)))
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(0)).futureValue should be(None)
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(1)).futureValue should be(None)
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(2)).futureValue should be(Some(SequenceNr(25)))
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(3)).futureValue should be(None)
+
+      // Test:
+      val events =
+        queries.currentEventsAfter(persistenceId, SequenceNr(9)).runWith(Sink.seq).futureValue
+      all(events.map(_.persistenceId)) should be(persistenceId)
+      events.map(_.sequenceNr) should be((23 to 25).map(SequenceNr(_)))
+      events.map(_.event) should be((23 to 25).map(TestPersistentActor.Event(_)))
+      all(events.map(_.offset)) shouldBe a[TimeBasedUUID]
+      all(events.map(_.tags)) should be(empty)
+    }
+
+    "return a source that emits current events after th given sequence number inclusive " +
+    "if old events are deleted, and an empty partition exists" in {
+      val queries       = new CassandraPersistenceQueries(system, defaultSettings)
+      val probe         = TestProbe()
+      val persistenceId = nextPersistenceId()
+
+      // Prepare:
+      val actor: ActorRef = system.actorOf(TestPersistentActor.props(persistenceId))
+      for (sequenceNr <- 1 to 30) {
+        actor ! TestPersistentActor.PersistEvent(probe.ref)
+        probe.expectMsg(TestPersistentActor.Ack(sequenceNr))
+      }
+      actor ! TestPersistentActor.SaveSnapshot(probe.ref)
+      probe.expectMsg(TestPersistentActor.Ack(30))
+      actor ! TestPersistentActor.DeleteEventsTo(30, probe.ref)
+      probe.expectMsg(TestPersistentActor.Ack(30))
+      actor ! TestPersistentActor.PersistEventsAtomically(numOfEvents = 11, replyTo = probe.ref)
+      probe.expectMsg(TestPersistentActor.Ack(41))
+
+      // Test prerequisites:
+      queries.selectDeletedToSequenceNr(persistenceId).futureValue should be(Some(SequenceNr(30)))
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(0)).futureValue should be(None)
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(1)).futureValue should be(None)
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(2)).futureValue should be(None)
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(3)).futureValue should be(None)
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(4)).futureValue should be(Some(SequenceNr(41)))
+      queries.selectHighestSequenceNr(persistenceId, PartitionNr(5)).futureValue should be(None)
+
+      // Test:
+      val events =
+        queries.currentEventsAfter(persistenceId, SequenceNr(9)).runWith(Sink.seq).futureValue
+      all(events.map(_.persistenceId)) should be(persistenceId)
+      events.map(_.sequenceNr) should be((31 to 41).map(SequenceNr(_)))
+      events.map(_.event) should be((31 to 41).map(TestPersistentActor.Event(_)))
       all(events.map(_.offset)) shouldBe a[TimeBasedUUID]
       all(events.map(_.tags)) should be(empty)
     }
@@ -456,6 +852,54 @@ final class CassandraPersistenceQueriesSpec
       eventsOfPartition2 should be(empty)
     }
 
+  }
+
+  "CassandraPersistenceQueries.selectDeletedToSequenceNr" should {
+
+    "return None if no events are persisted" in {
+      val queries       = new CassandraPersistenceQueries(system, defaultSettings)
+      val persistenceId = nextPersistenceId()
+
+      // Prepare:
+      val _: ActorRef = system.actorOf(TestPersistentActor.props(persistenceId))
+
+      // Test:
+      queries.selectDeletedToSequenceNr(persistenceId).futureValue should be(None)
+    }
+  }
+
+  "return None if no events are deleted" in {
+    val queries       = new CassandraPersistenceQueries(system, defaultSettings)
+    val probe         = TestProbe()
+    val persistenceId = nextPersistenceId()
+
+    // Prepare:
+    val actor: ActorRef = system.actorOf(TestPersistentActor.props(persistenceId))
+    actor ! TestPersistentActor.PersistEvent(probe.ref)
+    probe.expectMsg(TestPersistentActor.Ack(1))
+
+    // Test:
+    queries.selectDeletedToSequenceNr(persistenceId).futureValue should be(None)
+  }
+
+  "return the highest deleted sequence number (`deleted_to`) if events are deleted" in {
+    val queries       = new CassandraPersistenceQueries(system, defaultSettings)
+    val probe         = TestProbe()
+    val persistenceId = nextPersistenceId()
+
+    // Prepare:
+    val actor: ActorRef = system.actorOf(TestPersistentActor.props(persistenceId))
+    for (sequenceNr <- 1 to 5) {
+      actor ! TestPersistentActor.PersistEvent(probe.ref)
+      probe.expectMsg(TestPersistentActor.Ack(sequenceNr))
+    }
+    actor ! TestPersistentActor.SaveSnapshot(probe.ref)
+    probe.expectMsg(TestPersistentActor.Ack(5))
+
+    // Test:
+    actor ! TestPersistentActor.DeleteEventsTo(3, probe.ref)
+    probe.expectMsg(TestPersistentActor.Ack(3))
+    queries.selectDeletedToSequenceNr(persistenceId).futureValue should be(Some(SequenceNr(3)))
   }
 
 }


### PR DESCRIPTION
Closes #207, #208 

By using the highest deleted sequence number (`deleted_to`), `CassandraPersistenceQueries` handles deleted partitions (those partitions' all events have been deleted).

`deleted_to` is described as:
* https://doc.akka.io/docs/akka-persistence-cassandra/1.0.5/journal.html#schema
* https://github.com/akka/akka-persistence-cassandra/blob/v1.0.5/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala#L526-L628