### PR TITLE
Improve snapshot synchronization diagnostic logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 [Unreleased]: https://github.com/lerna-stack/akka-entity-replication/compare/v2.3.0...master
 
+### Changed
+- Improve snapshot synchronization diagnostic logging
+  [PR#216](https://github.com/lerna-stack/akka-entity-replication/pull/216)
 
 ## [v2.3.0] - 2023-06-19
 [v2.3.0]: https://github.com/lerna-stack/akka-entity-replication/compare/v2.2.0...v2.3.0

--- a/core/src/main/scala/lerna/akka/entityreplication/raft/snapshot/sync/SnapshotSyncManager.scala
+++ b/core/src/main/scala/lerna/akka/entityreplication/raft/snapshot/sync/SnapshotSyncManager.scala
@@ -222,7 +222,7 @@ private[entityreplication] class SnapshotSyncManager(
       shardId,
     )
 
-  private val log: LoggingAdapter =
+  private implicit val log: LoggingAdapter =
     Logging(this.context.system, this)
 
   private val shouldDeleteOldEvents: Boolean =
@@ -499,6 +499,7 @@ private[entityreplication] class SnapshotSyncManager(
             offset,
           )
       }
+      .log("entity-snapshots-updated-events")
       .filter { event =>
         dstLatestSnapshotLastLogTerm <= event.snapshotLastLogTerm &&
         dstLatestSnapshotLastLogIndex < event.snapshotLastLogIndex

--- a/core/src/main/scala/lerna/akka/entityreplication/raft/snapshot/sync/SnapshotSyncManager.scala
+++ b/core/src/main/scala/lerna/akka/entityreplication/raft/snapshot/sync/SnapshotSyncManager.scala
@@ -1,6 +1,7 @@
 package lerna.akka.entityreplication.raft.snapshot.sync
 
-import akka.actor.{ ActorLogging, ActorRef, Props, Status }
+import akka.actor.{ ActorRef, Props, Status }
+import akka.event.{ Logging, LoggingAdapter }
 import akka.pattern.extended.ask
 import akka.pattern.pipe
 import akka.persistence.{
@@ -196,7 +197,6 @@ private[entityreplication] class SnapshotSyncManager(
     shardId: NormalizedShardId,
     settings: RaftSettings,
 ) extends PersistentActor
-    with ActorLogging
     with RuntimePluginConfig {
   import SnapshotSyncManager._
 
@@ -221,6 +221,9 @@ private[entityreplication] class SnapshotSyncManager(
       dstMemberIndex = dstMemberIndex,
       shardId,
     )
+
+  private val log: LoggingAdapter =
+    Logging(this.context.system, this)
 
   private val shouldDeleteOldEvents: Boolean =
     settings.snapshotSyncDeleteOldEvents

--- a/core/src/main/scala/lerna/akka/entityreplication/raft/snapshot/sync/SnapshotSyncManager.scala
+++ b/core/src/main/scala/lerna/akka/entityreplication/raft/snapshot/sync/SnapshotSyncManager.scala
@@ -583,10 +583,11 @@ private[entityreplication] class SnapshotSyncManager(
     implicit val executionContext: ExecutionContext = context.dispatcher
     if (log.isDebugEnabled) {
       log.debug(
-        "Copying EntitySnapshot: entityId=[{}], from=[{}], to=[{}]",
+        "Copying EntitySnapshot: typeName=[{}], shardId=[{}], entityId=[{}], " +
+        s"from=[$sourceShardSnapshotStore], to=[$dstShardSnapshotStore]",
+        typeName,
+        shardId.raw,
         entityId.raw,
-        sourceShardSnapshotStore,
-        dstShardSnapshotStore,
       )
     }
     for {
@@ -624,12 +625,13 @@ private[entityreplication] class SnapshotSyncManager(
     } yield {
       if (log.isDebugEnabled) {
         log.debug(
-          "Copied EntitySnapshot: entityId=[{}], from=[{}], to=[{}], " +
+          "Copied EntitySnapshot: typeName=[{}], shardId=[{}], entityId=[{}], " +
+          s"from=[$sourceShardSnapshotStore], to=[$dstShardSnapshotStore], " +
           s"sourceEntitySnapshotMetadata=[${srcEntitySnapshot.metadata}], " +
           s"destinationEntitySnapshotMetadata=[${dstEntitySnapshotMetadata}]",
+          typeName,
+          shardId.raw,
           entityId.raw,
-          sourceShardSnapshotStore,
-          dstShardSnapshotStore,
         )
       }
       dstEntitySnapshotMetadata


### PR DESCRIPTION
This change improves diagnostic logging in snapshot synchronization. It contains the following improvements:
* Fix thread-unsafe logger use
* Log each EntitySnapshot copy progress
* Log EntitySnapshotsUpdated events that SnapshotSyncManager subscribed