### PR TITLE
Rollback preparation fails if required data have been deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `CassandraPersistenceQueries.currentEventsBefore` skips deleted partitions
   [#208](https://github.com/lerna-stack/akka-entity-replication/issues/208),
   [PR#209](https://github.com/lerna-stack/akka-entity-replication/pull/209)
+- Rollback preparation fails if required data have been deleted
+  [#206](https://github.com/lerna-stack/akka-entity-replication/issues/206),
+  [PR#210](https://github.com/lerna-stack/akka-entity-replication/pull/210)
 
 ### Fixed
 - Dead letters about ReplicationRegion$Passivate continue

--- a/docs/rollback_guide.md
+++ b/docs/rollback_guide.md
@@ -17,11 +17,9 @@ details.
 ## WARNING
 
 `akka-entity-replication` (v.2.3.0 or later) supports deleting old events and snapshots. Once events or snapshots
-are deleted, a rollback to a timestamp that requires such deleted events or snapshots is impossible. At the time of
-writing, the rollback tool can't detect such deletions yet. If such a timestamp is specified, the rollback tool will
-delete all events and snapshots of the target Raft shard, or persistent actors of the target Raft shard will be
-inconsistent state. Please ensure that a rollback is possible by inspecting data stores if either event or snapshot
-deletion is enabled.
+have been deleted, a rollback to a timestamp that requires such deleted events or snapshots is impossible. The rollback
+tool can detect such deletions. If such a timestamp is specified, the rollback tool fails during preparation and doesn't
+issue any deletion of data for the rollback.
 
 ## Rollback Procedures
 

--- a/rollback-tool-cassandra/src/main/mima-filters/2.2.0.backwards.excludes/pr-210-rollback-preparation-fails-if-required-data-have-been-deleted
+++ b/rollback-tool-cassandra/src/main/mima-filters/2.2.0.backwards.excludes/pr-210-rollback-preparation-fails-if-required-data-have-been-deleted
@@ -1,0 +1,20 @@
+# PersistenceQueries#TaggedEventEnvelope is private:
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.akka.entityreplication.rollback.PersistenceQueries#TaggedEventEnvelope.copy")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("lerna.akka.entityreplication.rollback.PersistenceQueries#TaggedEventEnvelope.copy$default$5")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("lerna.akka.entityreplication.rollback.PersistenceQueries#TaggedEventEnvelope.copy$default$6")
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.akka.entityreplication.rollback.PersistenceQueries#TaggedEventEnvelope.this")
+ProblemFilters.exclude[MissingTypesProblem]("lerna.akka.entityreplication.rollback.PersistenceQueries$TaggedEventEnvelope$")
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.akka.entityreplication.rollback.PersistenceQueries#TaggedEventEnvelope.apply")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("lerna.akka.entityreplication.rollback.PersistenceQueries#TaggedEventEnvelope.unapply")
+
+# PersistentActorRollback is private:
+ProblemFilters.exclude[ReversedMissingMethodProblem]("lerna.akka.entityreplication.rollback.PersistentActorRollback.findRollbackRequirements")
+
+# RaftEventSourcedPersistence is private:
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.akka.entityreplication.rollback.RaftEventSourcedPersistence.this")
+
+# RaftPersistence is private:
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.akka.entityreplication.rollback.RaftPersistence.this")
+
+# CassandraSnapshotSettings is private:
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.akka.entityreplication.rollback.cassandra.CassandraSnapshotSettings.this")

--- a/rollback-tool-cassandra/src/main/scala/lerna/akka/entityreplication/rollback/DefaultRollbackRequirementsVerifier.scala
+++ b/rollback-tool-cassandra/src/main/scala/lerna/akka/entityreplication/rollback/DefaultRollbackRequirementsVerifier.scala
@@ -1,0 +1,87 @@
+package lerna.akka.entityreplication.rollback
+
+import akka.Done
+import akka.actor.{ ActorSystem, ClassicActorSystemProvider }
+
+import java.time.Instant
+import scala.concurrent.Future
+
+/** @inheritdoc */
+private final class DefaultRollbackRequirementsVerifier(
+    systemProvider: ClassicActorSystemProvider,
+    rollback: PersistentActorRollback,
+    timestampHintFinder: RollbackTimestampHintFinder,
+) extends RollbackRequirementsVerifier {
+
+  private implicit val system: ActorSystem =
+    systemProvider.classicSystem
+
+  import system.dispatcher
+
+  /** @inheritdoc */
+  override def verify(
+      persistenceId: String,
+      toSequenceNr: Option[SequenceNr],
+      toTimestampHintOpt: Option[Instant],
+  ): Future[Done] = {
+    rollback.findRollbackRequirements(persistenceId).flatMap { requirements =>
+      assert(requirements.persistenceId == persistenceId)
+      toSequenceNr match {
+        case Some(sequenceNr) =>
+          if (sequenceNr >= requirements.lowestSequenceNr) {
+            Future.successful(Done)
+          } else {
+            tryFindRollbackTimestampHint(requirements, toTimestampHintOpt)
+              .flatMap { rollbackTimestampHintOpt =>
+                Future.failed(
+                  new RollbackRequirementsNotFulfilled(
+                    s"Rollback to sequence number [${sequenceNr.value}] for the persistent actor [${persistenceId}] is impossible" +
+                    s" since the sequence number should be greater than or equal to [${requirements.lowestSequenceNr.value}]." +
+                    rollbackTimestampHintOpt.fold("")(" " + _),
+                  ),
+                )
+              }
+          }
+        case None =>
+          if (requirements.lowestSequenceNr == SequenceNr(1)) {
+            Future.successful(Done)
+          } else {
+            tryFindRollbackTimestampHint(requirements, toTimestampHintOpt)
+              .flatMap { rollbackTimestampHintOpt =>
+                Future.failed(
+                  new RollbackRequirementsNotFulfilled(
+                    s"Deleting all data for the persistent actor [${persistenceId}] is impossible" +
+                    " since already deleted events might contain required data for consistency with other persistent actors." +
+                    rollbackTimestampHintOpt.fold("")(" " + _),
+                  ),
+                )
+              }
+          }
+      }
+    }
+  }
+
+  private def tryFindRollbackTimestampHint(
+      requirements: PersistentActorRollback.RollbackRequirements,
+      toTimestampHintOpt: Option[Instant],
+  ): Future[Option[String]] = {
+    toTimestampHintOpt match {
+      case Some(toTimestamp) =>
+        timestampHintFinder
+          .findTimestampHint(requirements)
+          .transform { hintOrError =>
+            hintOrError
+              .map { hint =>
+                s"Hint: rollback timestamp [$toTimestamp] should be newer than timestamp [${hint.timestamp}] of sequence number [${hint.sequenceNr.value}], at least."
+              }.recover { cause =>
+                s"Hint: not available due to [${cause.getClass.getCanonicalName}]: ${cause.getMessage}]."
+              }
+              .map(Option.apply)
+          }
+      case None =>
+        // Not needed for non-timestamp-based rollback.
+        Future.successful(None)
+    }
+  }
+
+}

--- a/rollback-tool-cassandra/src/main/scala/lerna/akka/entityreplication/rollback/LinearRollbackTimestampHintFinder.scala
+++ b/rollback-tool-cassandra/src/main/scala/lerna/akka/entityreplication/rollback/LinearRollbackTimestampHintFinder.scala
@@ -1,0 +1,46 @@
+package lerna.akka.entityreplication.rollback
+import akka.actor.{ ActorSystem, ClassicActorSystemProvider }
+import akka.stream.scaladsl.Sink
+
+import java.time.Instant
+import scala.concurrent.Future
+
+/** @inheritdoc */
+private final class LinearRollbackTimestampHintFinder(
+    systemProvider: ClassicActorSystemProvider,
+    queries: PersistenceQueries,
+) extends RollbackTimestampHintFinder {
+
+  private implicit val system: ActorSystem =
+    systemProvider.classicSystem
+
+  import system.dispatcher
+
+  /** @inheritdoc */
+  override def findTimestampHint(
+      requirements: PersistentActorRollback.RollbackRequirements,
+  ): Future[RollbackTimestampHintFinder.TimestampHint] = {
+    // NOTE: In most cases, an event with `lowestSequenceNr` or `lowestSequenceNr+1` exists.
+    // TODO Search a timestamp hint from snapshots since the persistent actor can delete the event with `lowestSequenceNr`.
+    queries
+      .currentEventsAfter(requirements.persistenceId, requirements.lowestSequenceNr)
+      .runWith(Sink.headOption)
+      .flatMap {
+        case Some(hintEvent) =>
+          val hint = RollbackTimestampHintFinder.TimestampHint(
+            requirements.persistenceId,
+            hintEvent.sequenceNr,
+            Instant.ofEpochMilli(hintEvent.timestamp),
+          )
+          Future.successful(hint)
+        case None =>
+          Future.failed(
+            new RollbackTimestampHintNotFound(
+              s"no events of persistenceId=[${requirements.persistenceId}] with a sequence number" +
+              s" greater than or equal to lowestSequenceNr=[${requirements.lowestSequenceNr.value}]",
+            ),
+          )
+      }
+  }
+
+}

--- a/rollback-tool-cassandra/src/main/scala/lerna/akka/entityreplication/rollback/PersistenceQueries.scala
+++ b/rollback-tool-cassandra/src/main/scala/lerna/akka/entityreplication/rollback/PersistenceQueries.scala
@@ -14,6 +14,7 @@ private object PersistenceQueries {
       sequenceNr: SequenceNr,
       event: Any,
       offset: Offset,
+      timestamp: Long,
       tags: Set[String],
       writerUuid: String,
   )

--- a/rollback-tool-cassandra/src/main/scala/lerna/akka/entityreplication/rollback/RaftEventSourcedPersistence.scala
+++ b/rollback-tool-cassandra/src/main/scala/lerna/akka/entityreplication/rollback/RaftEventSourcedPersistence.scala
@@ -3,4 +3,5 @@ package lerna.akka.entityreplication.rollback
 /** Persistence operations for persistence plugin `lerna.akka.entityreplication.raft.eventsourced.persistence` */
 private class RaftEventSourcedPersistence(
     val persistentActorRollback: PersistentActorRollback,
+    val requirementsVerifier: RollbackRequirementsVerifier,
 )

--- a/rollback-tool-cassandra/src/main/scala/lerna/akka/entityreplication/rollback/RaftPersistence.scala
+++ b/rollback-tool-cassandra/src/main/scala/lerna/akka/entityreplication/rollback/RaftPersistence.scala
@@ -5,4 +5,5 @@ private class RaftPersistence(
     val persistentActorRollback: PersistentActorRollback,
     val raftShardPersistenceQueries: RaftShardPersistenceQueries,
     val sequenceNrSearchStrategy: SequenceNrSearchStrategy,
+    val requirementsVerifier: RollbackRequirementsVerifier,
 )

--- a/rollback-tool-cassandra/src/main/scala/lerna/akka/entityreplication/rollback/RollbackException.scala
+++ b/rollback-tool-cassandra/src/main/scala/lerna/akka/entityreplication/rollback/RollbackException.scala
@@ -1,0 +1,16 @@
+package lerna.akka.entityreplication.rollback
+
+/** Exception thrown when a rollback-related operation fails */
+class RollbackException private[rollback] (message: String) extends RuntimeException(message)
+
+/** Exception thrown when rollback requirements are not found */
+private class RollbackRequirementsNotFound(message: String)
+    extends RollbackException(s"Rollback requirements not found: $message")
+
+/** Exception thrown when a rollback request doesn't fulfill rollback requirements */
+private class RollbackRequirementsNotFulfilled(message: String)
+    extends RollbackException(s"Rollback requirements not fulfilled: $message")
+
+/** Exception thrown when a rollback timestamp hint is not found */
+private class RollbackTimestampHintNotFound(message: String)
+    extends RollbackException(s"Rollback timestamp hint not found: $message")

--- a/rollback-tool-cassandra/src/main/scala/lerna/akka/entityreplication/rollback/RollbackRequirementsVerifier.scala
+++ b/rollback-tool-cassandra/src/main/scala/lerna/akka/entityreplication/rollback/RollbackRequirementsVerifier.scala
@@ -1,0 +1,29 @@
+package lerna.akka.entityreplication.rollback
+
+import akka.Done
+
+import java.time.Instant
+import scala.concurrent.Future
+
+/** Verifies the rollback request meets rollback requirements */
+private trait RollbackRequirementsVerifier {
+
+  /** Verifies that the given rollback request for `persistenceId` meets rollback requirements
+    *
+    *  - If the request meets requirements, this returns a successful `Future`.
+    *  - Otherwise, this returns a failed `Future` containing a [[RollbackRequirementsNotFulfilled]].
+    *
+    * @param toSequenceNr
+    *   - `None` means deleting all data for rollback.
+    *   - `Some(sequenceNr)` means rollback to `sequenceNr`.
+    * @param toTimestampHintOpt
+    *   - `None` means the request is not timestamp-based.
+    *   - `Some(_)` means the request is timestamp-based.
+    */
+  def verify(
+      persistenceId: String,
+      toSequenceNr: Option[SequenceNr],
+      toTimestampHintOpt: Option[Instant],
+  ): Future[Done]
+
+}

--- a/rollback-tool-cassandra/src/main/scala/lerna/akka/entityreplication/rollback/RollbackTimestampHintFinder.scala
+++ b/rollback-tool-cassandra/src/main/scala/lerna/akka/entityreplication/rollback/RollbackTimestampHintFinder.scala
@@ -1,0 +1,36 @@
+package lerna.akka.entityreplication.rollback
+
+import lerna.akka.entityreplication.rollback.RollbackTimestampHintFinder.TimestampHint
+
+import java.time.Instant
+import scala.concurrent.Future
+
+private object RollbackTimestampHintFinder {
+
+  /** Timestamp hint for rollback
+    *
+    * Timestamp-based rollback for the persistent actor with `persistenceId` requires a rollback timestamp new than or
+    * equal to `timestamp` of data (event or snapshot) with `sequenceNr`. While the timestamp is a hint and might need
+    * to be more strictly correct, it helps to know why the timestamp-based rollback request doesn't fulfill rollback
+    * requirements.
+    */
+  final case class TimestampHint(
+      persistenceId: String,
+      sequenceNr: SequenceNr,
+      timestamp: Instant,
+  )
+
+}
+
+/** Finds a rollback timestamp hint for the requirements */
+private trait RollbackTimestampHintFinder {
+
+  /** Finds a rollback timestamp hint for the given rollback requirements
+    *
+    * If a hint is not found, this method returns a failed `Future` containing a [[RollbackTimestampHintNotFound]].
+    *
+    * @see [[RollbackTimestampHintFinder.TimestampHint]]
+    */
+  def findTimestampHint(requirements: PersistentActorRollback.RollbackRequirements): Future[TimestampHint]
+
+}

--- a/rollback-tool-cassandra/src/main/scala/lerna/akka/entityreplication/rollback/cassandra/CassandraPersistenceQueriesSettings.scala
+++ b/rollback-tool-cassandra/src/main/scala/lerna/akka/entityreplication/rollback/cassandra/CassandraPersistenceQueriesSettings.scala
@@ -19,4 +19,10 @@ private final class CassandraPersistenceQueriesSettings(
     CassandraQuerySettings(pluginConfig)
   }
 
+  /** Resolves `pluginLocation` on the given system and then returns the snapshot plugin settings */
+  def resolveSnapshotSettings(system: ActorSystem): CassandraSnapshotSettings = {
+    val pluginConfig = system.settings.config.getConfig(pluginLocation)
+    CassandraSnapshotSettings(pluginConfig)
+  }
+
 }

--- a/rollback-tool-cassandra/src/main/scala/lerna/akka/entityreplication/rollback/cassandra/CassandraPersistenceQueriesStatements.scala
+++ b/rollback-tool-cassandra/src/main/scala/lerna/akka/entityreplication/rollback/cassandra/CassandraPersistenceQueriesStatements.scala
@@ -9,6 +9,8 @@ private final class CassandraPersistenceQueriesStatements(
 
   private val journalSettings: CassandraJournalSettings =
     settings.resolveJournalSettings(system)
+  private val snapshotSettings: CassandraSnapshotSettings =
+    settings.resolveSnapshotSettings(system)
 
   val selectHighestSequenceNr: String =
     s"""
@@ -46,5 +48,15 @@ private final class CassandraPersistenceQueriesStatements(
        WHERE
          persistence_id = ?
      """
+
+  val selectLowestSnapshotSequenceNrFrom: String =
+    s"""
+       SELECT sequence_nr FROM ${snapshotSettings.tableName}
+       WHERE
+         persistence_id = ? AND
+         sequence_nr >= ?
+       ORDER BY sequence_nr ASC
+       LIMIT 1
+       """
 
 }

--- a/rollback-tool-cassandra/src/main/scala/lerna/akka/entityreplication/rollback/cassandra/CassandraSnapshotSettings.scala
+++ b/rollback-tool-cassandra/src/main/scala/lerna/akka/entityreplication/rollback/cassandra/CassandraSnapshotSettings.scala
@@ -10,6 +10,8 @@ private object CassandraSnapshotSettings {
     * (`akka.persistence.cassandra`).
     */
   def apply(pluginConfig: Config): CassandraSnapshotSettings = {
+    val readProfile: String =
+      pluginConfig.getString("snapshot.read-profile")
     val writeProfile: String =
       pluginConfig.getString("snapshot.write-profile")
     val keyspace: String =
@@ -17,6 +19,7 @@ private object CassandraSnapshotSettings {
     val table: String =
       pluginConfig.getString("snapshot.table")
     new CassandraSnapshotSettings(
+      readProfile,
       writeProfile,
       keyspace,
       table,
@@ -26,6 +29,7 @@ private object CassandraSnapshotSettings {
 }
 
 private final class CassandraSnapshotSettings private (
+    val readProfile: String,
     val writeProfile: String,
     val keyspace: String,
     val table: String,

--- a/rollback-tool-cassandra/src/multi-jvm/resources/application.conf
+++ b/rollback-tool-cassandra/src/multi-jvm/resources/application.conf
@@ -35,3 +35,6 @@ lerna.akka.entityreplication.raft {
     }
   }
 }
+
+// Needed for initializing the default journal plugin with event adapters by PersistenceInitializationAwaiter
+akka.persistence.cassandra.journal = ${akka.persistence.cassandra.journal} ${lerna.akka.entityreplication.raft.persistence.journal-plugin-additional}

--- a/rollback-tool-cassandra/src/multi-jvm/resources/logback.xml
+++ b/rollback-tool-cassandra/src/multi-jvm/resources/logback.xml
@@ -9,6 +9,7 @@
   <logger name="akka" level="ERROR" />
   <logger name="lerna.akka.entityreplication" level="WARN" />
   <logger name="lerna.akka.entityreplication.rollback" level="DEBUG" />
+  <logger name="lerna.akka.entityreplication.rollback.testkit" level="INFO" />
   <root level="INFO">
     <appender-ref ref="STDOUT"/>
   </root>

--- a/rollback-tool-cassandra/src/multi-jvm/scala/lerna/akka/entityreplication/rollback/cassandra/CassandraRaftShardRollbackFailureWithDeletionSpec.scala
+++ b/rollback-tool-cassandra/src/multi-jvm/scala/lerna/akka/entityreplication/rollback/cassandra/CassandraRaftShardRollbackFailureWithDeletionSpec.scala
@@ -1,0 +1,330 @@
+package lerna.akka.entityreplication.rollback.cassandra
+
+import akka.Done
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.adapter._
+import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal
+import akka.persistence.cassandra.testkit.CassandraLauncher
+import akka.persistence.query.{ EventEnvelope, Offset, PersistenceQuery }
+import akka.remote.testconductor.RoleName
+import akka.remote.testkit.{ MultiNodeConfig, MultiNodeSpec }
+import akka.stream.scaladsl.Sink
+import akka.util.Timeout
+import com.typesafe.config.{ Config, ConfigFactory, ConfigValueFactory }
+import lerna.akka.entityreplication.raft.routing.MemberIndex
+import lerna.akka.entityreplication.rollback.RollbackRequirementsNotFulfilled
+import lerna.akka.entityreplication.rollback.cassandra.testkit.PersistenceCassandraConfigProvider
+import lerna.akka.entityreplication.rollback.testkit.{ CatalogReplicatedEntity, PersistenceInitializationAwaiter }
+import lerna.akka.entityreplication.typed._
+import lerna.akka.entityreplication.util.AtLeastOnceComplete
+
+import java.time.{ Instant, ZonedDateTime }
+import scala.concurrent.duration.{ DurationInt, FiniteDuration }
+import scala.jdk.CollectionConverters._
+
+object CassandraRaftShardRollbackFailureWithDeletionSpecConfig
+    extends MultiNodeConfig
+    with PersistenceCassandraConfigProvider {
+  val node1: RoleName = role("node1")
+  val node2: RoleName = role("node2")
+  val node3: RoleName = role("node3")
+  val node4: RoleName = role("node4")
+
+  val memberIndexes: Map[RoleName, MemberIndex] = Map(
+    node1 -> MemberIndex("member-1"),
+    node2 -> MemberIndex("member-1"),
+    node3 -> MemberIndex("member-2"),
+    node4 -> MemberIndex("member-3"),
+  )
+
+  // The length of keyspace name should be less than or equal to 48.
+  // See https://docs.datastax.com/en/cql-oss/3.3/cql/cql_reference/refLimits.html
+  private val journalKeyspaceName  = getClass.getSimpleName.replace("$", "").take(48)
+  private val snapshotKeyspaceName = getClass.getSimpleName.replace("$", "").take(48)
+
+  object Rollback {
+    val targetShardId: String                = "2"
+    val targetLeaderMemberIndex: MemberIndex = MemberIndex("member-1")
+  }
+
+  /** Each JVM node should sync its clock in this tolerance */
+  val clockOutOfSyncTolerance: FiniteDuration = 500.millis
+
+  private val deletionConfig: Config = ConfigFactory.parseString(
+    """
+      |lerna.akka.entityreplication.raft {
+      |  delete-old-events = on
+      |  delete-old-snapshots = on
+      |  delete-before-relative-sequence-nr = 200
+      |
+      |  compaction.log-size-check-interval = 3s
+      |  compaction.log-size-threshold = 100
+      |  compaction.preserve-log-size = 25
+      |
+      |  entity-snapshot-store.snapshot-every = 1
+      |  entity-snapshot-store.delete-old-events = on
+      |  entity-snapshot-store.delete-old-snapshots = on
+      |  entity-snapshot-store.delete-before-relative-sequence-nr = 5
+      |
+      |  eventsourced.persistence.snapshot-every = 100
+      |  eventsourced.persistence.delete-old-events = on
+      |  eventsourced.persistence.delete-old-snapshots = on
+      |  eventsourced.persistence.delete-before-relative-sequence-nr = 200
+      |}
+      |""".stripMargin,
+  )
+
+  commonConfig(
+    debugConfig(false)
+      .withValue(
+        "lerna.akka.entityreplication.raft.multi-raft-roles",
+        ConfigValueFactory.fromIterable(memberIndexes.values.map(_.role).toSet.asJava),
+      )
+      .withFallback(deletionConfig)
+      .withFallback(ConfigFactory.parseString(s"""
+          |akka.persistence.cassandra.journal {
+          |  ${CatalogReplicatedEntity.EventAdapter.config}
+          |}
+          |""".stripMargin))
+      .withFallback(ConfigFactory.load()),
+  )
+
+  nodeConfig(node1)(
+    ConfigFactory
+      .parseString(
+        s"""
+           |akka.cluster.roles = ["${memberIndexes(node1)}"]
+           |lerna.akka.entityreplication.rollback {
+           |  clock-out-of-sync-tolerance = ${clockOutOfSyncTolerance.toMillis} ms
+           |}
+           |""".stripMargin,
+      )
+      .withFallback(persistenceCassandraConfig(journalKeyspaceName, snapshotKeyspaceName, autoCreate = true)),
+  )
+  Set(node2, node3, node4).foreach { node =>
+    nodeConfig(node)(
+      ConfigFactory
+        .parseString(
+          s"""
+             |akka.cluster.roles = ["${memberIndexes(node)}"]
+             |""".stripMargin,
+        )
+        .withFallback(persistenceCassandraConfig(journalKeyspaceName, snapshotKeyspaceName)),
+    )
+  }
+
+}
+
+final class CassandraRaftShardRollbackFailureWithDeletionSpecMultiJvmNode1
+    extends CassandraRaftShardRollbackFailureWithDeletionSpec
+final class CassandraRaftShardRollbackFailureWithDeletionSpecMultiJvmNode2
+    extends CassandraRaftShardRollbackFailureWithDeletionSpec
+final class CassandraRaftShardRollbackFailureWithDeletionSpecMultiJvmNode3
+    extends CassandraRaftShardRollbackFailureWithDeletionSpec
+final class CassandraRaftShardRollbackFailureWithDeletionSpecMultiJvmNode4
+    extends CassandraRaftShardRollbackFailureWithDeletionSpec
+
+class CassandraRaftShardRollbackFailureWithDeletionSpec
+    extends MultiNodeSpec(CassandraRaftShardRollbackFailureWithDeletionSpecConfig)
+    with STMultiNodeSpec {
+
+  import CassandraRaftShardRollbackFailureWithDeletionSpecConfig._
+  import CatalogReplicatedEntity._
+
+  override def initialParticipants: Int = 4
+
+  private implicit val typedSystem: ActorSystem[Nothing] = system.toTyped
+
+  private val targetLeaderMemberIndex: MemberIndex = Rollback.targetLeaderMemberIndex
+  private val targetShardId: String                = Rollback.targetShardId
+  private val entityIdA                            = "entity-A"
+  private val entityIdB                            = "entity-B"
+  private val numOfEventsOnRound1                  = 25
+  private val numOfEventsOnRound2                  = 300
+
+  private lazy val clusterReplication =
+    ClusterReplication(typedSystem)
+
+  private lazy val clusterReplicationSettings =
+    ClusterReplicationSettings(typedSystem)
+      .withStickyLeaders(Map(targetShardId -> targetLeaderMemberIndex.role))
+
+  private lazy val queries: CassandraReadJournal =
+    PersistenceQuery(system).readJournalFor[CassandraReadJournal](CassandraReadJournal.Identifier)
+
+  /** Cassandra should be ready to handle requests within this timeout */
+  private val cassandraInitializationTimeout: FiniteDuration = 30.seconds
+
+  /** ClusterReplication should be ready to handle requests within this timeout */
+  private val initializationTimeout: FiniteDuration = 10.seconds
+
+  /** ClusterReplication should persist events eventually within this timeout. */
+  private val propagationTimeout: FiniteDuration = 20.seconds
+
+  // Updated in the following tests
+  private var rollbackTimestamp: Option[Instant] = None
+
+  "CassandraRaftShardRollback" should {
+
+    "start Cassandra" in {
+      runOn(node1) {
+        CassandraLauncher.main(Array(s"$cassandraPort", "true"))
+      }
+      Thread.sleep(cassandraInitializationTimeout.toMillis)
+      enterBarrier("Started Cassandra")
+    }
+
+    "initialize Persistence Cassandra" in {
+      runOn(node1) {
+        PersistenceInitializationAwaiter(system).awaitInit()
+      }
+      enterBarrier("Initialized Persistence Cassandra (node1)")
+
+      runOn(node2, node3, node4) {
+        PersistenceInitializationAwaiter(system).awaitInit()
+      }
+      enterBarrier("Initialized Persistence Cassandra (nodes: [2,3,4])")
+    }
+
+    "form a new cluster (nodes: [2,3,4])" in {
+      newCluster(node2, node3, node4)
+      enterBarrier("Formed the new cluster (nodes: [2,3,4])")
+    }
+
+    "start ClusterReplication (nodes: [2,3,4])" in {
+      runOn(node2, node3, node4) {
+        clusterReplication.init(CatalogReplicatedEntity().withSettings(clusterReplicationSettings))
+      }
+      Thread.sleep(initializationTimeout.toMillis)
+      enterBarrier("Started ClusterReplication (nodes: [2,3,4])")
+    }
+
+    "persist events (round 1)" in {
+      runOn(node2) {
+        assert(clusterReplication.shardIdOf(typeKey, entityIdA) == targetShardId)
+        assert(clusterReplication.shardIdOf(typeKey, entityIdB) != targetShardId)
+      }
+      implicit val timeout: Timeout = 3000.millis
+      runOn(node2) {
+        for (i <- 0 until numOfEventsOnRound1) {
+          val entityA = clusterReplication.entityRefFor(typeKey, entityIdA)
+          AtLeastOnceComplete.askTo(entityA, Add(i, _), 1000.millis).await should be(Done)
+        }
+      }
+      runOn(node3) {
+        for (i <- 0 until numOfEventsOnRound1) {
+          val entityB = clusterReplication.entityRefFor(typeKey, entityIdB)
+          AtLeastOnceComplete.askTo(entityB, Add(i, _), 1000.millis).await should be(Done)
+        }
+      }
+      val totalPersistTimeout =
+        clusterReplicationSettings.raftSettings.heartbeatInterval * numOfEventsOnRound1
+      enterBarrier(max = totalPersistTimeout, "Persisted Events (round 1)")
+    }
+
+    "wait for the completion of the event sourcing (round 1)" in {
+      runOn(node2, node3, node4) {
+        awaitAssert(
+          {
+            val source = queries
+              .currentEventsByTag(EventAdapter.tag, Offset.noOffset)
+            val events = source.runWith(Sink.seq).await.collect {
+              case EventEnvelope(_, _, _, event: Event) => event
+            }
+            val expectedEventsOfEntityA =
+              (0 until numOfEventsOnRound1).map(i => Added(entityIdA, i))
+            events.filter(_.entityId == entityIdA) should be(expectedEventsOfEntityA)
+            val expectedEventsOfEntityB =
+              (0 until numOfEventsOnRound1).map(i => Added(entityIdB, i))
+            events.filter(_.entityId == entityIdB) should be(expectedEventsOfEntityB)
+          },
+          max = propagationTimeout,
+          interval = 500.millis,
+        )
+      }
+      enterBarrier(max = propagationTimeout, "Completed the event sourcing (round 1)")
+    }
+
+    "store a rollback timestamp" in {
+      Thread.sleep(clockOutOfSyncTolerance.toMillis)
+      runOn(node1) {
+        rollbackTimestamp = Option(ZonedDateTime.now().toInstant)
+      }
+      enterBarrier("Stored the rollback timestamp")
+    }
+
+    "persist events (round 2)" in {
+      implicit val timeout: Timeout = 3000.millis
+      val baseValue                 = numOfEventsOnRound1
+      runOn(node2) {
+        for (i <- 0 until numOfEventsOnRound2) {
+          val entityA = clusterReplication.entityRefFor(typeKey, entityIdA)
+          AtLeastOnceComplete.askTo(entityA, Add(baseValue + i, _), 1000.millis).await should be(Done)
+        }
+      }
+      runOn(node3) {
+        for (i <- 0 until numOfEventsOnRound2) {
+          val entityB = clusterReplication.entityRefFor(typeKey, entityIdB)
+          AtLeastOnceComplete.askTo(entityB, Add(baseValue + i, _), 1000.millis).await should be(Done)
+        }
+      }
+      val totalPersistTimeout =
+        clusterReplicationSettings.raftSettings.heartbeatInterval * numOfEventsOnRound2
+      enterBarrier(max = totalPersistTimeout, "Persisted events (round 2)")
+    }
+
+    "wait for the completion of the event sourcing (round 2)" in {
+      runOn(node2, node3, node4) {
+        awaitAssert(
+          {
+            val source = queries
+              .currentEventsByTag(EventAdapter.tag, Offset.noOffset)
+            val events = source.runWith(Sink.seq).await.collect {
+              case EventEnvelope(_, _, _, event: Event) => event
+            }
+            val expectedEventsOfEntityA =
+              (0 until numOfEventsOnRound1 + numOfEventsOnRound2).map(i => Added(entityIdA, i))
+            events.filter(_.entityId == entityIdA) should be(expectedEventsOfEntityA)
+            val expectedEventsOfEntityB =
+              (0 until numOfEventsOnRound1 + numOfEventsOnRound2).map(i => Added(entityIdB, i))
+            events.filter(_.entityId == entityIdB) should be(expectedEventsOfEntityB)
+          },
+          max = propagationTimeout,
+          interval = 500.millis,
+        )
+      }
+      enterBarrier(max = propagationTimeout, "Completed the event sourcing (round 2)")
+    }
+
+    "shut down the cluster (nodes: [2,3,4])" in {
+      runOn(node1) {
+        testConductor.shutdown(node2).await
+        testConductor.shutdown(node3).await
+        testConductor.shutdown(node4).await
+      }
+      runOn(node1) {
+        enterBarrier("Shut down the cluster (nodes: [2,3,4])")
+      }
+    }
+
+    "fail a rollback preparation" in {
+      runOn(node1) {
+        val rollback    = CassandraRaftShardRollback(system)
+        val toTimestamp = rollbackTimestamp.get
+        val exception = intercept[RollbackRequirementsNotFulfilled] {
+          rollback
+            .prepareRollback(
+              typeKey.name,
+              targetShardId,
+              clusterReplicationSettings.raftSettings.multiRaftRoles,
+              targetLeaderMemberIndex.role,
+              toTimestamp,
+            ).await
+        }
+        log.info("Got expected RollbackRequirementsNotFulfilled: [{}]", exception.getMessage)
+      }
+    }
+
+  }
+
+}

--- a/rollback-tool-cassandra/src/multi-jvm/scala/lerna/akka/entityreplication/rollback/testkit/CatalogReplicatedEntity.scala
+++ b/rollback-tool-cassandra/src/multi-jvm/scala/lerna/akka/entityreplication/rollback/testkit/CatalogReplicatedEntity.scala
@@ -1,0 +1,98 @@
+package lerna.akka.entityreplication.rollback.testkit
+
+import akka.Done
+import akka.actor.ExtendedActorSystem
+import akka.actor.typed.ActorRef
+import akka.actor.typed.scaladsl.Behaviors
+import akka.event.Logging
+import akka.persistence.journal.{ Tagged, WriteEventAdapter }
+import lerna.akka.entityreplication.rollback.JsonSerializable
+import lerna.akka.entityreplication.typed.{
+  Effect,
+  ReplicatedEntity,
+  ReplicatedEntityBehavior,
+  ReplicatedEntityTypeKey,
+  ReplicationEnvelope,
+}
+
+/** Test implementation of [[ReplicatedEntity]]
+  *
+  * It holds a set of integers and provides commands to modify the set.
+  */
+object CatalogReplicatedEntity {
+  val typeKey: ReplicatedEntityTypeKey[Command] = ReplicatedEntityTypeKey("catalog")
+
+  sealed trait Command                                      extends JsonSerializable
+  final case class Add(value: Int, replyTo: ActorRef[Done]) extends Command
+  final case class Get(replyTo: ActorRef[GetResponse])      extends Command
+  final case class GetResponse(values: Set[Int])            extends JsonSerializable
+
+  sealed trait Event extends JsonSerializable {
+    def entityId: String
+  }
+  final case class Added(entityId: String, value: Int) extends Event
+
+  final case class State(entityId: String, values: Set[Int]) extends JsonSerializable
+
+  def apply(): ReplicatedEntity[Command, ReplicationEnvelope[Command]] =
+    ReplicatedEntity(typeKey)(entityContext =>
+      Behaviors.setup { context =>
+        context.setLoggerName(CatalogReplicatedEntity.getClass)
+        ReplicatedEntityBehavior[Command, Event, State](
+          entityContext = entityContext,
+          emptyState = State(entityContext.entityId, Set.empty),
+          commandHandler = commandHandler,
+          eventHandler = eventHandler,
+        )
+      },
+    )
+
+  // NOTE: Command Handler should be idempotent.
+  private def commandHandler(state: State, command: Command): Effect[Event, State] =
+    command match {
+      case Add(value, replyTo) =>
+        if (state.values.contains(value)) {
+          Effect.none.thenReply(replyTo) { _ => Done }
+        } else {
+          Effect
+            .replicate(Added(state.entityId, value))
+            .thenReply(replyTo)(_ => Done)
+        }
+      case Get(replyTo) =>
+        Effect.reply(replyTo)(GetResponse(state.values))
+    }
+
+  private def eventHandler(state: State, event: Event): State =
+    event match {
+      case Added(_, value) =>
+        state.copy(values = state.values + value)
+    }
+
+  object EventAdapter {
+    val tag: String = "testkit-catalog"
+    val config: String = {
+      s"""
+         |event-adapters {
+         |  testkit-catalog-tagging = "lerna.akka.entityreplication.rollback.testkit.CatalogReplicatedEntity$$EventAdapter"
+         |}
+         |event-adapter-bindings {
+         |  "lerna.akka.entityreplication.rollback.testkit.CatalogReplicatedEntity$$Event" = testkit-catalog-tagging
+         |}
+         |""".stripMargin
+    }
+  }
+
+  final class EventAdapter(system: ExtendedActorSystem) extends WriteEventAdapter {
+    private val log                           = Logging(system, getClass)
+    override def manifest(event: Any): String = ""
+    override def toJournal(event: Any): Any =
+      event match {
+        case event: CatalogReplicatedEntity.Event =>
+          Tagged(event, tags = Set(EventAdapter.tag))
+        case _ =>
+          log.warning("Got unexpected event [{}]", event)
+          event
+      }
+  }
+
+}

--- a/rollback-tool-cassandra/src/test/scala/lerna/akka/entityreplication/rollback/DefaultRollbackRequirementsVerifierSpec.scala
+++ b/rollback-tool-cassandra/src/test/scala/lerna/akka/entityreplication/rollback/DefaultRollbackRequirementsVerifierSpec.scala
@@ -1,0 +1,232 @@
+package lerna.akka.entityreplication.rollback
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.testkit.TestKitBase
+import lerna.akka.entityreplication.rollback.PersistentActorRollback.RollbackRequirements
+import lerna.akka.entityreplication.rollback.testkit.PatienceConfigurationForTestKitBase
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
+
+import java.time.{ ZoneOffset, ZonedDateTime }
+import scala.concurrent.Future
+
+final class DefaultRollbackRequirementsVerifierSpec
+    extends TestKitBase
+    with WordSpecLike
+    with BeforeAndAfterAll
+    with Matchers
+    with ScalaFutures
+    with MockFactory
+    with PatienceConfigurationForTestKitBase {
+
+  override implicit val system: ActorSystem =
+    ActorSystem(getClass.getSimpleName)
+
+  override def afterAll(): Unit = {
+    shutdown(system)
+    super.afterAll()
+  }
+
+  private trait Fixture {
+    val rollback: PersistentActorRollback                = mock[PersistentActorRollback]
+    val timestampHintFinder: RollbackTimestampHintFinder = mock[RollbackTimestampHintFinder]
+  }
+
+  "DefaultRollbackRequirementsVerifier.verify" should {
+
+    "return a successful Future if toSequenceNr is greater than the required lowest sequence number" in new Fixture {
+      val verifier = new DefaultRollbackRequirementsVerifier(system, rollback, timestampHintFinder)
+
+      // Expectations:
+      (rollback.findRollbackRequirements _)
+        .expects("pid")
+        .returns(Future.successful(RollbackRequirements("pid", SequenceNr(5))))
+        .once()
+
+      // Test:
+      verifier.verify("pid", Some(SequenceNr(6)), None).futureValue should be(Done)
+    }
+
+    "return a successful Future if toSequenceNr equals the required lowest sequence number" in new Fixture {
+      val verifier = new DefaultRollbackRequirementsVerifier(system, rollback, timestampHintFinder)
+
+      // Expectations:
+      (rollback.findRollbackRequirements _)
+        .expects("pid")
+        .returns(Future.successful(RollbackRequirements("pid", SequenceNr(5))))
+        .once()
+
+      // Test:
+      verifier.verify("pid", Some(SequenceNr(5)), None).futureValue should be(Done)
+    }
+
+    "return a failed Future containing a RollbackRequirementsNotFulfilled with a timestamp hint" +
+    " if toSequenceNr is less than the required lowest sequence number" in new Fixture {
+      val verifier = new DefaultRollbackRequirementsVerifier(system, rollback, timestampHintFinder)
+
+      // Expectations:
+      (rollback.findRollbackRequirements _)
+        .expects("pid")
+        .returns(Future.successful(RollbackRequirements("pid", SequenceNr(5))))
+        .once()
+
+      // Expectations:
+      val timestamp = ZonedDateTime.of(2022, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC).toInstant
+      (timestampHintFinder.findTimestampHint _)
+        .expects(RollbackRequirements("pid", SequenceNr(5)))
+        .returns(
+          Future.successful(RollbackTimestampHintFinder.TimestampHint("pid", SequenceNr(5), timestamp.plusMillis(1))),
+        )
+
+      // Test:
+      val exception = verifier.verify("pid", Some(SequenceNr(4)), Some(timestamp)).failed.futureValue
+      exception should be(a[RollbackRequirementsNotFulfilled])
+      exception.getMessage should be(
+        "Rollback requirements not fulfilled:" +
+        s" Rollback to sequence number [4] for the persistent actor [pid] is impossible" +
+        s" since the sequence number should be greater than or equal to [5]." +
+        s" Hint: rollback timestamp [$timestamp] should be newer than timestamp [${timestamp.plusMillis(1)}] of sequence number [5], at least.",
+      )
+    }
+
+    "return a failed Future containing a RollbackRequirementsNotFulfilled without a timestamp hint" +
+    "if toSequenceNr is less than the required lowest sequence number and the finding of a timestamp hint fails" in new Fixture {
+      val verifier = new DefaultRollbackRequirementsVerifier(system, rollback, timestampHintFinder)
+
+      // Expectations:
+      (rollback.findRollbackRequirements _)
+        .expects("pid")
+        .returns(Future.successful(RollbackRequirements("pid", SequenceNr(5))))
+        .once()
+
+      // Expectations:
+      val timestamp = ZonedDateTime.of(2022, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC).toInstant
+      (timestampHintFinder.findTimestampHint _)
+        .expects(RollbackRequirements("pid", SequenceNr(5)))
+        .returns(Future.failed(new RuntimeException("unexpected failure")))
+
+      // Test:
+      val exception = verifier.verify("pid", Some(SequenceNr(4)), Some(timestamp)).failed.futureValue
+      exception should be(a[RollbackRequirementsNotFulfilled])
+      exception.getMessage should be(
+        "Rollback requirements not fulfilled:" +
+        s" Rollback to sequence number [4] for the persistent actor [pid] is impossible" +
+        s" since the sequence number should be greater than or equal to [5]." +
+        s" Hint: not available due to [${classOf[RuntimeException].getCanonicalName}]: unexpected failure].",
+      )
+    }
+
+    "return a failed Future containing a RollbackRequirementsNotFulfilled without a timestamp hint" +
+    " if toSequenceNr is less than the required lowest sequence number and toTimestampHintOpt is None" in new Fixture {
+      val verifier = new DefaultRollbackRequirementsVerifier(system, rollback, timestampHintFinder)
+
+      // Expectations:
+      (rollback.findRollbackRequirements _)
+        .expects("pid")
+        .returns(Future.successful(RollbackRequirements("pid", SequenceNr(5))))
+        .once()
+
+      // Test:
+      val exception = verifier.verify("pid", Some(SequenceNr(4)), None).failed.futureValue
+      exception should be(a[RollbackRequirementsNotFulfilled])
+      exception.getMessage should be(
+        "Rollback requirements not fulfilled:" +
+        s" Rollback to sequence number [4] for the persistent actor [pid] is impossible" +
+        s" since the sequence number should be greater than or equal to [5].",
+      )
+    }
+
+    "return a successful Future if toSequenceNr is None and the required lowest sequence number is 1" in new Fixture {
+      val verifier = new DefaultRollbackRequirementsVerifier(system, rollback, timestampHintFinder)
+
+      // Expectations:
+      (rollback.findRollbackRequirements _)
+        .expects("pid")
+        .returns(Future.successful(RollbackRequirements("pid", SequenceNr(1))))
+        .once()
+
+      // Test:
+      verifier.verify("pid", None, None).futureValue should be(Done)
+    }
+
+    "return a failed Future containing a RollbackRequirementsNotFulfilled with a timestamp hint" +
+    " if toSequenceNr is None and the required lowest sequence number is not 1" in new Fixture {
+      val verifier = new DefaultRollbackRequirementsVerifier(system, rollback, timestampHintFinder)
+
+      // Expectations:
+      (rollback.findRollbackRequirements _)
+        .expects("pid")
+        .returns(Future.successful(RollbackRequirements("pid", SequenceNr(2))))
+        .once()
+
+      // Expectations:
+      val timestamp = ZonedDateTime.of(2022, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC).toInstant
+      (timestampHintFinder.findTimestampHint _)
+        .expects(RollbackRequirements("pid", SequenceNr(2)))
+        .returns(
+          Future.successful(RollbackTimestampHintFinder.TimestampHint("pid", SequenceNr(2), timestamp.plusMillis(1))),
+        )
+
+      // Test:
+      val exception = verifier.verify("pid", None, Some(timestamp)).failed.futureValue
+      exception should be(a[RollbackRequirementsNotFulfilled])
+      exception.getMessage should be(
+        "Rollback requirements not fulfilled:" +
+        " Deleting all data for the persistent actor [pid] is impossible" +
+        " since already deleted events might contain required data for consistency with other persistent actors." +
+        s" Hint: rollback timestamp [$timestamp] should be newer than timestamp [${timestamp.plusMillis(1)}] of sequence number [2], at least.",
+      )
+    }
+
+    "return a failed Future containing a RollbackRequirementsNotFulfilled without a timestamp hint" +
+    "if toSequenceNr is None and the finding of a timestamp hint fails" in new Fixture {
+      val verifier = new DefaultRollbackRequirementsVerifier(system, rollback, timestampHintFinder)
+
+      // Expectations:
+      (rollback.findRollbackRequirements _)
+        .expects("pid")
+        .returns(Future.successful(RollbackRequirements("pid", SequenceNr(2))))
+        .once()
+
+      // Expectations:
+      val timestamp = ZonedDateTime.of(2022, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC).toInstant
+      (timestampHintFinder.findTimestampHint _)
+        .expects(RollbackRequirements("pid", SequenceNr(2)))
+        .returns(Future.failed(new RuntimeException("unexpected failure")))
+
+      // Test:
+      val exception = verifier.verify("pid", None, Some(timestamp)).failed.futureValue
+      exception should be(a[RollbackRequirementsNotFulfilled])
+      exception.getMessage should be(
+        "Rollback requirements not fulfilled:" +
+        " Deleting all data for the persistent actor [pid] is impossible" +
+        " since already deleted events might contain required data for consistency with other persistent actors." +
+        s" Hint: not available due to [${classOf[RuntimeException].getCanonicalName}]: unexpected failure].",
+      )
+    }
+
+    "return a failed Future containing a RollbackRequirementsNotFulfilled without a timestamp hint" +
+    " if toSequenceNr is None, the required lowest sequence number is not 1, and toTimestampHintOpt is None" in new Fixture {
+      val verifier = new DefaultRollbackRequirementsVerifier(system, rollback, timestampHintFinder)
+
+      // Expectations:
+      (rollback.findRollbackRequirements _)
+        .expects("pid")
+        .returns(Future.successful(RollbackRequirements("pid", SequenceNr(2))))
+        .once()
+
+      // Test:
+      val exception = verifier.verify("pid", None, None).failed.futureValue
+      exception should be(a[RollbackRequirementsNotFulfilled])
+      exception.getMessage should be(
+        "Rollback requirements not fulfilled:" +
+        " Deleting all data for the persistent actor [pid] is impossible" +
+        " since already deleted events might contain required data for consistency with other persistent actors.",
+      )
+    }
+
+  }
+
+}

--- a/rollback-tool-cassandra/src/test/scala/lerna/akka/entityreplication/rollback/LinearRollbackTimestampHintFinderSpec.scala
+++ b/rollback-tool-cassandra/src/test/scala/lerna/akka/entityreplication/rollback/LinearRollbackTimestampHintFinderSpec.scala
@@ -1,0 +1,106 @@
+package lerna.akka.entityreplication.rollback
+
+import akka.actor.ActorSystem
+import akka.persistence.query.Offset
+import akka.testkit.TestKitBase
+import lerna.akka.entityreplication.rollback.PersistenceQueries.TaggedEventEnvelope
+import lerna.akka.entityreplication.rollback.testkit.{ ConstantPersistenceQueries, PatienceConfigurationForTestKitBase }
+import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
+import org.scalatest.concurrent.ScalaFutures
+
+import java.time.{ Instant, ZoneOffset, ZonedDateTime }
+import java.util.UUID
+
+final class LinearRollbackTimestampHintFinderSpec
+    extends TestKitBase
+    with WordSpecLike
+    with BeforeAndAfterAll
+    with Matchers
+    with ScalaFutures
+    with PatienceConfigurationForTestKitBase {
+
+  override implicit val system: ActorSystem =
+    ActorSystem(getClass.getSimpleName)
+
+  override def afterAll(): Unit = {
+    shutdown(system)
+    super.afterAll()
+  }
+
+  private trait Fixture {
+
+    val persistenceId: String = "pid"
+    val writerUUID: String    = UUID.randomUUID().toString
+
+    def createEventEnvelope(sequenceNr: SequenceNr, timestamp: Instant): TaggedEventEnvelope =
+      TaggedEventEnvelope(
+        persistenceId,
+        sequenceNr,
+        s"event-${sequenceNr.value}",
+        Offset.sequence(sequenceNr.value),
+        timestamp.toEpochMilli,
+        Set.empty,
+        writerUUID,
+      )
+
+  }
+
+  "LinearRollbackTimestampHintFinder.findTimestampHint" should {
+
+    "return a rollback timestamp hint if an event with the given required lowest sequence number exists" in new Fixture {
+
+      val baseTimestamp = ZonedDateTime.of(2022, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC).toInstant
+      val events = IndexedSeq(
+        createEventEnvelope(SequenceNr(9), baseTimestamp.plusMillis(90)),
+        createEventEnvelope(SequenceNr(10), baseTimestamp.plusMillis(100)),
+        createEventEnvelope(SequenceNr(11), baseTimestamp.plusMillis(110)),
+      )
+      val queries = new ConstantPersistenceQueries(events)
+      val finder  = new LinearRollbackTimestampHintFinder(system, queries)
+
+      val requirements  = PersistentActorRollback.RollbackRequirements(persistenceId, SequenceNr(10))
+      val timestampHint = finder.findTimestampHint(requirements).futureValue
+      timestampHint.persistenceId should be(persistenceId)
+      timestampHint.sequenceNr should be(SequenceNr(10))
+      timestampHint.timestamp should be(baseTimestamp.plusMillis(100))
+    }
+
+    "return a rollback timestamp hint if an event with a sequence number higher than the given lowest one exists" in new Fixture {
+
+      val baseTimestamp = ZonedDateTime.of(2022, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC).toInstant
+      val events = IndexedSeq(
+        createEventEnvelope(SequenceNr(11), baseTimestamp.plusMillis(110)),
+        createEventEnvelope(SequenceNr(12), baseTimestamp.plusMillis(120)),
+      )
+      val queries = new ConstantPersistenceQueries(events)
+      val finder  = new LinearRollbackTimestampHintFinder(system, queries)
+
+      val requirements  = PersistentActorRollback.RollbackRequirements(persistenceId, SequenceNr(10))
+      val timestampHint = finder.findTimestampHint(requirements).futureValue
+      timestampHint.persistenceId should be(persistenceId)
+      timestampHint.sequenceNr should be(SequenceNr(11))
+      timestampHint.timestamp should be(baseTimestamp.plusMillis(110))
+    }
+
+    "return a failed Future containing RollbackTimestampHintNotFound" +
+    " if any event with a sequence number higher than or equal to the lowest one doesn't exist" in new Fixture {
+
+      val baseTimestamp = ZonedDateTime.of(2022, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC).toInstant
+      val events = IndexedSeq(
+        createEventEnvelope(SequenceNr(9), baseTimestamp.plusMillis(90)),
+      )
+      val queries = new ConstantPersistenceQueries(events)
+      val finder  = new LinearRollbackTimestampHintFinder(system, queries)
+
+      val requirements = PersistentActorRollback.RollbackRequirements(persistenceId, SequenceNr(10))
+      val exception    = finder.findTimestampHint(requirements).failed.futureValue
+      exception should be(a[RollbackTimestampHintNotFound])
+      exception.getMessage should be(
+        "Rollback timestamp hint not found:" +
+        s" no events of persistenceId=[$persistenceId] with a sequence number greater than or equal to lowestSequenceNr=[10]",
+      )
+    }
+
+  }
+
+}

--- a/rollback-tool-cassandra/src/test/scala/lerna/akka/entityreplication/rollback/RaftShardRollbackSpec.scala
+++ b/rollback-tool-cassandra/src/test/scala/lerna/akka/entityreplication/rollback/RaftShardRollbackSpec.scala
@@ -13,7 +13,7 @@ import lerna.akka.entityreplication.rollback.setup._
 import lerna.akka.entityreplication.rollback.testkit.PatienceConfigurationForTestKitBase
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{ Matchers, WordSpecLike }
+import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
 
 import java.time.{ ZoneOffset, ZonedDateTime }
 import scala.concurrent.Future
@@ -21,6 +21,7 @@ import scala.concurrent.Future
 final class RaftShardRollbackSpec
     extends TestKitBase
     with WordSpecLike
+    with BeforeAndAfterAll
     with Matchers
     with ScalaFutures
     with MockFactory
@@ -47,20 +48,32 @@ final class RaftShardRollbackSpec
   private val defaultShardId: NormalizedShardId =
     NormalizedShardId.from("1")
 
+  override def afterAll(): Unit = {
+    shutdown(system)
+    super.afterAll()
+  }
+
+  private def createRaftShardRollback(settings: RaftShardRollbackSettings): RaftShardRollback = {
+    new RaftShardRollback(
+      system,
+      settings,
+      new RaftPersistence(
+        mock[PersistentActorRollback],
+        mock[RaftShardPersistenceQueries],
+        mock[SequenceNrSearchStrategy],
+        mock[RollbackRequirementsVerifier],
+      ),
+      new RaftEventSourcedPersistence(
+        mock[PersistentActorRollback],
+        mock[RollbackRequirementsVerifier],
+      ),
+    )
+  }
+
   "RaftShardRollback.prepareRaftActorsRollback" should {
 
     "return all RaftActors' rollback setups for the given Raft shard" in {
-      val rollback =
-        new RaftShardRollback(
-          system,
-          settings,
-          new RaftPersistence(
-            mock[PersistentActorRollback],
-            mock[RaftShardPersistenceQueries],
-            mock[SequenceNrSearchStrategy],
-          ),
-          mock[RaftEventSourcedPersistence],
-        )
+      val rollback = createRaftShardRollback(settings)
 
       val memberIndex1 = MemberIndex("replica-group-1")
       val memberIndex2 = MemberIndex("replica-group-2")
@@ -96,6 +109,20 @@ final class RaftShardRollbackSpec
         .returns(Future.successful(None))
         .once()
 
+      // Expectations:
+      (rollback.raftPersistence.requirementsVerifier.verify _)
+        .expects(raftActorId1.persistenceId, Some(SequenceNr(7)), Some(leadersTimestamp))
+        .returns(Future.successful(Done))
+        .once()
+      (rollback.raftPersistence.requirementsVerifier.verify _)
+        .expects(raftActorId2.persistenceId, Some(SequenceNr(5)), Some(nonLeadersTimestamp))
+        .returns(Future.successful(Done))
+        .once()
+      (rollback.raftPersistence.requirementsVerifier.verify _)
+        .expects(raftActorId3.persistenceId, None, Some(nonLeadersTimestamp))
+        .returns(Future.successful(Done))
+        .once()
+
       // Test:
       rollback.prepareRaftActorsRollback(parameters).futureValue should contain theSameElementsAs Seq(
         RaftActorRollbackSetup(raftActorId1, Some(SequenceNr(7))),
@@ -104,22 +131,68 @@ final class RaftShardRollbackSpec
       )
     }
 
+    "return a failed Future if the rollback request doesn't meet requirements" in {
+      val rollback = createRaftShardRollback(settings)
+
+      val memberIndex1 = MemberIndex("replica-group-1")
+      val memberIndex2 = MemberIndex("replica-group-2")
+      val memberIndex3 = MemberIndex("replica-group-3")
+
+      val raftActorId1 = RaftActorId(defaultTypeName, defaultShardId, memberIndex1)
+      val raftActorId2 = RaftActorId(defaultTypeName, defaultShardId, memberIndex2)
+      val raftActorId3 = RaftActorId(defaultTypeName, defaultShardId, memberIndex3)
+
+      val leadersTimestamp    = ZonedDateTime.of(2022, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC).toInstant
+      val nonLeadersTimestamp = leadersTimestamp.minusSeconds(rollback.settings.clockOutOfSyncTolerance.toSeconds)
+
+      val parameters =
+        RaftShardRollbackParameters(
+          defaultTypeName,
+          defaultShardId,
+          Set(memberIndex1, memberIndex2, memberIndex3),
+          memberIndex1,
+          leadersTimestamp,
+        )
+
+      // Expectations:
+      (rollback.raftPersistence.sequenceNrSearchStrategy.findUpperBound _)
+        .expects(raftActorId1.persistenceId, leadersTimestamp)
+        .returns(Future.successful(Some(SequenceNr(7))))
+        .noMoreThanOnce()
+      (rollback.raftPersistence.sequenceNrSearchStrategy.findUpperBound _)
+        .expects(raftActorId2.persistenceId, nonLeadersTimestamp)
+        .returns(Future.successful(Some(SequenceNr(5))))
+        .noMoreThanOnce()
+      (rollback.raftPersistence.sequenceNrSearchStrategy.findUpperBound _)
+        .expects(raftActorId3.persistenceId, nonLeadersTimestamp)
+        .returns(Future.successful(None))
+        .noMoreThanOnce()
+
+      // Expectations:
+      (rollback.raftPersistence.requirementsVerifier.verify _)
+        .expects(raftActorId1.persistenceId, Some(SequenceNr(7)), Some(leadersTimestamp))
+        .returns(Future.successful(Done))
+        .noMoreThanOnce()
+      (rollback.raftPersistence.requirementsVerifier.verify _)
+        .expects(raftActorId2.persistenceId, Some(SequenceNr(5)), Some(nonLeadersTimestamp))
+        .returns(Future.successful(Done))
+        .noMoreThanOnce()
+      (rollback.raftPersistence.requirementsVerifier.verify _)
+        .expects(raftActorId3.persistenceId, None, Some(nonLeadersTimestamp))
+        .returns(Future.failed(new RollbackRequirementsNotFulfilled("mocked")))
+        .once()
+
+      // Test:
+      val exception = rollback.prepareRaftActorsRollback(parameters).failed.futureValue
+      exception should be(a[RollbackRequirementsNotFulfilled])
+    }
+
   }
 
   "RaftShardRollback.prepareSnapshotStoresRollback" should {
 
     "return all SnapshotStores' rollback setups for the given Raft shard " in {
-      val rollback =
-        new RaftShardRollback(
-          system,
-          settings,
-          new RaftPersistence(
-            mock[PersistentActorRollback],
-            mock[RaftShardPersistenceQueries],
-            mock[SequenceNrSearchStrategy],
-          ),
-          mock[RaftEventSourcedPersistence],
-        )
+      val rollback = createRaftShardRollback(settings)
 
       val memberIndex1 = MemberIndex("replica-group-1")
       val memberIndex2 = MemberIndex("replica-group-2")
@@ -190,6 +263,8 @@ final class RaftShardRollbackSpec
           ),
         )
         .once()
+
+      // Expectations:
       (rollback.raftPersistence.sequenceNrSearchStrategy.findUpperBound _)
         .expects(snapshotStoreId1A.persistenceId, leadersTimestamp)
         .returns(Future.successful(Some(SequenceNr(2))))
@@ -209,6 +284,32 @@ final class RaftShardRollbackSpec
         .expects(snapshotStoreId3D.persistenceId, nonLeadersTimestamp)
         .returns(Future.successful(None))
 
+      // Expectations:
+      (rollback.raftPersistence.requirementsVerifier.verify _)
+        .expects(snapshotStoreId1A.persistenceId, Some(SequenceNr(2)), Some(leadersTimestamp))
+        .returns(Future.successful(Done))
+        .once()
+      (rollback.raftPersistence.requirementsVerifier.verify _)
+        .expects(snapshotStoreId1B.persistenceId, Some(SequenceNr(5)), Some(leadersTimestamp))
+        .returns(Future.successful(Done))
+        .once()
+      (rollback.raftPersistence.requirementsVerifier.verify _)
+        .expects(snapshotStoreId2B.persistenceId, Some(SequenceNr(3)), Some(nonLeadersTimestamp))
+        .returns(Future.successful(Done))
+        .once()
+      (rollback.raftPersistence.requirementsVerifier.verify _)
+        .expects(snapshotStoreId2C.persistenceId, None, Some(nonLeadersTimestamp))
+        .returns(Future.successful(Done))
+        .once()
+      (rollback.raftPersistence.requirementsVerifier.verify _)
+        .expects(snapshotStoreId3C.persistenceId, Some(SequenceNr(1)), Some(nonLeadersTimestamp))
+        .returns(Future.successful(Done))
+        .once()
+      (rollback.raftPersistence.requirementsVerifier.verify _)
+        .expects(snapshotStoreId3D.persistenceId, None, Some(nonLeadersTimestamp))
+        .returns(Future.successful(Done))
+        .once()
+
       // Test:
       val snapshotStoresRollbackSetups =
         rollback.prepareSnapshotStoresRollback(parameters, raftActorRollbackSetups).futureValue
@@ -222,22 +323,142 @@ final class RaftShardRollbackSpec
       )
     }
 
+    "return a failed Future if the rollback request doesn't meet requirements" in {
+      val rollback = createRaftShardRollback(settings)
+
+      val memberIndex1 = MemberIndex("replica-group-1")
+      val memberIndex2 = MemberIndex("replica-group-2")
+      val memberIndex3 = MemberIndex("replica-group-3")
+
+      val raftActorId1 = RaftActorId(defaultTypeName, defaultShardId, memberIndex1)
+      val raftActorId2 = RaftActorId(defaultTypeName, defaultShardId, memberIndex2)
+      val raftActorId3 = RaftActorId(defaultTypeName, defaultShardId, memberIndex3)
+
+      val leadersTimestamp    = ZonedDateTime.of(2022, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC).toInstant
+      val nonLeadersTimestamp = leadersTimestamp.minusSeconds(rollback.settings.clockOutOfSyncTolerance.toSeconds)
+
+      val parameters =
+        RaftShardRollbackParameters(
+          defaultTypeName,
+          defaultShardId,
+          Set(memberIndex1, memberIndex2, memberIndex3),
+          memberIndex1,
+          leadersTimestamp,
+        )
+      val raftActorRollbackSetups = Seq(
+        RaftActorRollbackSetup(raftActorId1, Some(SequenceNr(100))),
+        RaftActorRollbackSetup(raftActorId2, Some(SequenceNr(40))),
+        RaftActorRollbackSetup(raftActorId3, None),
+      )
+
+      val snapshotStoreId1A = SnapshotStoreId(defaultTypeName, memberIndex1, NormalizedEntityId.from("A"))
+      val snapshotStoreId1B = SnapshotStoreId(defaultTypeName, memberIndex1, NormalizedEntityId.from("B"))
+      val snapshotStoreId2B = SnapshotStoreId(defaultTypeName, memberIndex2, NormalizedEntityId.from("B"))
+      val snapshotStoreId2C = SnapshotStoreId(defaultTypeName, memberIndex2, NormalizedEntityId.from("C"))
+      val snapshotStoreId3C = SnapshotStoreId(defaultTypeName, memberIndex3, NormalizedEntityId.from("C"))
+      val snapshotStoreId3D = SnapshotStoreId(defaultTypeName, memberIndex3, NormalizedEntityId.from("D"))
+
+      // Expectations:
+      (rollback.raftPersistence.raftShardPersistenceQueries.entityIdsAfter _)
+        .expects(raftActorId1, SequenceNr(100))
+        .returns(
+          Source(
+            Seq(
+              snapshotStoreId1A.entityId,
+              snapshotStoreId1B.entityId,
+              snapshotStoreId1A.entityId,
+            ),
+          ),
+        )
+        .noMoreThanOnce()
+      (rollback.raftPersistence.raftShardPersistenceQueries.entityIdsAfter _)
+        .expects(raftActorId2, SequenceNr(40))
+        .returns(
+          Source(
+            Seq(
+              snapshotStoreId2B.entityId,
+              snapshotStoreId2B.entityId,
+              snapshotStoreId2C.entityId,
+            ),
+          ),
+        )
+        .noMoreThanOnce()
+      (rollback.raftPersistence.raftShardPersistenceQueries.entityIdsAfter _)
+        .expects(raftActorId3, SequenceNr(1))
+        .returns(
+          Source(
+            Seq(
+              snapshotStoreId3D.entityId,
+              snapshotStoreId3C.entityId,
+              snapshotStoreId3C.entityId,
+            ),
+          ),
+        )
+        .noMoreThanOnce()
+
+      // Expectations:
+      (rollback.raftPersistence.sequenceNrSearchStrategy.findUpperBound _)
+        .expects(snapshotStoreId1A.persistenceId, leadersTimestamp)
+        .returns(Future.successful(Some(SequenceNr(2))))
+        .noMoreThanOnce()
+      (rollback.raftPersistence.sequenceNrSearchStrategy.findUpperBound _)
+        .expects(snapshotStoreId1B.persistenceId, leadersTimestamp)
+        .returns(Future.successful(Some(SequenceNr(5))))
+        .noMoreThanOnce()
+      (rollback.raftPersistence.sequenceNrSearchStrategy.findUpperBound _)
+        .expects(snapshotStoreId2B.persistenceId, nonLeadersTimestamp)
+        .returns(Future.successful(Some(SequenceNr(3))))
+        .noMoreThanOnce()
+      (rollback.raftPersistence.sequenceNrSearchStrategy.findUpperBound _)
+        .expects(snapshotStoreId2C.persistenceId, nonLeadersTimestamp)
+        .returns(Future.successful(None))
+        .noMoreThanOnce()
+      (rollback.raftPersistence.sequenceNrSearchStrategy.findUpperBound _)
+        .expects(snapshotStoreId3C.persistenceId, nonLeadersTimestamp)
+        .returns(Future.successful(Some(SequenceNr(1))))
+        .noMoreThanOnce()
+      (rollback.raftPersistence.sequenceNrSearchStrategy.findUpperBound _)
+        .expects(snapshotStoreId3D.persistenceId, nonLeadersTimestamp)
+        .returns(Future.successful(None))
+        .noMoreThanOnce()
+
+      // Expectations:
+      (rollback.raftPersistence.requirementsVerifier.verify _)
+        .expects(snapshotStoreId1A.persistenceId, Some(SequenceNr(2)), Some(leadersTimestamp))
+        .returns(Future.successful(Done))
+        .noMoreThanOnce()
+      (rollback.raftPersistence.requirementsVerifier.verify _)
+        .expects(snapshotStoreId1B.persistenceId, Some(SequenceNr(5)), Some(leadersTimestamp))
+        .returns(Future.successful(Done))
+        .noMoreThanOnce()
+      (rollback.raftPersistence.requirementsVerifier.verify _)
+        .expects(snapshotStoreId2B.persistenceId, Some(SequenceNr(3)), Some(nonLeadersTimestamp))
+        .returns(Future.successful(Done))
+        .noMoreThanOnce()
+      (rollback.raftPersistence.requirementsVerifier.verify _)
+        .expects(snapshotStoreId2C.persistenceId, None, Some(nonLeadersTimestamp))
+        .returns(Future.successful(Done))
+        .noMoreThanOnce()
+      (rollback.raftPersistence.requirementsVerifier.verify _)
+        .expects(snapshotStoreId3C.persistenceId, Some(SequenceNr(1)), Some(nonLeadersTimestamp))
+        .returns(Future.successful(Done))
+        .noMoreThanOnce()
+      (rollback.raftPersistence.requirementsVerifier.verify _)
+        .expects(snapshotStoreId3D.persistenceId, None, Some(nonLeadersTimestamp))
+        .returns(Future.failed(new RollbackRequirementsNotFulfilled("mocked")))
+        .once()
+
+      // Test:
+      val exception = rollback.prepareSnapshotStoresRollback(parameters, raftActorRollbackSetups).failed.futureValue
+      exception should be(a[RollbackRequirementsNotFulfilled])
+    }
+
   }
 
   "RaftShardRollback.prepareSnapshotSyncManagersRollback" should {
 
     "return all SnapshotSyncManagers' rollback setups for the given Raft shard" in {
-      val rollback =
-        new RaftShardRollback(
-          system,
-          settings,
-          new RaftPersistence(
-            mock[PersistentActorRollback],
-            mock[RaftShardPersistenceQueries],
-            mock[SequenceNrSearchStrategy],
-          ),
-          mock[RaftEventSourcedPersistence],
-        )
+      val rollback = createRaftShardRollback(settings)
 
       val memberIndex1 = MemberIndex("replica-group-1")
       val memberIndex2 = MemberIndex("replica-group-2")
@@ -288,6 +509,32 @@ final class RaftShardRollbackSpec
         .returns(Future.successful(None))
         .once()
 
+      // Expectations:
+      (rollback.raftPersistence.requirementsVerifier.verify _)
+        .expects(snapshotSyncManagerId21.persistenceId, Some(SequenceNr(7)), Some(leadersTimestamp))
+        .returns(Future.successful(Done))
+        .once()
+      (rollback.raftPersistence.requirementsVerifier.verify _)
+        .expects(snapshotSyncManagerId31.persistenceId, Some(SequenceNr(10)), Some(leadersTimestamp))
+        .returns(Future.successful(Done))
+        .once()
+      (rollback.raftPersistence.requirementsVerifier.verify _)
+        .expects(snapshotSyncManagerId12.persistenceId, None, Some(nonLeadersTimestamp))
+        .returns(Future.successful(Done))
+        .once()
+      (rollback.raftPersistence.requirementsVerifier.verify _)
+        .expects(snapshotSyncManagerId32.persistenceId, Some(SequenceNr(20)), Some(nonLeadersTimestamp))
+        .returns(Future.successful(Done))
+        .once()
+      (rollback.raftPersistence.requirementsVerifier.verify _)
+        .expects(snapshotSyncManagerId13.persistenceId, Some(SequenceNr(30)), Some(nonLeadersTimestamp))
+        .returns(Future.successful(Done))
+        .once()
+      (rollback.raftPersistence.requirementsVerifier.verify _)
+        .expects(snapshotSyncManagerId23.persistenceId, None, Some(nonLeadersTimestamp))
+        .returns(Future.successful(Done))
+        .once()
+
       // Test:
       rollback.prepareSnapshotSyncManagersRollback(parameters).futureValue should contain theSameElementsAs Seq(
         SnapshotSyncManagerRollbackSetup(snapshotSyncManagerId21, Some(SequenceNr(7))),
@@ -299,18 +546,95 @@ final class RaftShardRollbackSpec
       )
     }
 
+    "return a failed Future if the rollback request doesn't meet requirements" in {
+      val rollback = createRaftShardRollback(settings)
+
+      val memberIndex1 = MemberIndex("replica-group-1")
+      val memberIndex2 = MemberIndex("replica-group-2")
+      val memberIndex3 = MemberIndex("replica-group-3")
+
+      val leadersTimestamp    = ZonedDateTime.of(2022, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC).toInstant
+      val nonLeadersTimestamp = leadersTimestamp.minusSeconds(rollback.settings.clockOutOfSyncTolerance.toSeconds)
+
+      val parameters =
+        RaftShardRollbackParameters(
+          defaultTypeName,
+          defaultShardId,
+          Set(memberIndex1, memberIndex2, memberIndex3),
+          memberIndex1,
+          leadersTimestamp,
+        )
+
+      val snapshotSyncManagerId21 = SnapshotSyncManagerId(defaultTypeName, defaultShardId, memberIndex2, memberIndex1)
+      val snapshotSyncManagerId31 = SnapshotSyncManagerId(defaultTypeName, defaultShardId, memberIndex3, memberIndex1)
+      val snapshotSyncManagerId12 = SnapshotSyncManagerId(defaultTypeName, defaultShardId, memberIndex1, memberIndex2)
+      val snapshotSyncManagerId32 = SnapshotSyncManagerId(defaultTypeName, defaultShardId, memberIndex3, memberIndex2)
+      val snapshotSyncManagerId13 = SnapshotSyncManagerId(defaultTypeName, defaultShardId, memberIndex1, memberIndex3)
+      val snapshotSyncManagerId23 = SnapshotSyncManagerId(defaultTypeName, defaultShardId, memberIndex2, memberIndex3)
+
+      // Expectations:
+      (rollback.raftPersistence.sequenceNrSearchStrategy.findUpperBound _)
+        .expects(snapshotSyncManagerId21.persistenceId, leadersTimestamp)
+        .returns(Future.successful(Some(SequenceNr(7))))
+        .noMoreThanOnce()
+      (rollback.raftPersistence.sequenceNrSearchStrategy.findUpperBound _)
+        .expects(snapshotSyncManagerId31.persistenceId, leadersTimestamp)
+        .returns(Future.successful(Some(SequenceNr(10))))
+        .noMoreThanOnce()
+      (rollback.raftPersistence.sequenceNrSearchStrategy.findUpperBound _)
+        .expects(snapshotSyncManagerId12.persistenceId, nonLeadersTimestamp)
+        .returns(Future.successful(None))
+        .noMoreThanOnce()
+      (rollback.raftPersistence.sequenceNrSearchStrategy.findUpperBound _)
+        .expects(snapshotSyncManagerId32.persistenceId, nonLeadersTimestamp)
+        .returns(Future.successful(Some(SequenceNr(20))))
+        .noMoreThanOnce()
+      (rollback.raftPersistence.sequenceNrSearchStrategy.findUpperBound _)
+        .expects(snapshotSyncManagerId13.persistenceId, nonLeadersTimestamp)
+        .returns(Future.successful(Some(SequenceNr(30))))
+        .noMoreThanOnce()
+      (rollback.raftPersistence.sequenceNrSearchStrategy.findUpperBound _)
+        .expects(snapshotSyncManagerId23.persistenceId, nonLeadersTimestamp)
+        .returns(Future.successful(None))
+        .noMoreThanOnce()
+
+      // Expectations:
+      (rollback.raftPersistence.requirementsVerifier.verify _)
+        .expects(snapshotSyncManagerId21.persistenceId, Some(SequenceNr(7)), Some(leadersTimestamp))
+        .returns(Future.successful(Done))
+        .noMoreThanOnce()
+      (rollback.raftPersistence.requirementsVerifier.verify _)
+        .expects(snapshotSyncManagerId31.persistenceId, Some(SequenceNr(10)), Some(leadersTimestamp))
+        .returns(Future.successful(Done))
+        .noMoreThanOnce()
+      (rollback.raftPersistence.requirementsVerifier.verify _)
+        .expects(snapshotSyncManagerId12.persistenceId, None, Some(nonLeadersTimestamp))
+        .returns(Future.successful(Done))
+        .noMoreThanOnce()
+      (rollback.raftPersistence.requirementsVerifier.verify _)
+        .expects(snapshotSyncManagerId32.persistenceId, Some(SequenceNr(20)), Some(nonLeadersTimestamp))
+        .returns(Future.successful(Done))
+        .noMoreThanOnce()
+      (rollback.raftPersistence.requirementsVerifier.verify _)
+        .expects(snapshotSyncManagerId13.persistenceId, Some(SequenceNr(30)), Some(nonLeadersTimestamp))
+        .returns(Future.successful(Done))
+        .noMoreThanOnce()
+      (rollback.raftPersistence.requirementsVerifier.verify _)
+        .expects(snapshotSyncManagerId23.persistenceId, None, Some(nonLeadersTimestamp))
+        .returns(Future.failed(new RollbackRequirementsNotFulfilled("mocked")))
+        .once()
+
+      // Test:
+      val exception = rollback.prepareSnapshotSyncManagersRollback(parameters).failed.futureValue
+      exception should be(a[RollbackRequirementsNotFulfilled])
+    }
+
   }
 
   "RaftShardRollback.prepareCommitLogStoreActorRollback" should {
 
     "throw an IllegalArgumentException if the given RaftActors' setups doesn't contain the leader's setup" in {
-      val rollback =
-        new RaftShardRollback(
-          system,
-          settings,
-          mock[RaftPersistence],
-          mock[RaftEventSourcedPersistence],
-        )
+      val rollback = createRaftShardRollback(settings)
 
       val memberIndex1 = MemberIndex("replica-group-1")
       val memberIndex2 = MemberIndex("replica-group-2")
@@ -339,17 +663,7 @@ final class RaftShardRollbackSpec
     }
 
     "return a CommitLogStoreActor's rollback setup for the given Raft shard" in {
-      val rollback =
-        new RaftShardRollback(
-          system,
-          settings,
-          new RaftPersistence(
-            mock[PersistentActorRollback],
-            mock[RaftShardPersistenceQueries],
-            mock[SequenceNrSearchStrategy],
-          ),
-          mock[RaftEventSourcedPersistence],
-        )
+      val rollback = createRaftShardRollback(settings)
 
       val memberIndex1 = MemberIndex("replica-group-1")
       val memberIndex2 = MemberIndex("replica-group-2")
@@ -382,6 +696,12 @@ final class RaftShardRollbackSpec
         .returns(Future.successful(Some(LogEntryIndex(2))))
         .once()
 
+      // Expectations:
+      (rollback.raftEventSourcedPersistence.requirementsVerifier.verify _)
+        .expects(commitLogStoreActorId.persistenceId, Some(SequenceNr(2)), None)
+        .returns(Future.successful(Done))
+        .once()
+
       // Test:
       rollback.prepareCommitLogStoreActorRollback(parameters, raftActorRollbackSetups).futureValue should be(
         CommitLogStoreActorRollbackSetup(commitLogStoreActorId, Some(SequenceNr(2))),
@@ -389,17 +709,7 @@ final class RaftShardRollbackSpec
     }
 
     "return a CommitLogStoreActor's rollback setup (indicates all data delete) for the given Raft shard" in {
-      val rollback =
-        new RaftShardRollback(
-          system,
-          settings,
-          new RaftPersistence(
-            mock[PersistentActorRollback],
-            mock[RaftShardPersistenceQueries],
-            mock[SequenceNrSearchStrategy],
-          ),
-          mock[RaftEventSourcedPersistence],
-        )
+      val rollback = createRaftShardRollback(settings)
 
       val memberIndex1 = MemberIndex("replica-group-1")
       val memberIndex2 = MemberIndex("replica-group-2")
@@ -432,10 +742,62 @@ final class RaftShardRollbackSpec
         .returns(Future.successful(None))
         .once()
 
+      // Expectations:
+      (rollback.raftEventSourcedPersistence.requirementsVerifier.verify _)
+        .expects(commitLogStoreActorId.persistenceId, None, None)
+        .returns(Future.successful(Done))
+        .once()
+
       // Test:
       rollback.prepareCommitLogStoreActorRollback(parameters, raftActorRollbackSetups).futureValue should be(
         CommitLogStoreActorRollbackSetup(commitLogStoreActorId, None),
       )
+    }
+
+    "return a failed Future if the rollback request doesn't meet requirements" in {
+      val rollback = createRaftShardRollback(settings)
+
+      val memberIndex1 = MemberIndex("replica-group-1")
+      val memberIndex2 = MemberIndex("replica-group-2")
+      val memberIndex3 = MemberIndex("replica-group-3")
+
+      val leadersTimestamp =
+        ZonedDateTime.of(2022, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC).toInstant
+
+      val parameters =
+        RaftShardRollbackParameters(
+          defaultTypeName,
+          defaultShardId,
+          Set(memberIndex1, memberIndex2, memberIndex3),
+          memberIndex1,
+          leadersTimestamp,
+        )
+      val raftActorRollbackSetups = Seq(
+        RaftActorRollbackSetup(RaftActorId(defaultTypeName, defaultShardId, memberIndex1), Some(SequenceNr(10))),
+        RaftActorRollbackSetup(RaftActorId(defaultTypeName, defaultShardId, memberIndex2), Some(SequenceNr(4))),
+        RaftActorRollbackSetup(RaftActorId(defaultTypeName, defaultShardId, memberIndex3), Some(SequenceNr(5))),
+      )
+
+      val leaderRaftActorId     = RaftActorId(defaultTypeName, defaultShardId, memberIndex1)
+      val commitLogStoreActorId = CommitLogStoreActorId(defaultTypeName, defaultShardId)
+
+      // Expectations:
+      (rollback.raftPersistence.raftShardPersistenceQueries
+        .findLastTruncatedLogEntryIndex(_: RaftActorId, _: SequenceNr)(_: Materializer))
+        .expects(leaderRaftActorId, SequenceNr(10), *)
+        .returns(Future.successful(None))
+        .once()
+
+      // Expectations:
+      (rollback.raftEventSourcedPersistence.requirementsVerifier.verify _)
+        .expects(commitLogStoreActorId.persistenceId, None, None)
+        .returns(Future.failed(new RollbackRequirementsNotFulfilled("mocked")))
+        .once()
+
+      // Test:
+      val exception =
+        rollback.prepareCommitLogStoreActorRollback(parameters, raftActorRollbackSetups).failed.futureValue
+      exception should be(a[RollbackRequirementsNotFulfilled])
     }
 
   }
@@ -443,19 +805,7 @@ final class RaftShardRollbackSpec
   "RaftShardRollback.rollback" should {
 
     "call all rollback operations for the given rollback setup" in {
-      val rollback =
-        new RaftShardRollback(
-          system,
-          settings,
-          new RaftPersistence(
-            mock[PersistentActorRollback],
-            mock[RaftShardPersistenceQueries],
-            mock[SequenceNrSearchStrategy],
-          ),
-          new RaftEventSourcedPersistence(
-            mock[PersistentActorRollback],
-          ),
-        )
+      val rollback = createRaftShardRollback(settings)
 
       val memberIndex1 = MemberIndex("replica-group-1")
       val memberIndex2 = MemberIndex("replica-group-2")
@@ -601,19 +951,7 @@ final class RaftShardRollbackSpec
     }
 
     "throw an AssertionError if it runs in dry-run mode and the raft-persistence runs not in dry-run mode" in {
-      val rollback =
-        new RaftShardRollback(
-          system,
-          settingsForDryRun,
-          new RaftPersistence(
-            mock[PersistentActorRollback],
-            mock[RaftShardPersistenceQueries],
-            mock[SequenceNrSearchStrategy],
-          ),
-          new RaftEventSourcedPersistence(
-            mock[PersistentActorRollback],
-          ),
-        )
+      val rollback = createRaftShardRollback(settingsForDryRun)
 
       (() => rollback.raftPersistence.persistentActorRollback.isDryRun)
         .expects()
@@ -634,19 +972,7 @@ final class RaftShardRollbackSpec
     }
 
     "throw an AssertionError if it runs in dry-run mode and the raft-eventsourced-persistence runs not in dry-run mode" in {
-      val rollback =
-        new RaftShardRollback(
-          system,
-          settingsForDryRun,
-          new RaftPersistence(
-            mock[PersistentActorRollback],
-            mock[RaftShardPersistenceQueries],
-            mock[SequenceNrSearchStrategy],
-          ),
-          new RaftEventSourcedPersistence(
-            mock[PersistentActorRollback],
-          ),
-        )
+      val rollback = createRaftShardRollback(settingsForDryRun)
 
       (() => rollback.raftPersistence.persistentActorRollback.isDryRun)
         .expects()
@@ -667,19 +993,7 @@ final class RaftShardRollbackSpec
     }
 
     "throw an AssertionError if it runs not in dry-run mode and the raft-persistence runs in dry-run mode" in {
-      val rollback =
-        new RaftShardRollback(
-          system,
-          settings,
-          new RaftPersistence(
-            mock[PersistentActorRollback],
-            mock[RaftShardPersistenceQueries],
-            mock[SequenceNrSearchStrategy],
-          ),
-          new RaftEventSourcedPersistence(
-            mock[PersistentActorRollback],
-          ),
-        )
+      val rollback = createRaftShardRollback(settings)
 
       (() => rollback.raftPersistence.persistentActorRollback.isDryRun)
         .expects()
@@ -700,19 +1014,7 @@ final class RaftShardRollbackSpec
     }
 
     "throw an AssertionError if it runs not in dry-run mode and the raft-eventsourced-persistence runs in dry-run mode" in {
-      val rollback =
-        new RaftShardRollback(
-          system,
-          settings,
-          new RaftPersistence(
-            mock[PersistentActorRollback],
-            mock[RaftShardPersistenceQueries],
-            mock[SequenceNrSearchStrategy],
-          ),
-          new RaftEventSourcedPersistence(
-            mock[PersistentActorRollback],
-          ),
-        )
+      val rollback: RaftShardRollback = createRaftShardRollback(settings)
 
       (() => rollback.raftPersistence.persistentActorRollback.isDryRun)
         .expects()

--- a/rollback-tool-cassandra/src/test/scala/lerna/akka/entityreplication/rollback/cassandra/CassandraSnapshotSettingsSpec.scala
+++ b/rollback-tool-cassandra/src/test/scala/lerna/akka/entityreplication/rollback/cassandra/CassandraSnapshotSettingsSpec.scala
@@ -10,6 +10,7 @@ final class CassandraSnapshotSettingsSpec extends WordSpec with Matchers {
 
   private val customPluginConfig: Config = ConfigFactory.parseString("""
       |snapshot {
+      |  read-profile = "custom_akka-persistence-cassandra-snapshot-read-profile"
       |  write-profile = "custom_akka-persistence-cassandra-snapshot-write-profile"
       |  keyspace = "custom_akka_snapshot"
       |  table = "custom_snapshots"
@@ -20,6 +21,7 @@ final class CassandraSnapshotSettingsSpec extends WordSpec with Matchers {
 
     "load the default config" in {
       val settings = CassandraSnapshotSettings(defaultPluginConfig)
+      settings.readProfile should be("akka-persistence-cassandra-snapshot-profile")
       settings.writeProfile should be("akka-persistence-cassandra-snapshot-profile")
       settings.keyspace should be("akka_snapshot")
       settings.table should be("snapshots")
@@ -27,6 +29,7 @@ final class CassandraSnapshotSettingsSpec extends WordSpec with Matchers {
 
     "load the given custom config" in {
       val settings = CassandraSnapshotSettings(customPluginConfig)
+      settings.readProfile should be("custom_akka-persistence-cassandra-snapshot-read-profile")
       settings.writeProfile should be("custom_akka-persistence-cassandra-snapshot-write-profile")
       settings.keyspace should be("custom_akka_snapshot")
       settings.table should be("custom_snapshots")

--- a/rollback-tool-cassandra/src/test/scala/lerna/akka/entityreplication/rollback/cassandra/CassandraSpecBase.scala
+++ b/rollback-tool-cassandra/src/test/scala/lerna/akka/entityreplication/rollback/cassandra/CassandraSpecBase.scala
@@ -48,6 +48,11 @@ abstract class CassandraSpecBase(
     PersistenceInitializationAwaiter(system).awaitInit()
   }
 
+  override def afterAll(): Unit = {
+    shutdown(system)
+    super.afterAll()
+  }
+
   private val currentPersistenceId: AtomicLong = new AtomicLong(0)
 
   /** Returns the next (unique) persistence ID */

--- a/rollback-tool-cassandra/src/test/scala/lerna/akka/entityreplication/rollback/cassandra/testkit/PersistenceCassandraConfigProvider.scala
+++ b/rollback-tool-cassandra/src/test/scala/lerna/akka/entityreplication/rollback/cassandra/testkit/PersistenceCassandraConfigProvider.scala
@@ -18,6 +18,14 @@ trait PersistenceCassandraConfigProvider {
       snapshotKeyspace: String,
       autoCreate: Boolean = false,
   ): Config = {
+    require(
+      journalKeyspace.length <= 48,
+      s"journalKeyspace.length [${journalKeyspace.length}] should be less than or equal to 48. See https://docs.datastax.com/en/cql-oss/3.3/cql/cql_reference/refLimits.html.",
+    )
+    require(
+      snapshotKeyspace.length <= 48,
+      s"snapshotKeyspace.length [${snapshotKeyspace.length}] should be less than or equal to 48. See https://docs.datastax.com/en/cql-oss/3.3/cql/cql_reference/refLimits.html.",
+    )
     ConfigFactory.parseString(s"""
       |akka.persistence.journal.plugin = akka.persistence.cassandra.journal
       |akka.persistence.snapshot-store.plugin = akka.persistence.cassandra.snapshot


### PR DESCRIPTION
Closes #206 

Once data (events or snapshots) have been deleted, a rollback to a timestamp that requires such deleted data is impossible. This PR changes the rollback preparation (`prepareRollback`) such that it fails if required data have already been deleted.

The rollback preparation checks that each persistent actor can be rolled back (the persistent actor has a consistent state after rollback) based on sequence numbers. These checks involve the following component:
* `RollbackRequirementsVerifier`: for each persistent actor, it verifies whether the rollback is possible.
* `PersistentActorRollback.findRollbackRequirements`: for each persistent actor, it finds the possible lowest sequence number such that the persistent actor is consistent after rollbacks.
* `RollbackTimestampHintFinder`: it finds a timestamp hint if the rollback is impossible. Rollbacks should specify a newer timestamp than the hint, at least. While the hint might need to be more strictly correct, it helps to know why the given timestamp-based rollback is impossible.