### PR TITLE
Release v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [Unreleased]: https://github.com/lerna-stack/akka-entity-replication/compare/v2.3.0...master
 
 
-## [v2.3.0] - 2023-06-16
+## [v2.3.0] - 2023-06-19
 [v2.3.0]: https://github.com/lerna-stack/akka-entity-replication/compare/v2.2.0...v2.3.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-[Unreleased]: https://github.com/lerna-stack/akka-entity-replication/compare/v2.2.0...master
+[Unreleased]: https://github.com/lerna-stack/akka-entity-replication/compare/v2.3.0...master
+
+
+## [v2.3.0] - 2023-06-16
+[v2.3.0]: https://github.com/lerna-stack/akka-entity-replication/compare/v2.2.0...v2.3.0
 
 ### Added
 - Support deleting old events and snapshots


### PR DESCRIPTION
Release new version `v2.3.0`.

https://github.com/lerna-stack/akka-entity-replication/blob/master/RELEASING.md describes release steps.