### PR TITLE
Fix old snapshot read in consecutive snapshot synchronization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve snapshot synchronization diagnostic logging
   [PR#216](https://github.com/lerna-stack/akka-entity-replication/pull/216)
 
+### Fixed
+- Consecutive snapshot synchronizations could not synchronize new entity snapshots
+  [#215](https://github.com/lerna-stack/akka-entity-replication/issues/215),
+  [PR#217](https://github.com/lerna-stack/akka-entity-replication/pull/217)
+
 ## [v2.3.0] - 2023-06-19
 [v2.3.0]: https://github.com/lerna-stack/akka-entity-replication/compare/v2.2.0...v2.3.0
 

--- a/core/src/main/mima-filters/2.3.0.backwards.excludes/pr-217-fix-old-snapshot-read-in-consecutive-snapshot-synchronization.excludes
+++ b/core/src/main/mima-filters/2.3.0.backwards.excludes/pr-217-fix-old-snapshot-read-in-consecutive-snapshot-synchronization.excludes
@@ -1,0 +1,2 @@
+# It's safe to exclude the following since Stop is a private class.
+ProblemFilters.exclude[MissingClassProblem]("lerna.akka.entityreplication.raft.snapshot.sync.SnapshotSyncManager$Stop$")

--- a/core/src/test/scala/lerna/akka/entityreplication/raft/snapshot/sync/SnapshotSyncManagerFinalizingSpec.scala
+++ b/core/src/test/scala/lerna/akka/entityreplication/raft/snapshot/sync/SnapshotSyncManagerFinalizingSpec.scala
@@ -24,7 +24,7 @@ import org.scalatest.{ BeforeAndAfterAll, Inside }
 
 import java.util.UUID
 
-object SnapshotSyncManagerPersistenceDeletionSpec {
+object SnapshotSyncManagerFinalizingSpec {
 
   def config: Config = {
     PersistenceTestKitPlugin.config
@@ -45,11 +45,11 @@ object SnapshotSyncManagerPersistenceDeletionSpec {
 
 }
 
-final class SnapshotSyncManagerPersistenceDeletionSpec
+final class SnapshotSyncManagerFinalizingSpec
     extends TestKit(
       ActorSystem(
-        "SnapshotSyncManagerPersistenceDeletionSpec",
-        SnapshotSyncManagerPersistenceDeletionSpec.config,
+        "SnapshotSyncManagerFinalizingSpec",
+        SnapshotSyncManagerFinalizingSpec.config,
       ),
     )
     with ActorSpec

--- a/core/src/test/scala/lerna/akka/entityreplication/raft/snapshot/sync/SnapshotSyncManagerSpec.scala
+++ b/core/src/test/scala/lerna/akka/entityreplication/raft/snapshot/sync/SnapshotSyncManagerSpec.scala
@@ -293,7 +293,9 @@ class SnapshotSyncManagerSpec extends TestKit(ActorSystem()) with ActorSpec with
       /* check */
       awaitAssert { // Persistent events may not be retrieved immediately
         val probe = TestProbe()
-        createSnapshotSyncManager() ! SnapshotSyncManager.SyncSnapshot(
+        val snapshotSyncManager = createSnapshotSyncManager()
+        probe.watch(snapshotSyncManager)
+        snapshotSyncManager ! SnapshotSyncManager.SyncSnapshot(
           srcLatestSnapshotLastLogTerm = srcSnapshotTerm,
           srcLatestSnapshotLastLogIndex = srcSnapshotLogIndex,
           dstLatestSnapshotLastLogTerm = dstSnapshotTerm,
@@ -303,6 +305,7 @@ class SnapshotSyncManagerSpec extends TestKit(ActorSystem()) with ActorSpec with
         probe.expectMsgType[SnapshotSyncManager.Response] should be(
           SnapshotSyncManager.SyncSnapshotSucceeded(srcSnapshotTerm, srcSnapshotLogIndex, srcMemberIndex),
         )
+        probe.expectTerminated(snapshotSyncManager)
       }
       val probe               = TestProbe()
       val snapshotSyncManager = probe.watch(createSnapshotSyncManager())

--- a/core/src/test/scala/lerna/akka/entityreplication/raft/snapshot/sync/SnapshotSyncManagerSpec.scala
+++ b/core/src/test/scala/lerna/akka/entityreplication/raft/snapshot/sync/SnapshotSyncManagerSpec.scala
@@ -292,7 +292,7 @@ class SnapshotSyncManagerSpec extends TestKit(ActorSystem()) with ActorSpec with
 
       /* check */
       awaitAssert { // Persistent events may not be retrieved immediately
-        val probe = TestProbe()
+        val probe               = TestProbe()
         val snapshotSyncManager = createSnapshotSyncManager()
         probe.watch(snapshotSyncManager)
         snapshotSyncManager ! SnapshotSyncManager.SyncSnapshot(


### PR DESCRIPTION
Closes #215 

Changes SnapshotSyncManager such that it executes only one snapshotsynchronization in its lifecycle. That means SnapshotSyncManager doesn't reuse SnapshotStore instances. Each synchronization will be performed by a different SnapshotSyncManager instance and in serial order.

TODO:
* [x] Verify the issue doesn't occur by executing fault injection tests several times
* [x] Add unit tests